### PR TITLE
feat: add shared validation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Once running, log in with any of these accounts (password: `testpassword123`):
 This package serves as the single source of truth for:
 
 - **DTOs**: TypeScript interfaces for all API request/response types
+- **Validation**: Shared validation utilities for consistent validation across services
 - **Test Utilities**: Shared fixtures, factories, and assertions
 - **E2E Tests**: End-to-end tests that verify full-stack integration
 
@@ -154,6 +155,30 @@ describe('MyComponent', () => {
 });
 ```
 
+### Validation
+
+```typescript
+import {
+  isValidEmail,
+  validateEmail,
+  EMAIL_REGEX,
+} from '@wxyc/shared/validation';
+
+// Simple boolean check
+if (isValidEmail(userInput)) {
+  // proceed
+}
+
+// Structured validation with error messages
+const result = validateEmail(userInput);
+if (!result.valid) {
+  showError(result.error); // "Email is required" or "Invalid email format"
+}
+
+// Use the regex directly if needed
+const isValid = EMAIL_REGEX.test(email);
+```
+
 ## Available Exports
 
 ### DTOs (`@wxyc/shared/dtos`)
@@ -176,6 +201,15 @@ describe('MyComponent', () => {
 | `fixtures` | Static test data for common entities |
 | `factories` | Factory functions with override support |
 | `assertions` | Custom assertion helpers |
+
+### Validation (`@wxyc/shared/validation`)
+
+| Export | Description |
+|--------|-------------|
+| `EMAIL_REGEX` | Regex pattern for email validation |
+| `isValidEmail(email)` | Returns `true` if valid email format |
+| `validateEmail(email)` | Returns `{ valid, error? }` with detailed result |
+| `ValidationResult` | TypeScript type for validation results |
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wxyc/shared",
   "version": "0.1.0",
-  "description": "Shared DTOs, test utilities, and E2E tests for WXYC services",
+  "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
@@ -25,6 +25,11 @@
       "types": "./dist/auth-client/index.d.ts",
       "import": "./dist/auth-client/index.js",
       "default": "./dist/auth-client/index.js"
+    },
+    "./validation": {
+      "types": "./dist/validation/index.d.ts",
+      "import": "./dist/validation/index.js",
+      "default": "./dist/validation/index.js"
     }
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @wxyc/shared
  *
- * Shared DTOs, test utilities, and E2E tests for WXYC services.
+ * Shared DTOs, test utilities, validation, and E2E tests for WXYC services.
  *
  * @example
  * ```ts
@@ -10,8 +10,12 @@
  *
  * // Import test utilities
  * import { createTestAlbum, createTestFlowsheetEntry } from '@wxyc/shared/test-utils';
