### PR TITLE
feat: add V2 flowsheet discriminated union schemas and type guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ if (hasPermission(user.role, "catalog", "write")) {
 
 | Module | Description |
 |--------|-------------|
-| `flowsheet.dto` | Flowsheet entries, shows, on-air status |
+| `flowsheet.dto` | V1 flowsheet entries, shows, on-air status |
+| `flowsheet-v2.dto` | V2 flowsheet entries (discriminated union by `entry_type`) |
 | `catalog.dto` | Albums, artists, search results |
 | `rotation.dto` | Rotation entries and frequencies |
 | `schedule.dto` | DJ schedule and shifts |

--- a/api.yaml
+++ b/api.yaml
@@ -417,6 +417,265 @@ components:
         totalPages:
           type: integer
 
+    # ===================
+    # Flowsheet V2 Types (Discriminated Union)
+    # ===================
+
+    FlowsheetEntryType:
+      type: string
+      enum:
+        - track
+        - show_start
+        - show_end
+        - dj_join
+        - dj_leave
+        - talkset
+        - breakpoint
+        - message
+      description: Discriminator for V2 flowsheet entry types
+
+    FlowsheetV2Base:
+      type: object
+      description: Base fields shared by all V2 flowsheet entries
+      required:
+        - id
+        - show_id
+        - play_order
+        - add_time
+        - entry_type
+      properties:
+        id:
+          type: integer
+        show_id:
+          type: integer
+          nullable: true
+        play_order:
+          type: integer
+        add_time:
+          type: string
+          format: date-time
+
+    FlowsheetV2TrackEntry:
+      description: V2 track entry - a song that was played
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+            - request_flag
+          properties:
+            entry_type:
+              type: string
+              enum: [track]
+            album_id:
+              type: integer
+              nullable: true
+            rotation_id:
+              type: integer
+              nullable: true
+            artist_name:
+              type: string
+              nullable: true
+            album_title:
+              type: string
+              nullable: true
+            track_title:
+              type: string
+              nullable: true
+            record_label:
+              type: string
+              nullable: true
+            request_flag:
+              type: boolean
+            rotation_bin:
+              $ref: '#/components/schemas/RotationBin'
+            artwork_url:
+              type: string
+              nullable: true
+            discogs_url:
+              type: string
+              nullable: true
+            release_year:
+              type: integer
+              nullable: true
+            spotify_url:
+              type: string
+              nullable: true
+            apple_music_url:
+              type: string
+              nullable: true
+            youtube_music_url:
+              type: string
+              nullable: true
+            bandcamp_url:
+              type: string
+              nullable: true
+            soundcloud_url:
+              type: string
+              nullable: true
+            artist_bio:
+              type: string
+              nullable: true
+            artist_wikipedia_url:
+              type: string
+              nullable: true
+
+    FlowsheetV2ShowStartEntry:
+      description: V2 show start event - when a show begins
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+            - dj_name
+            - timestamp
+          properties:
+            entry_type:
+              type: string
+              enum: [show_start]
+            dj_name:
+              type: string
+            timestamp:
+              type: string
+              format: date-time
+
+    FlowsheetV2ShowEndEntry:
+      description: V2 show end event - when a show ends
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+            - dj_name
+            - timestamp
+          properties:
+            entry_type:
+              type: string
+              enum: [show_end]
+            dj_name:
+              type: string
+            timestamp:
+              type: string
+              format: date-time
+
+    FlowsheetV2DJJoinEntry:
+      description: V2 DJ join event - when a DJ joins an active show
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+            - dj_name
+          properties:
+            entry_type:
+              type: string
+              enum: [dj_join]
+            dj_name:
+              type: string
+
+    FlowsheetV2DJLeaveEntry:
+      description: V2 DJ leave event - when a DJ leaves an active show
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+            - dj_name
+          properties:
+            entry_type:
+              type: string
+              enum: [dj_leave]
+            dj_name:
+              type: string
+
+    FlowsheetV2TalksetEntry:
+      description: V2 talkset entry - DJ talk segment
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+            - message
+          properties:
+            entry_type:
+              type: string
+              enum: [talkset]
+            message:
+              type: string
+
+    FlowsheetV2BreakpointEntry:
+      description: V2 breakpoint entry - hour marker
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+          properties:
+            entry_type:
+              type: string
+              enum: [breakpoint]
+            message:
+              type: string
+              nullable: true
+
+    FlowsheetV2MessageEntry:
+      description: V2 message entry - custom/arbitrary message
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetV2Base'
+        - type: object
+          required:
+            - entry_type
+            - message
+          properties:
+            entry_type:
+              type: string
+              enum: [message]
+            message:
+              type: string
+
+    FlowsheetV2PaginatedResponse:
+      type: object
+      required:
+        - entries
+        - page
+        - limit
+        - total
+        - totalPages
+      properties:
+        entries:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/FlowsheetV2TrackEntry'
+              - $ref: '#/components/schemas/FlowsheetV2ShowStartEntry'
+              - $ref: '#/components/schemas/FlowsheetV2ShowEndEntry'
+              - $ref: '#/components/schemas/FlowsheetV2DJJoinEntry'
+              - $ref: '#/components/schemas/FlowsheetV2DJLeaveEntry'
+              - $ref: '#/components/schemas/FlowsheetV2TalksetEntry'
+              - $ref: '#/components/schemas/FlowsheetV2BreakpointEntry'
+              - $ref: '#/components/schemas/FlowsheetV2MessageEntry'
+            discriminator:
+              propertyName: entry_type
+              mapping:
+                track: '#/components/schemas/FlowsheetV2TrackEntry'
+                show_start: '#/components/schemas/FlowsheetV2ShowStartEntry'
+                show_end: '#/components/schemas/FlowsheetV2ShowEndEntry'
+                dj_join: '#/components/schemas/FlowsheetV2DJJoinEntry'
+                dj_leave: '#/components/schemas/FlowsheetV2DJLeaveEntry'
+                talkset: '#/components/schemas/FlowsheetV2TalksetEntry'
+                breakpoint: '#/components/schemas/FlowsheetV2BreakpointEntry'
+                message: '#/components/schemas/FlowsheetV2MessageEntry'
+        page:
+          type: integer
+        limit:
+          type: integer
+        total:
+          type: integer
+          description: Total number of entries
+        totalPages:
+          type: integer
+          description: Total number of pages
+
     OnAirDJ:
       type: object
       required:
@@ -1967,6 +2226,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PlaylistSearchResponse'
+
+  # ===================
+  # Flowsheet V2 Endpoints
+  # ===================
+
+  /v2/flowsheet:
+    get:
+      summary: Get V2 flowsheet entries (paginated, discriminated union)
+      description: |
+        Returns flowsheet entries as a discriminated union with entry_type field.
+        Each entry type has a well-defined shape instead of optional fields.
+      security: []
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: Page number (0-indexed)
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 30
+          description: Number of entries per page
+      responses:
+        '200':
+          description: Paginated list of V2 flowsheet entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowsheetV2PaginatedResponse'
+
+  /v2/flowsheet/latest:
+    get:
+      summary: Get the most recent V2 flowsheet entry
+      security: []
+      responses:
+        '200':
+          description: Latest flowsheet entry in V2 format
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/FlowsheetV2TrackEntry'
+                  - $ref: '#/components/schemas/FlowsheetV2ShowStartEntry'
+                  - $ref: '#/components/schemas/FlowsheetV2ShowEndEntry'
+                  - $ref: '#/components/schemas/FlowsheetV2DJJoinEntry'
+                  - $ref: '#/components/schemas/FlowsheetV2DJLeaveEntry'
+                  - $ref: '#/components/schemas/FlowsheetV2TalksetEntry'
+                  - $ref: '#/components/schemas/FlowsheetV2BreakpointEntry'
+                  - $ref: '#/components/schemas/FlowsheetV2MessageEntry'
+                discriminator:
+                  propertyName: entry_type
+                  mapping:
+                    track: '#/components/schemas/FlowsheetV2TrackEntry'
+                    show_start: '#/components/schemas/FlowsheetV2ShowStartEntry'
+                    show_end: '#/components/schemas/FlowsheetV2ShowEndEntry'
+                    dj_join: '#/components/schemas/FlowsheetV2DJJoinEntry'
+                    dj_leave: '#/components/schemas/FlowsheetV2DJLeaveEntry'
+                    talkset: '#/components/schemas/FlowsheetV2TalksetEntry'
+                    breakpoint: '#/components/schemas/FlowsheetV2BreakpointEntry'
+                    message: '#/components/schemas/FlowsheetV2MessageEntry'
 
   /djs:
     get:

--- a/src/dtos/extensions.ts
+++ b/src/dtos/extensions.ts
@@ -14,6 +14,14 @@ import type {
   FlowsheetMessageEntry,
   FlowsheetBreakpointEntry,
   FlowsheetShowBlockEntry,
+  FlowsheetV2TrackEntry,
+  FlowsheetV2ShowStartEntry,
+  FlowsheetV2ShowEndEntry,
+  FlowsheetV2DJJoinEntry,
+  FlowsheetV2DJLeaveEntry,
+  FlowsheetV2TalksetEntry,
+  FlowsheetV2BreakpointEntry,
+  FlowsheetV2MessageEntry,
   ScheduleShift,
   DayOfWeek,
 } from '../generated/models/index.js';
@@ -46,12 +54,23 @@ export type WeeklySchedule = {
 // Union Types (not expressible in OpenAPI)
 // =============================================================================
 
-/** Union type for all flowsheet entry types */
+/** Union type for all V1 flowsheet entry types */
 export type FlowsheetEntry =
   | FlowsheetSongEntry
   | FlowsheetBreakpointEntry
   | FlowsheetShowBlockEntry
   | FlowsheetMessageEntry;
+
+/** Union type for all V2 flowsheet entry types (discriminated by entry_type) */
+export type FlowsheetV2Entry =
+  | FlowsheetV2TrackEntry
+  | FlowsheetV2ShowStartEntry
+  | FlowsheetV2ShowEndEntry
+  | FlowsheetV2DJJoinEntry
+  | FlowsheetV2DJLeaveEntry
+  | FlowsheetV2TalksetEntry
+  | FlowsheetV2BreakpointEntry
+  | FlowsheetV2MessageEntry;
 
 // =============================================================================
 // Type Guards
@@ -97,4 +116,56 @@ export function isFlowsheetBreakpointEntry(
   entry: FlowsheetEntry | FlowsheetEntryResponse
 ): entry is FlowsheetBreakpointEntry {
   return isFlowsheetMessageEntry(entry) && entry.message.includes('Breakpoint');
+}
+
+// =============================================================================
+// V2 Type Guards (discriminated by entry_type)
+// =============================================================================
+
+export function isV2TrackEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2TrackEntry {
+  return entry.entry_type === 'track';
+}
+
+export function isV2ShowStartEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2ShowStartEntry {
+  return entry.entry_type === 'show_start';
+}
+
+export function isV2ShowEndEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2ShowEndEntry {
+  return entry.entry_type === 'show_end';
+}
+
+export function isV2DJJoinEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2DJJoinEntry {
+  return entry.entry_type === 'dj_join';
+}
+
+export function isV2DJLeaveEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2DJLeaveEntry {
+  return entry.entry_type === 'dj_leave';
+}
+
+export function isV2TalksetEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2TalksetEntry {
+  return entry.entry_type === 'talkset';
+}
+
+export function isV2BreakpointEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2BreakpointEntry {
+  return entry.entry_type === 'breakpoint';
+}
+
+export function isV2MessageEntry(
+  entry: FlowsheetV2Entry
+): entry is FlowsheetV2MessageEntry {
+  return entry.entry_type === 'message';
 }

--- a/src/test-utils/factories.ts
+++ b/src/test-utils/factories.ts
@@ -11,6 +11,14 @@ import type {
   FlowsheetEntryResponse,
   FlowsheetSongEntry,
   FlowsheetPostRequest,
+  FlowsheetV2TrackEntry,
+  FlowsheetV2ShowStartEntry,
+  FlowsheetV2ShowEndEntry,
+  FlowsheetV2DJJoinEntry,
+  FlowsheetV2DJLeaveEntry,
+  FlowsheetV2TalksetEntry,
+  FlowsheetV2BreakpointEntry,
+  FlowsheetV2MessageEntry,
   RotationEntry,
   DJ,
   BinEntry,
@@ -20,12 +28,22 @@ import type {
   ParsedSongRequest,
 } from '../dtos/index.js';
 
+import type { FlowsheetV2Entry } from '../dtos/extensions.js';
+
 import {
   testArtist,
   testAlbum,
   testAlbumSearchResult,
   testFlowsheetEntry,
   testFlowsheetSongEntry,
+  testV2TrackEntry,
+  testV2ShowStartEntry,
+  testV2ShowEndEntry,
+  testV2DJJoinEntry,
+  testV2DJLeaveEntry,
+  testV2TalksetEntry,
+  testV2BreakpointEntry,
+  testV2MessageEntry,
   testRotation,
   testDJ,
   testBinEntry,
@@ -134,6 +152,98 @@ export function createFlowsheetPostRequest(
         ...overrides,
       } as FlowsheetPostRequest;
   }
+}
+
+// ============================================================================
+// Flowsheet V2
+// ============================================================================
+
+export function createTestV2TrackEntry(
+  overrides: Partial<FlowsheetV2TrackEntry> = {}
+): FlowsheetV2TrackEntry {
+  return {
+    ...testV2TrackEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
+}
+
+export function createTestV2ShowStartEntry(
+  overrides: Partial<FlowsheetV2ShowStartEntry> = {}
+): FlowsheetV2ShowStartEntry {
+  return {
+    ...testV2ShowStartEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
+}
+
+export function createTestV2ShowEndEntry(
+  overrides: Partial<FlowsheetV2ShowEndEntry> = {}
+): FlowsheetV2ShowEndEntry {
+  return {
+    ...testV2ShowEndEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
+}
+
+export function createTestV2DJJoinEntry(
+  overrides: Partial<FlowsheetV2DJJoinEntry> = {}
+): FlowsheetV2DJJoinEntry {
+  return {
+    ...testV2DJJoinEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
+}
+
+export function createTestV2DJLeaveEntry(
+  overrides: Partial<FlowsheetV2DJLeaveEntry> = {}
+): FlowsheetV2DJLeaveEntry {
+  return {
+    ...testV2DJLeaveEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
+}
+
+export function createTestV2TalksetEntry(
+  overrides: Partial<FlowsheetV2TalksetEntry> = {}
+): FlowsheetV2TalksetEntry {
+  return {
+    ...testV2TalksetEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
+}
+
+export function createTestV2BreakpointEntry(
+  overrides: Partial<FlowsheetV2BreakpointEntry> = {}
+): FlowsheetV2BreakpointEntry {
+  return {
+    ...testV2BreakpointEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
+}
+
+export function createTestV2MessageEntry(
+  overrides: Partial<FlowsheetV2MessageEntry> = {}
+): FlowsheetV2MessageEntry {
+  return {
+    ...testV2MessageEntry,
+    id: generateId(),
+    play_order: generateId(),
+    ...overrides,
+  };
 }
 
 // ============================================================================

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -10,6 +10,14 @@ import type {
   AlbumSearchResult,
   FlowsheetEntryResponse,
   FlowsheetSongEntry,
+  FlowsheetV2TrackEntry,
+  FlowsheetV2ShowStartEntry,
+  FlowsheetV2ShowEndEntry,
+  FlowsheetV2DJJoinEntry,
+  FlowsheetV2DJLeaveEntry,
+  FlowsheetV2TalksetEntry,
+  FlowsheetV2BreakpointEntry,
+  FlowsheetV2MessageEntry,
   OnAirDJ,
   RotationEntry,
   DJ,
@@ -109,6 +117,93 @@ export const testFlowsheetSongEntry: FlowsheetSongEntry = {
 export const testOnAirDJ: OnAirDJ = {
   id: 1,
   dj_name: 'DJ Test',
+};
+
+// ============================================================================
+// Flowsheet V2
+// ============================================================================
+
+const testV2AddTime = new Date('2024-06-15T14:30:00.000Z');
+
+export const testV2TrackEntry: FlowsheetV2TrackEntry = {
+  id: 100,
+  show_id: 1,
+  play_order: 50,
+  add_time: testV2AddTime,
+  entry_type: 'track',
+  album_id: 1,
+  rotation_id: 5001,
+  artist_name: 'Test Artist',
+  album_title: 'Test Album',
+  track_title: 'Test Track',
+  record_label: 'Test Label',
+  request_flag: false,
+  rotation_bin: 'H',
+};
+
+export const testV2ShowStartEntry: FlowsheetV2ShowStartEntry = {
+  id: 101,
+  show_id: 1,
+  play_order: 1,
+  add_time: testV2AddTime,
+  entry_type: 'show_start',
+  dj_name: 'DJ Test',
+  timestamp: testV2AddTime,
+};
+
+export const testV2ShowEndEntry: FlowsheetV2ShowEndEntry = {
+  id: 102,
+  show_id: 1,
+  play_order: 200,
+  add_time: testV2AddTime,
+  entry_type: 'show_end',
+  dj_name: 'DJ Test',
+  timestamp: testV2AddTime,
+};
+
+export const testV2DJJoinEntry: FlowsheetV2DJJoinEntry = {
+  id: 103,
+  show_id: 1,
+  play_order: 10,
+  add_time: testV2AddTime,
+  entry_type: 'dj_join',
+  dj_name: 'DJ Guest',
+};
+
+export const testV2DJLeaveEntry: FlowsheetV2DJLeaveEntry = {
+  id: 104,
+  show_id: 1,
+  play_order: 190,
+  add_time: testV2AddTime,
+  entry_type: 'dj_leave',
+  dj_name: 'DJ Guest',
+};
+
+export const testV2TalksetEntry: FlowsheetV2TalksetEntry = {
+  id: 105,
+  show_id: 1,
+  play_order: 60,
+  add_time: testV2AddTime,
+  entry_type: 'talkset',
+  message: 'Talkset - station ID',
+};
+
+export const testV2BreakpointEntry: FlowsheetV2BreakpointEntry = {
+  id: 106,
+  show_id: 1,
+  play_order: 100,
+  add_time: testV2AddTime,
+  entry_type: 'breakpoint',
+  message: 'Breakpoint - 3:00 PM',
+};
+
+export const testV2MessageEntry: FlowsheetV2MessageEntry = {
+  id: 107,
+  show_id: 1,
+  play_order: 70,
+  add_time: testV2AddTime,
+  entry_type: 'message',
+  message: 'Listener shout-out to Chapel Hill',
 };
 
 // ============================================================================

--- a/tests/v2-flowsheet.test.ts
+++ b/tests/v2-flowsheet.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Tests for V2 Flowsheet Types and Type Guards
+ *
+ * Validates:
+ * - Generated V2 types round-trip through FromJSON/ToJSON
+ * - Discriminator-based type guards narrow correctly
+ * - FlowsheetEntryType enum has all expected values
+ * - PaginatedResponse wrapper deserializes entries via discriminator
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  FlowsheetEntryType,
+  FlowsheetV2TrackEntry,
+  FlowsheetV2TrackEntryFromJSON,
+  FlowsheetV2TrackEntryToJSON,
+  FlowsheetV2ShowStartEntry,
+  FlowsheetV2ShowStartEntryFromJSON,
+  FlowsheetV2ShowStartEntryToJSON,
+  FlowsheetV2ShowEndEntry,
+  FlowsheetV2ShowEndEntryFromJSON,
+  FlowsheetV2ShowEndEntryToJSON,
+  FlowsheetV2DJJoinEntry,
+  FlowsheetV2DJJoinEntryFromJSON,
+  FlowsheetV2DJJoinEntryToJSON,
+  FlowsheetV2DJLeaveEntry,
+  FlowsheetV2DJLeaveEntryFromJSON,
+  FlowsheetV2DJLeaveEntryToJSON,
+  FlowsheetV2TalksetEntry,
+  FlowsheetV2TalksetEntryFromJSON,
+  FlowsheetV2TalksetEntryToJSON,
+  FlowsheetV2BreakpointEntry,
+  FlowsheetV2BreakpointEntryFromJSON,
+  FlowsheetV2BreakpointEntryToJSON,
+  FlowsheetV2MessageEntry,
+  FlowsheetV2MessageEntryFromJSON,
+  FlowsheetV2MessageEntryToJSON,
+  FlowsheetV2PaginatedResponse,
+  FlowsheetV2PaginatedResponseFromJSON,
+  FlowsheetV2PaginatedResponseToJSON,
+  RotationBin,
+} from '../src/generated/models/index.js';
+import {
+  isV2TrackEntry,
+  isV2ShowStartEntry,
+  isV2ShowEndEntry,
+  isV2DJJoinEntry,
+  isV2DJLeaveEntry,
+  isV2TalksetEntry,
+  isV2BreakpointEntry,
+  isV2MessageEntry,
+  type FlowsheetV2Entry,
+} from '../src/dtos/extensions.js';
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+const baseFields = {
+  id: 1,
+  show_id: 42,
+  play_order: 100,
+  add_time: '2024-06-15T14:30:00.000Z',
+};
+
+const sampleTrack = {
+  ...baseFields,
+  entry_type: 'track',
+  artist_name: 'Radiohead',
+  album_title: 'OK Computer',
+  track_title: 'Paranoid Android',
+  record_label: 'Parlophone',
+  request_flag: false,
+  rotation_bin: 'H',
+  album_id: 1001,
+  rotation_id: 5001,
+  artwork_url: 'https://example.com/art.jpg',
+  spotify_url: 'https://open.spotify.com/track/abc',
+};
+
+const sampleShowStart = {
+  ...baseFields,
+  entry_type: 'show_start',
+  dj_name: 'DJ Cool',
+  timestamp: '2024-06-15T14:00:00.000Z',
+};
+
+const sampleShowEnd = {
+  ...baseFields,
+  entry_type: 'show_end',
+  dj_name: 'DJ Cool',
+  timestamp: '2024-06-15T16:00:00.000Z',
+};
+
+const sampleDJJoin = {
+  ...baseFields,
+  entry_type: 'dj_join',
+  dj_name: 'DJ Guest',
+};
+
+const sampleDJLeave = {
+  ...baseFields,
+  entry_type: 'dj_leave',
+  dj_name: 'DJ Guest',
+};
+
+const sampleTalkset = {
+  ...baseFields,
+  entry_type: 'talkset',
+  message: 'Talkset - station ID',
+};
+
+const sampleBreakpoint = {
+  ...baseFields,
+  entry_type: 'breakpoint',
+  message: 'Breakpoint - 3:00 PM',
+};
+
+const sampleMessage = {
+  ...baseFields,
+  entry_type: 'message',
+  message: 'Shout-out to Chapel Hill',
+};
+
+// =============================================================================
+// FlowsheetEntryType Enum
+// =============================================================================
+
+describe('FlowsheetEntryType', () => {
+  it.each([
+    'track',
+    'show_start',
+    'show_end',
+    'dj_join',
+    'dj_leave',
+    'talkset',
+    'breakpoint',
+    'message',
+  ])('should include "%s"', (value) => {
+    expect(Object.values(FlowsheetEntryType)).toContain(value);
+  });
+
+  it('should have exactly 8 values', () => {
+    expect(Object.keys(FlowsheetEntryType)).toHaveLength(8);
+  });
+});
+
+// =============================================================================
+// Round-trip JSON Tests (FromJSON -> ToJSON -> FromJSON)
+// =============================================================================
+
+describe('V2 Generated Types - JSON Round-trip', () => {
+  describe('FlowsheetV2TrackEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2TrackEntryFromJSON(sampleTrack);
+
+      expect(entry.id).toBe(1);
+      expect(entry.entry_type).toBe('track');
+      expect(entry.artist_name).toBe('Radiohead');
+      expect(entry.track_title).toBe('Paranoid Android');
+      expect(entry.rotation_bin).toBe(RotationBin.H);
+      expect(entry.request_flag).toBe(false);
+      expect(entry.add_time).toBeInstanceOf(Date);
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2TrackEntryFromJSON(sampleTrack);
+      const json = FlowsheetV2TrackEntryToJSON(entry);
+      const roundTrip = FlowsheetV2TrackEntryFromJSON(json);
+
+      expect(roundTrip.id).toBe(entry.id);
+      expect(roundTrip.entry_type).toBe('track');
+      expect(roundTrip.artist_name).toBe(entry.artist_name);
+      expect(roundTrip.rotation_bin).toBe(entry.rotation_bin);
+    });
+
+    it('should handle nullable metadata fields', () => {
+      const entry = FlowsheetV2TrackEntryFromJSON({
+        ...sampleTrack,
+        artwork_url: null,
+        spotify_url: null,
+        release_year: null,
+        artist_bio: null,
+      });
+
+      expect(entry.artwork_url).toBeUndefined();
+      expect(entry.spotify_url).toBeUndefined();
+      expect(entry.release_year).toBeUndefined();
+      expect(entry.artist_bio).toBeUndefined();
+    });
+
+    it('should handle nullable show_id', () => {
+      const entry = FlowsheetV2TrackEntryFromJSON({
+        ...sampleTrack,
+        show_id: null,
+      });
+
+      expect(entry.show_id).toBeNull();
+    });
+  });
+
+  describe('FlowsheetV2ShowStartEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2ShowStartEntryFromJSON(sampleShowStart);
+
+      expect(entry.entry_type).toBe('show_start');
+      expect(entry.dj_name).toBe('DJ Cool');
+      expect(entry.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2ShowStartEntryFromJSON(sampleShowStart);
+      const json = FlowsheetV2ShowStartEntryToJSON(entry);
+      const roundTrip = FlowsheetV2ShowStartEntryFromJSON(json);
+
+      expect(roundTrip.entry_type).toBe('show_start');
+      expect(roundTrip.dj_name).toBe(entry.dj_name);
+    });
+  });
+
+  describe('FlowsheetV2ShowEndEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2ShowEndEntryFromJSON(sampleShowEnd);
+
+      expect(entry.entry_type).toBe('show_end');
+      expect(entry.dj_name).toBe('DJ Cool');
+      expect(entry.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2ShowEndEntryFromJSON(sampleShowEnd);
+      const json = FlowsheetV2ShowEndEntryToJSON(entry);
+      const roundTrip = FlowsheetV2ShowEndEntryFromJSON(json);
+
+      expect(roundTrip.entry_type).toBe('show_end');
+      expect(roundTrip.dj_name).toBe(entry.dj_name);
+    });
+  });
+
+  describe('FlowsheetV2DJJoinEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2DJJoinEntryFromJSON(sampleDJJoin);
+
+      expect(entry.entry_type).toBe('dj_join');
+      expect(entry.dj_name).toBe('DJ Guest');
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2DJJoinEntryFromJSON(sampleDJJoin);
+      const json = FlowsheetV2DJJoinEntryToJSON(entry);
+      const roundTrip = FlowsheetV2DJJoinEntryFromJSON(json);
+
+      expect(roundTrip.entry_type).toBe('dj_join');
+      expect(roundTrip.dj_name).toBe(entry.dj_name);
+    });
+  });
+
+  describe('FlowsheetV2DJLeaveEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2DJLeaveEntryFromJSON(sampleDJLeave);
+
+      expect(entry.entry_type).toBe('dj_leave');
+      expect(entry.dj_name).toBe('DJ Guest');
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2DJLeaveEntryFromJSON(sampleDJLeave);
+      const json = FlowsheetV2DJLeaveEntryToJSON(entry);
+      const roundTrip = FlowsheetV2DJLeaveEntryFromJSON(json);
+
+      expect(roundTrip.entry_type).toBe('dj_leave');
+      expect(roundTrip.dj_name).toBe(entry.dj_name);
+    });
+  });
+
+  describe('FlowsheetV2TalksetEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2TalksetEntryFromJSON(sampleTalkset);
+
+      expect(entry.entry_type).toBe('talkset');
+      expect(entry.message).toBe('Talkset - station ID');
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2TalksetEntryFromJSON(sampleTalkset);
+      const json = FlowsheetV2TalksetEntryToJSON(entry);
+      const roundTrip = FlowsheetV2TalksetEntryFromJSON(json);
+
+      expect(roundTrip.entry_type).toBe('talkset');
+      expect(roundTrip.message).toBe(entry.message);
+    });
+  });
+
+  describe('FlowsheetV2BreakpointEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2BreakpointEntryFromJSON(sampleBreakpoint);
+
+      expect(entry.entry_type).toBe('breakpoint');
+      expect(entry.message).toBe('Breakpoint - 3:00 PM');
+    });
+
+    it('should handle null message', () => {
+      const entry = FlowsheetV2BreakpointEntryFromJSON({
+        ...baseFields,
+        entry_type: 'breakpoint',
+        message: null,
+      });
+
+      expect(entry.entry_type).toBe('breakpoint');
+      expect(entry.message).toBeUndefined();
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2BreakpointEntryFromJSON(sampleBreakpoint);
+      const json = FlowsheetV2BreakpointEntryToJSON(entry);
+      const roundTrip = FlowsheetV2BreakpointEntryFromJSON(json);
+
+      expect(roundTrip.entry_type).toBe('breakpoint');
+      expect(roundTrip.message).toBe(entry.message);
+    });
+  });
+
+  describe('FlowsheetV2MessageEntry', () => {
+    it('should parse from JSON', () => {
+      const entry = FlowsheetV2MessageEntryFromJSON(sampleMessage);
+
+      expect(entry.entry_type).toBe('message');
+      expect(entry.message).toBe('Shout-out to Chapel Hill');
+    });
+
+    it('should round-trip through JSON', () => {
+      const entry = FlowsheetV2MessageEntryFromJSON(sampleMessage);
+      const json = FlowsheetV2MessageEntryToJSON(entry);
+      const roundTrip = FlowsheetV2MessageEntryFromJSON(json);
+
+      expect(roundTrip.entry_type).toBe('message');
+      expect(roundTrip.message).toBe(entry.message);
+    });
+  });
+});
+
+// =============================================================================
+// V2 Type Guards
+// =============================================================================
+
+describe('V2 Type Guards', () => {
+  const entries: Array<{ entry: FlowsheetV2Entry; type: string }> = [
+    { entry: FlowsheetV2TrackEntryFromJSON(sampleTrack), type: 'track' },
+    { entry: FlowsheetV2ShowStartEntryFromJSON(sampleShowStart), type: 'show_start' },
+    { entry: FlowsheetV2ShowEndEntryFromJSON(sampleShowEnd), type: 'show_end' },
+    { entry: FlowsheetV2DJJoinEntryFromJSON(sampleDJJoin), type: 'dj_join' },
+    { entry: FlowsheetV2DJLeaveEntryFromJSON(sampleDJLeave), type: 'dj_leave' },
+    { entry: FlowsheetV2TalksetEntryFromJSON(sampleTalkset), type: 'talkset' },
+    { entry: FlowsheetV2BreakpointEntryFromJSON(sampleBreakpoint), type: 'breakpoint' },
+    { entry: FlowsheetV2MessageEntryFromJSON(sampleMessage), type: 'message' },
+  ];
+
+  const guards: Array<{
+    name: string;
+    guard: (e: FlowsheetV2Entry) => boolean;
+    matchType: string;
+  }> = [
+    { name: 'isV2TrackEntry', guard: isV2TrackEntry, matchType: 'track' },
+    { name: 'isV2ShowStartEntry', guard: isV2ShowStartEntry, matchType: 'show_start' },
+    { name: 'isV2ShowEndEntry', guard: isV2ShowEndEntry, matchType: 'show_end' },
+    { name: 'isV2DJJoinEntry', guard: isV2DJJoinEntry, matchType: 'dj_join' },
+    { name: 'isV2DJLeaveEntry', guard: isV2DJLeaveEntry, matchType: 'dj_leave' },
+    { name: 'isV2TalksetEntry', guard: isV2TalksetEntry, matchType: 'talkset' },
+    { name: 'isV2BreakpointEntry', guard: isV2BreakpointEntry, matchType: 'breakpoint' },
+    { name: 'isV2MessageEntry', guard: isV2MessageEntry, matchType: 'message' },
+  ];
+
+  describe.each(guards)('$name', ({ guard, matchType }) => {
+    it.each(entries)(
+      `should return ${matchType === '$type' ? 'true' : 'false'} for $type entry`,
+      ({ entry, type }) => {
+        expect(guard(entry)).toBe(type === matchType);
+      }
+    );
+  });
+});
+
+// =============================================================================
+// Paginated Response
+// =============================================================================
+
+describe('FlowsheetV2PaginatedResponse', () => {
+  const paginatedJson = {
+    entries: [sampleTrack, sampleShowStart, sampleBreakpoint, sampleMessage],
+    page: 0,
+    limit: 30,
+    total: 150,
+    totalPages: 5,
+  };
+
+  it('should parse paginated response with mixed entry types', () => {
+    const response = FlowsheetV2PaginatedResponseFromJSON(paginatedJson);
+
+    expect(response.entries).toHaveLength(4);
+    expect(response.page).toBe(0);
+    expect(response.limit).toBe(30);
+    expect(response.total).toBe(150);
+    expect(response.totalPages).toBe(5);
+  });
+
+  it('should deserialize entries using discriminator', () => {
+    const response = FlowsheetV2PaginatedResponseFromJSON(paginatedJson);
+
+    // Cast to FlowsheetV2Entry to use type guards
+    const entries = response.entries as unknown as FlowsheetV2Entry[];
+
+    expect(isV2TrackEntry(entries[0])).toBe(true);
+    expect(isV2ShowStartEntry(entries[1])).toBe(true);
+    expect(isV2BreakpointEntry(entries[2])).toBe(true);
+    expect(isV2MessageEntry(entries[3])).toBe(true);
+  });
+
+  it('should preserve track metadata through discriminator deserialization', () => {
+    const response = FlowsheetV2PaginatedResponseFromJSON(paginatedJson);
+    const trackEntry = response.entries[0] as unknown as FlowsheetV2TrackEntry;
+
+    expect(trackEntry.artist_name).toBe('Radiohead');
+    expect(trackEntry.track_title).toBe('Paranoid Android');
+    expect(trackEntry.rotation_bin).toBe(RotationBin.H);
+    expect(trackEntry.add_time).toBeInstanceOf(Date);
+  });
+
+  it('should round-trip through JSON', () => {
+    const response = FlowsheetV2PaginatedResponseFromJSON(paginatedJson);
+    const json = FlowsheetV2PaginatedResponseToJSON(response);
+    const roundTrip = FlowsheetV2PaginatedResponseFromJSON(json);
+
+    expect(roundTrip.entries).toHaveLength(4);
+    expect(roundTrip.page).toBe(0);
+    expect(roundTrip.total).toBe(150);
+  });
+
+  it('should handle empty entries array', () => {
+    const response = FlowsheetV2PaginatedResponseFromJSON({
+      entries: [],
+      page: 0,
+      limit: 30,
+      total: 0,
+      totalPages: 0,
+    });
+
+    expect(response.entries).toHaveLength(0);
+    expect(response.total).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add V2 flowsheet discriminated union schemas to `api.yaml` (track, show_start, show_end, dj_join, dj_leave, talkset, breakpoint, message)
- Add V2 type guards and factory functions in `extensions.ts`
- Add paginated response schema and `/v2/flowsheet` + `/v2/flowsheet/latest` endpoints
- Add comprehensive test coverage (97 tests)

## Test plan
- [x] All 354 unit tests pass
- [x] Type check clean
- [x] Build succeeds
- [x] Changes are additive only (no breaking changes)