### PR TITLE
docs: add Railway service topology and setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,10 @@ npm run lint
 
 See [e2e/README.md](./e2e/README.md) for details on running E2E tests.
 
+## Railway Deployment
+
+See [`railway/`](./railway/) for the Railway service topology, environment variable reference, and setup instructions for replicating the deployment environment.
+
 ## Contributing
 
 1. Add new DTOs in `src/dtos/`

--- a/railway/README.md
+++ b/railway/README.md
@@ -1,0 +1,124 @@
+# Railway Deployment
+
+Configuration and documentation for the WXYC Railway deployment.
+
+## Service Topology
+
+```mermaid
+flowchart TB
+    Slack[Slack Webhook]
+    Groq[Groq AI<br/>parsing]
+    ROM[request-o-matic<br/>WXYC/request-parser]
+    LML[library-metadata-lookup<br/>WXYC/library-metadata-lookup]
+    SQLite[(library.db<br/>SQLite)]
+    PG[(Postgres-Nard<br/>Discogs cache)]
+    ETL[discogs-cache ETL<br/>WXYC/discogs-cache]
+
+    ROM --> Slack
+    ROM --> Groq
+    ROM -. "Phase 2+" .-> LML
+    ROM --> PG
+    LML --> SQLite
+    LML --> PG
+    ETL --> PG
+```
+
+## Services
+
+### request-o-matic
+
+Parses song request messages via Groq AI, searches the library, fetches artwork from Discogs, and posts results to Slack.
+
+| Setting | Value |
+|---------|-------|
+| Repo | [WXYC/request-parser](https://github.com/WXYC/request-parser) |
+| Staging branch | `main` |
+| Production branch | `prod` |
+| Builder | nixpacks |
+| Health check | `GET /health` |
+
+### library-metadata-lookup
+
+Searches the library catalog and cross-references with Discogs metadata. Extracted from request-o-matic to separate search/lookup from message parsing.
+
+| Setting | Value |
+|---------|-------|
+| Repo | [WXYC/library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) |
+| Staging branch | `main` |
+| Production branch | `prod` |
+| Builder | Dockerfile |
+| Health check | `GET /health` |
+
+### Postgres-Nard
+
+PostgreSQL database used as a Discogs metadata cache. Populated by the [discogs-cache](https://github.com/WXYC/discogs-cache) ETL pipeline.
+
+Shared by both request-o-matic and library-metadata-lookup via the `DATABASE_URL_DISCOGS` environment variable.
+
+Internal URL: `postgres-nard.railway.internal:5432/railway`
+
+## Environment Variables
+
+### Shared across services
+
+These variables use the same values on both request-o-matic and library-metadata-lookup:
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DISCOGS_TOKEN` | Discogs API token | No (degrades gracefully) |
+| `DATABASE_URL_DISCOGS` | PostgreSQL URL for Discogs cache | No (degrades to API-only) |
+| `SENTRY_DSN` | Sentry error tracking | No |
+| `POSTHOG_API_KEY` | PostHog telemetry | No |
+
+### request-o-matic only
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `GROQ_API_KEY` | Groq AI key for message parsing | Yes |
+| `SLACK_WEBHOOK_URL` | Slack webhook for posting results | No |
+| `LOOKUP_SERVICE_URL` | URL of library-metadata-lookup (Phase 2+) | No |
+
+### library-metadata-lookup only
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LIBRARY_DB_PATH` | Path to SQLite database | `library.db` |
+| `DISCOGS_TRACK_CACHE_TTL` | In-memory track cache TTL (seconds) | 3600 |
+| `DISCOGS_RELEASE_CACHE_TTL` | In-memory release cache TTL (seconds) | 14400 |
+| `DISCOGS_SEARCH_CACHE_TTL` | In-memory search cache TTL (seconds) | 3600 |
+| `DISCOGS_CACHE_MAXSIZE` | Max entries per in-memory cache | 1000 |
+| `DISCOGS_RATE_LIMIT` | Max Discogs API requests/minute | 50 |
+| `DISCOGS_MAX_CONCURRENT` | Max concurrent Discogs requests | 5 |
+| `DISCOGS_MAX_RETRIES` | Max retries on 429 errors | 2 |
+
+## Environments
+
+Each service has two environments:
+
+| Environment | Branch | Auto-deploy |
+|-------------|--------|-------------|
+| Staging | `main` | Yes |
+| Production | `prod` | Yes |
+
+## Internal Networking
+
+Services on the same Railway project can communicate via internal URLs without exposing public endpoints:
+
+```
+postgres-nard.railway.internal:5432/railway
+library-metadata-lookup-staging.railway.internal:8000
+library-metadata-lookup-production.railway.internal:8000
+```
+
+## Setting Up a New Project
+
+See `services.yaml` for the full topology and `setup-environment.sh` for guided setup instructions.
+
+## Migration Phases
+
+This infrastructure supports the phased migration from monolith to microservices:
+
+1. **Phase 1** (current): Deploy library-metadata-lookup as standalone service
+2. **Phase 2**: request-o-matic calls both local search and library-metadata-lookup, compares results
+3. **Phase 3**: Switch request-o-matic to use library-metadata-lookup as primary
+4. **Phase 4**: Remove search/lookup code from request-o-matic

--- a/railway/services.yaml
+++ b/railway/services.yaml
@@ -1,0 +1,105 @@
+# WXYC Railway Service Topology
+#
+# This file documents all Railway services and their configuration.
+# It is not consumed by Railway directly -- it serves as the single source of
+# truth for replicating the environment.
+#
+# Use setup-environment.sh to bootstrap a new Railway project from this spec.
+
+project: wxyc-services
+
+# ---------------------------------------------------------------------------
+# Shared infrastructure
+# ---------------------------------------------------------------------------
+
+databases:
+  postgres-nard:
+    plugin: postgresql
+    description: >
+      Discogs metadata cache. Populated by discogs-cache ETL.
+      Shared by request-o-matic and library-metadata-lookup.
+
+# ---------------------------------------------------------------------------
+# Services
+# ---------------------------------------------------------------------------
+
+services:
+
+  # --- Request-O-Matic (message parser + Slack poster) ---
+  request-o-matic:
+    repo: WXYC/request-parser
+    environments:
+      staging:
+        branch: main
+      production:
+        branch: prod
+    build:
+      builder: nixpacks
+    deploy:
+      healthcheck_path: /health
+    env:
+      required:
+        - GROQ_API_KEY            # Groq AI for message parsing
+      optional:
+        - DISCOGS_TOKEN           # Discogs API for artwork + track lookup
+        - SLACK_WEBHOOK_URL       # Slack webhook for posting results
+        - SENTRY_DSN              # Sentry error tracking
+        - POSTHOG_API_KEY         # PostHog telemetry
+        - DATABASE_URL_DISCOGS    # PostgreSQL URL for Discogs cache (from postgres-nard)
+        - LIBRARY_DB_PATH         # Path to SQLite database (default: library.db)
+        - LOG_LEVEL               # Logging level (default: INFO)
+      # Future (Phase 2+): LOOKUP_SERVICE_URL for calling library-metadata-lookup
+
+  # --- Library Metadata Lookup (search + Discogs enrichment) ---
+  library-metadata-lookup:
+    repo: WXYC/library-metadata-lookup
+    environments:
+      staging:
+        branch: main
+      production:
+        branch: prod
+    build:
+      builder: dockerfile
+      dockerfile_path: Dockerfile
+    deploy:
+      healthcheck_path: /health
+      healthcheck_timeout: 60
+      restart_policy: on_failure
+      restart_max_retries: 10
+    env:
+      required: []  # All env vars are optional; service degrades gracefully
+      optional:
+        - DISCOGS_TOKEN           # Discogs API for artwork + track lookup
+        - SENTRY_DSN              # Sentry error tracking
+        - POSTHOG_API_KEY         # PostHog telemetry
+        - DATABASE_URL_DISCOGS    # PostgreSQL URL for Discogs cache (from postgres-nard)
+        - LIBRARY_DB_PATH         # Path to SQLite database (default: library.db)
+        - LOG_LEVEL               # Logging level (default: INFO)
+        # Cache TTL settings (all have sane defaults)
+        - DISCOGS_TRACK_CACHE_TTL
+        - DISCOGS_RELEASE_CACHE_TTL
+        - DISCOGS_SEARCH_CACHE_TTL
+        - DISCOGS_CACHE_MAXSIZE
+        # Rate limiting settings (all have sane defaults)
+        - DISCOGS_RATE_LIMIT
+        - DISCOGS_MAX_CONCURRENT
+        - DISCOGS_MAX_RETRIES
+
+# ---------------------------------------------------------------------------
+# Internal networking
+# ---------------------------------------------------------------------------
+#
+# Services on the same Railway project communicate via internal URLs:
+#
+#   postgres-nard:
+#     postgres-nard.railway.internal:5432/railway
+#
+#   library-metadata-lookup (staging):
+#     library-metadata-lookup-staging.railway.internal:8000
+#
+#   library-metadata-lookup (production):
+#     library-metadata-lookup-production.railway.internal:8000
+#
+# Set DATABASE_URL_DISCOGS on each service using the postgres-nard internal URL.
+# Set LOOKUP_SERVICE_URL on request-o-matic using the library-metadata-lookup
+# internal URL (Phase 2+).

--- a/railway/setup-environment.sh
+++ b/railway/setup-environment.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Set up a Railway project for WXYC services.
+#
+# Prerequisites:
+#   - Railway CLI installed: https://docs.railway.app/guides/cli
+#   - Logged in: railway login
+#   - GitHub repos exist: WXYC/request-parser, WXYC/library-metadata-lookup
+#
+# Usage:
+#   ./railway/setup-environment.sh
+#
+# This script creates Railway services and links them to GitHub repos.
+# You still need to set environment variables manually via the Railway dashboard
+# or `railway variables set`.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+if ! command -v railway &>/dev/null; then
+    error "Railway CLI not found. Install it: https://docs.railway.app/guides/cli"
+    exit 1
+fi
+
+if ! railway whoami &>/dev/null; then
+    error "Not logged in to Railway. Run: railway login"
+    exit 1
+fi
+
+info "Railway CLI detected. Logged in as: $(railway whoami 2>/dev/null || echo 'unknown')"
+
+# ---------------------------------------------------------------------------
+# Project selection
+# ---------------------------------------------------------------------------
+echo ""
+info "Select or create the Railway project to set up."
+info "If you already have a project, link it first: railway link"
+echo ""
+read -rp "Continue with the currently linked project? [y/N] " confirm
+if [[ "$confirm" != [yY] ]]; then
+    info "Exiting. Link a project first with: railway link"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Instructions
+# ---------------------------------------------------------------------------
+cat <<'INSTRUCTIONS'
+
+=== WXYC Railway Environment Setup ===
+
+Railway does not have a declarative config format for creating services
+programmatically. Use the Railway dashboard to complete the following:
+
+1. DATABASE: PostgreSQL
+   - Add a PostgreSQL plugin (or use an existing one)
+   - Note the internal connection URL for other services
+
+2. SERVICE: request-o-matic
+   - Create a new service from GitHub repo: WXYC/request-parser
+   - Staging environment: deploy from `main` branch
+   - Production environment: deploy from `prod` branch
+   - Set environment variables:
+     Required:
+       GROQ_API_KEY=<your-groq-api-key>
+     Recommended:
+       DISCOGS_TOKEN=<your-discogs-token>
+       DATABASE_URL_DISCOGS=<postgres-internal-url>
+       SENTRY_DSN=<your-sentry-dsn>
+       POSTHOG_API_KEY=<your-posthog-key>
+
+3. SERVICE: library-metadata-lookup
+   - Create a new service from GitHub repo: WXYC/library-metadata-lookup
+   - Staging environment: deploy from `main` branch
+   - Production environment: deploy from `prod` branch
+   - Set environment variables:
+     Recommended:
+       DISCOGS_TOKEN=<your-discogs-token>
+       DATABASE_URL_DISCOGS=<postgres-internal-url>
+       SENTRY_DSN=<your-sentry-dsn>
+       POSTHOG_API_KEY=<your-posthog-key>
+
+4. NETWORKING
+   - Both services share the same PostgreSQL instance via internal URL
+   - Future: request-o-matic will call library-metadata-lookup via:
+       LOOKUP_SERVICE_URL=http://library-metadata-lookup.railway.internal:8000
+
+5. VERIFY
+   - Check health endpoints:
+       curl https://<request-o-matic-staging>.up.railway.app/health
+       curl https://<library-metadata-lookup-staging>.up.railway.app/health
+
+INSTRUCTIONS
+
+info "See railway/services.yaml for the full service topology."
+info "See railway/README.md for detailed documentation."


### PR DESCRIPTION
## Summary

- Add `railway/` directory with service topology documentation, environment variable reference, and migration phases
- Add `railway/services.yaml` defining all WXYC services (backend, auth, request-o-matic, lookup, discogs-cache, frontend)
- Add `railway/setup-environment.sh` guided script for bootstrapping new Railway projects
- Link from main README

## Test plan

- [ ] Review `railway/README.md` for accuracy against current Railway deployment
- [ ] Verify `setup-environment.sh` runs without errors in a dry-run context