+ *
+ * // Import validation
+ * import { isValidEmail, validateEmail } from '@wxyc/shared/validation';
  * ```
  */
 
 export * from './dtos/index.js';
 export * from './test-utils/index.js';
+export * from './validation/index.js';

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared Validation Utilities
+ *
+ * Single source of truth for validation logic used across WXYC services.
+ * Import in both frontend and backend to ensure consistent validation.
+ */
+
+/**
+ * Result of a validation check
+ */
+export type ValidationResult = {
+  valid: boolean;
+  error?: string;
+};
+
+/**
+ * Email validation regex
+ * Requires: local part, @, domain, dot, TLD
+ */
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Check if a string is a valid email format
+ *
+ * @param email - The email string to validate
+ * @returns true if valid email format, false otherwise
+ *
+ * @example
+ * isValidEmail("user@example.com") // true
+ * isValidEmail("invalid") // false
+ */
+export function isValidEmail(email: string): boolean {
+  if (typeof email !== "string") {
+    return false;
+  }
+  return EMAIL_REGEX.test(email);
+}
+
+/**
+ * Validate an email and return structured result
+ *
+ * @param email - The email string to validate
+ * @returns ValidationResult with valid flag and optional error message
+ *
+ * @example
+ * validateEmail("user@example.com") // { valid: true }
+ * validateEmail("") // { valid: false, error: "Email is required" }
+ */
+export function validateEmail(email: string): ValidationResult {
+  // Handle null/undefined
+  if (email == null) {
+    return { valid: false, error: "Email is required" };
+  }
+
+  // Handle non-strings
+  if (typeof email !== "string") {
+    return { valid: false, error: "Email must be a string" };
+  }
+
+  // Trim whitespace
+  const trimmed = email.trim();
+
+  // Check for empty
+  if (trimmed.length === 0) {
+    return { valid: false, error: "Email is required" };
+  }
+
+  // Check format
+  if (!EMAIL_REGEX.test(trimmed)) {
+    return { valid: false, error: "Invalid email format" };
+  }
+
+  return { valid: true };
+}

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMAIL_REGEX,
+  isValidEmail,
+  validateEmail,
+  type ValidationResult,
+} from "../src/validation/index.js";
+
+describe("EMAIL_REGEX", () => {
+  it("should be a RegExp", () => {
+    expect(EMAIL_REGEX).toBeInstanceOf(RegExp);
+  });
+
+  describe("valid emails", () => {
+    it.each([
+      "test@example.com",
+      "user.name@domain.org",
+      "user+tag@example.co.uk",
+      "a@b.co",
+      "test123@test-domain.com",
+      "UPPERCASE@DOMAIN.COM",
+    ])("should match valid email: %s", (email) => {
+      expect(EMAIL_REGEX.test(email)).toBe(true);
+    });
+  });
+
+  describe("invalid emails", () => {
+    it.each([
+      "plaintext",
+      "@nodomain.com",
+      "no@domain",
+      "spaces in@email.com",
+      "missing@.com",
+      "",
+      "double@@at.com",
+    ])("should not match invalid email: %s", (email) => {
+      expect(EMAIL_REGEX.test(email)).toBe(false);
+    });
+  });
+});
+
+describe("isValidEmail", () => {
+  describe("returns true for valid emails", () => {
+    it.each([
+      "test@example.com",
+      "user@wxyc.org",
+      "dj.name@station.fm",
+    ])("isValidEmail(%s) returns true", (email) => {
+      expect(isValidEmail(email)).toBe(true);
+    });
+  });
+
+  describe("returns false for invalid emails", () => {
+    it.each([
+      ["", "empty string"],
+      ["notanemail", "no @ symbol"],
+      ["missing@tld", "no domain extension"],
+      ["@nolocal.com", "no local part"],
+      ["spaces @email.com", "contains spaces"],
+    ])("isValidEmail(%s) returns false (%s)", (email) => {
+      expect(isValidEmail(email)).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles null-ish values gracefully", () => {
+      expect(isValidEmail(null as unknown as string)).toBe(false);
+      expect(isValidEmail(undefined as unknown as string)).toBe(false);
+    });
+
+    it("handles non-string values gracefully", () => {
+      expect(isValidEmail(123 as unknown as string)).toBe(false);
+      expect(isValidEmail({} as unknown as string)).toBe(false);
+    });
+  });
+});
+
+describe("validateEmail", () => {
+  describe("valid emails", () => {
+    it("returns valid result for good email", () => {
+      const result = validateEmail("test@example.com");
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe("invalid emails", () => {
+    it("returns error for empty string", () => {
+      const result = validateEmail("");
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain("required");
+    });
+
+    it("returns error for invalid format", () => {
+      const result = validateEmail("notanemail");
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain("format");
+    });
+
+    it("returns error for email without domain extension", () => {
+      const result = validateEmail("test@nodomain");
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles null gracefully", () => {
+      const result = validateEmail(null as unknown as string);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it("handles undefined gracefully", () => {
+      const result = validateEmail(undefined as unknown as string);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it("trims whitespace before validation", () => {
+      const result = validateEmail("  test@example.com  ");
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("return type", () => {
+    it("satisfies ValidationResult type", () => {
+      const validResult: ValidationResult = validateEmail("test@example.com");
+      const invalidResult: ValidationResult = validateEmail("");
+
+      expect(validResult).toHaveProperty("valid");
+      expect(invalidResult).toHaveProperty("valid");
+      expect(invalidResult).toHaveProperty("error");
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig([
       index: 'src/index.ts',
       'dtos/index': 'src/dtos/index.ts',
       'test-utils/index': 'src/test-utils/index.ts',
+      'validation/index': 'src/validation/index.ts',
     },
     format: ['esm'],
     dts: true,


### PR DESCRIPTION
## Summary

Add shared validation utilities for consistent validation across WXYC services.

### New Exports (`@wxyc/shared/validation`)

- `EMAIL_REGEX` - Regex pattern for email format validation
- `isValidEmail(email)` - Boolean check for valid email format
- `validateEmail(email)` - Returns `{ valid, error? }` with detailed result
- `ValidationResult` - TypeScript type for validation results

### Usage

```typescript
import { isValidEmail, validateEmail } from '@wxyc/shared/validation';

// Simple check
if (isValidEmail(userInput)) { ... }

// Structured validation
const result = validateEmail(userInput);
if (!result.valid) {
  showError(result.error);
}
```

## Test plan

- [x] 32 unit tests covering valid/invalid cases and edge cases
- [x] Build succeeds with new subpath export

## Related PRs

- [dj-site#123](https://github.com/WXYC/dj-site/pull/123) - Use shared validation in EmailChangeModal