### PR TITLE
feat: add pure auth entry point and remove organizationClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/auth-client/index.js",
       "default": "./dist/auth-client/index.js"
     },
+    "./auth-client/auth": {
+      "types": "./dist/auth-client/auth.d.ts",
+      "import": "./dist/auth-client/auth.js",
+      "default": "./dist/auth-client/auth.js"
+    },
     "./validation": {
       "types": "./dist/validation/index.d.ts",
       "import": "./dist/validation/index.js",

--- a/src/auth-client/auth.ts
+++ b/src/auth-client/auth.ts
@@ -1,0 +1,10 @@
+/**
+ * Pure authorization utilities - no React or better-auth client dependencies.
+ * Use this entry point for server-side code or when you only need the
+ * permission/role/capability utilities without the React auth client.
+ */
+
+export * from "./permissions.js";
+export * from "./roles.js";
+export * from "./capabilities.js";
+export * from "./authorization.js";

--- a/src/auth-client/index.ts
+++ b/src/auth-client/index.ts
@@ -5,7 +5,6 @@ import {
   adminClient,
   usernameClient,
   jwtClient,
-  organizationClient,
 } from "better-auth/client/plugins";
 
 /**
@@ -63,7 +62,6 @@ export function createWXYCAuthClient(baseURL: string) {
       adminClient(),
       usernameClient(),
       jwtClient(),
-      organizationClient(),
     ],
   });
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -24,10 +24,11 @@ export default defineConfig([
     splitting: false,
     treeshake: true,
   },
-  // Auth client (needs "use client" directive preserved)
+  // Auth client entries (index needs "use client" directive)
   {
     entry: {
       'auth-client/index': 'src/auth-client/index.ts',
+      'auth-client/auth': 'src/auth-client/auth.ts',
     },
     format: ['esm'],
     dts: true,
@@ -35,6 +36,7 @@ export default defineConfig([
     splitting: false,
     treeshake: true,
     async onSuccess() {
+      // Only add "use client" to the index.js, not auth.js
       addUseClientDirective('dist/auth-client/index.js');
     },
   },


### PR DESCRIPTION
## Summary
- Add `auth.ts` pure entry point (no React/better-auth client deps)
- Add `auth-client/auth` to tsup build config  
- Add `./auth-client/auth` export path to package.json
- Remove `organizationClient()` from auth-client plugins

## Context
This supports the direct role auth model where WXYC roles are stored directly on `user.role` instead of via Better Auth organizations.

The pure entry point allows server-side code to import authorization utilities without pulling in React dependencies.

## Test plan
- [x] Build passes
- [x] All 225 tests pass

Made with [Cursor](https://cursor.com)