### PR TITLE
Remove admin from station role hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This package provides:
 ## Authorization Model
 
 The auth system has two dimensions:
-1. **Roles** (hierarchical): member < dj < musicDirector < stationManager < admin
+1. **Roles** (hierarchical): member < dj < musicDirector < stationManager
 2. **Capabilities** (cross-cutting): `editor`, `webmaster` - can be granted to any user
 
 Use `Authorization` enum for numeric comparisons, branded types (`RoleAuthorizedUser`, `CapabilityAuthorizedUser`) for compile-time enforcement.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/auth-client/auth.ts
+++ b/src/auth-client/auth.ts
@@ -4,6 +4,14 @@
  * permission/role/capability utilities without the React auth client.
  */
 
+/**
+ * Check if a user has the better-auth system admin role.
+ * This is orthogonal to the WXYC station role hierarchy (member/dj/md/sm).
+ */
+export function isSystemAdmin(user: { role?: string | null }): boolean {
+  return user.role === "admin";
+}
+
 export * from "./permissions.js";
 export * from "./roles.js";
 export * from "./capabilities.js";

--- a/src/auth-client/authorization.ts
+++ b/src/auth-client/authorization.ts
@@ -20,8 +20,6 @@ export enum Authorization {
   MD = 2,
   /** Station Manager - can manage roster */
   SM = 3,
-  /** Admin - full access */
-  ADMIN = 4,
 }
 
 /**
@@ -32,7 +30,6 @@ export const AUTHORIZATION_LABELS: Record<Authorization, string> = {
   [Authorization.DJ]: "DJ",
   [Authorization.MD]: "Music Director",
   [Authorization.SM]: "Station Manager",
-  [Authorization.ADMIN]: "Admin",
 };
 
 // ============================================================================
@@ -43,9 +40,10 @@ export const AUTHORIZATION_LABELS: Record<Authorization, string> = {
  * Maps a WXYCRole string to the Authorization enum.
  *
  * Handles variations:
- * - Standard roles: "member", "dj", "musicDirector", "stationManager", "admin"
+ * - Standard roles: "member", "dj", "musicDirector", "stationManager"
  * - Snake case: "station_manager", "music_director"
- * - Better-auth defaults: "owner", "user"
+ * - Better-auth defaults: "admin", "owner" -> SM (safe fallback)
+ * - "user" -> NO (member-level)
  *
  * @param role - The role string from better-auth
  * @returns The corresponding Authorization enum value
@@ -62,7 +60,6 @@ export function roleToAuthorization(
   switch (normalized) {
     case "admin":
     case "owner":
-      return Authorization.ADMIN;
     case "stationmanager":
     case "station_manager":
       return Authorization.SM;
@@ -84,8 +81,6 @@ export function roleToAuthorization(
  */
 export function authorizationToRole(auth: Authorization): WXYCRole {
   switch (auth) {
-    case Authorization.ADMIN:
-      return "admin";
     case Authorization.SM:
       return "stationManager";
     case Authorization.MD:

--- a/src/auth-client/capabilities.ts
+++ b/src/auth-client/capabilities.ts
@@ -12,7 +12,7 @@ export type Capability = (typeof CAPABILITIES)[number];
  * Policy as data: who can assign which capabilities.
  *
  * Delegation chain:
- *   Admin/StationManager -> can assign webmaster or editor
+ *   StationManager -> can assign webmaster or editor
  *   Webmaster (capability) -> can assign editor only
  */
 export const CAPABILITY_ASSIGNERS: Record<
@@ -20,11 +20,11 @@ export const CAPABILITY_ASSIGNERS: Record<
   { roles: readonly WXYCRole[]; capabilities: readonly Capability[] }
 > = {
   editor: {
-    roles: ["admin", "stationManager"],
+    roles: ["stationManager"],
     capabilities: ["webmaster"],
   },
   webmaster: {
-    roles: ["admin", "stationManager"],
+    roles: ["stationManager"],
     capabilities: [],
   },
 } as const;

--- a/src/auth-client/index.ts
+++ b/src/auth-client/index.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Roles that grant extended archive access (90 days instead of 14).
  */
-export const DJ_ROLES = ["dj", "musicDirector", "stationManager", "admin"] as const;
+export const DJ_ROLES = ["dj", "musicDirector", "stationManager"] as const;
 export type DJRole = (typeof DJ_ROLES)[number];
 
 /**

--- a/src/auth-client/roles.ts
+++ b/src/auth-client/roles.ts
@@ -1,10 +1,12 @@
 import type { Permission, Resource, Action } from "./permissions.js";
 
 /**
- * All WXYC roles, ordered by privilege level (highest first).
+ * All WXYC station roles, ordered by privilege level (highest first).
+ *
+ * Note: "admin" is a better-auth system role (auth_user.role), not a station role.
+ * Use isSystemAdmin() from auth.ts for system admin checks.
  */
 export const ROLES = [
-  "admin",
   "stationManager",
   "musicDirector",
   "dj",
@@ -16,12 +18,6 @@ export type WXYCRole = (typeof ROLES)[number];
  * Permission grants for each role.
  */
 export const ROLE_PERMISSIONS: Record<WXYCRole, Permission> = {
-  admin: {
-    catalog: ["read", "write"],
-    bin: ["read", "write"],
-    flowsheet: ["read", "write"],
-    roster: ["read", "write"],
-  },
   stationManager: {
     catalog: ["read", "write"],
     bin: ["read", "write"],
@@ -69,32 +65,21 @@ export function canManageRoster(role: WXYCRole | null | undefined): boolean {
 
 /**
  * Check if a role can assign other roles.
- * Only admin and stationManager can assign roles.
+ * Only stationManager can assign roles.
  */
 export function canAssignRoles(role: WXYCRole | null | undefined): boolean {
-  return role === "admin" || role === "stationManager";
-}
-
-/**
- * Check if a role can promote to admin.
- * Only admin can promote to admin.
- */
-export function canPromoteToAdmin(role: WXYCRole | null | undefined): boolean {
-  return role === "admin";
+  return role === "stationManager";
 }
 
 /**
  * Get assignable roles for a given role.
- * Admins can assign any role, SMs can assign up to SM.
+ * Station managers can assign any station role.
  */
 export function getAssignableRoles(
   role: WXYCRole | null | undefined
 ): WXYCRole[] {
-  if (role === "admin") {
-    return [...ROLES];
-  }
   if (role === "stationManager") {
-    return ["stationManager", "musicDirector", "dj", "member"];
+    return [...ROLES];
   }
   return [];
 }

--- a/tests/branded-auth.test.ts
+++ b/tests/branded-auth.test.ts
@@ -18,11 +18,9 @@ describe("Authorization enum", () => {
     expect(Authorization.DJ).toBe(1);
     expect(Authorization.MD).toBe(2);
     expect(Authorization.SM).toBe(3);
-    expect(Authorization.ADMIN).toBe(4);
   });
 
   it("supports numeric comparison for hierarchy", () => {
-    expect(Authorization.ADMIN > Authorization.SM).toBe(true);
     expect(Authorization.SM > Authorization.MD).toBe(true);
     expect(Authorization.MD > Authorization.DJ).toBe(true);
     expect(Authorization.DJ > Authorization.NO).toBe(true);
@@ -35,13 +33,12 @@ describe("AUTHORIZATION_LABELS", () => {
     expect(AUTHORIZATION_LABELS[Authorization.DJ]).toBe("DJ");
     expect(AUTHORIZATION_LABELS[Authorization.MD]).toBe("Music Director");
     expect(AUTHORIZATION_LABELS[Authorization.SM]).toBe("Station Manager");
-    expect(AUTHORIZATION_LABELS[Authorization.ADMIN]).toBe("Admin");
   });
 });
 
 describe("roleToAuthorization", () => {
   const cases: [WXYCRole | string | null | undefined, Authorization, string][] = [
-    ["admin", Authorization.ADMIN, "admin role"],
+    ["admin", Authorization.SM, "admin maps to SM"],
     ["stationManager", Authorization.SM, "stationManager role"],
     ["station_manager", Authorization.SM, "snake_case variant"],
     ["musicDirector", Authorization.MD, "musicDirector role"],
@@ -49,7 +46,7 @@ describe("roleToAuthorization", () => {
     ["dj", Authorization.DJ, "dj role"],
     ["member", Authorization.NO, "member role"],
     ["user", Authorization.NO, "user fallback"],
-    ["owner", Authorization.ADMIN, "owner maps to admin"],
+    ["owner", Authorization.SM, "owner maps to SM"],
     [null, Authorization.NO, "null defaults to NO"],
     [undefined, Authorization.NO, "undefined defaults to NO"],
     ["unknown", Authorization.NO, "unknown defaults to NO"],
@@ -62,7 +59,6 @@ describe("roleToAuthorization", () => {
 
 describe("authorizationToRole", () => {
   const cases: [Authorization, WXYCRole][] = [
-    [Authorization.ADMIN, "admin"],
     [Authorization.SM, "stationManager"],
     [Authorization.MD, "musicDirector"],
     [Authorization.DJ, "dj"],
@@ -108,7 +104,6 @@ describe("checkRole", () => {
       [Authorization.DJ, Authorization.MD, "DJ cannot access MD-required"],
       [Authorization.DJ, Authorization.SM, "DJ cannot access SM-required"],
       [Authorization.MD, Authorization.SM, "MD cannot access SM-required"],
-      [Authorization.SM, Authorization.ADMIN, "SM cannot access ADMIN-required"],
     ];
 
     it.each(insufficientCases)(
@@ -127,10 +122,7 @@ describe("checkRole", () => {
     const sufficientCases: [Authorization, Authorization, string][] = [
       [Authorization.DJ, Authorization.DJ, "exact match"],
       [Authorization.SM, Authorization.DJ, "higher role"],
-      [Authorization.ADMIN, Authorization.DJ, "admin accessing DJ"],
       [Authorization.SM, Authorization.SM, "SM accessing SM"],
-      [Authorization.ADMIN, Authorization.SM, "admin accessing SM"],
-      [Authorization.ADMIN, Authorization.ADMIN, "admin accessing admin"],
     ];
 
     it.each(sufficientCases)(

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -45,18 +45,16 @@ describe("canEditWebsite", () => {
 });
 
 describe("CAPABILITY_ASSIGNERS", () => {
-  it("allows admin and stationManager to assign editor", () => {
-    expect(CAPABILITY_ASSIGNERS.editor.roles).toContain("admin");
-    expect(CAPABILITY_ASSIGNERS.editor.roles).toContain("stationManager");
+  it("allows only stationManager to assign editor by role", () => {
+    expect(CAPABILITY_ASSIGNERS.editor.roles).toEqual(["stationManager"]);
   });
 
   it("allows webmaster capability to assign editor", () => {
     expect(CAPABILITY_ASSIGNERS.editor.capabilities).toContain("webmaster");
   });
 
-  it("allows admin and stationManager to assign webmaster", () => {
-    expect(CAPABILITY_ASSIGNERS.webmaster.roles).toContain("admin");
-    expect(CAPABILITY_ASSIGNERS.webmaster.roles).toContain("stationManager");
+  it("allows only stationManager to assign webmaster by role", () => {
+    expect(CAPABILITY_ASSIGNERS.webmaster.roles).toEqual(["stationManager"]);
   });
 
   it("does not allow any capability to assign webmaster", () => {
@@ -75,7 +73,6 @@ describe("canAssignCapability", () => {
     it.each<
       [{ role: WXYCRole; capabilities: Capability[] }, boolean, string]
     >([
-      [user("admin"), true, "admin can assign"],
       [user("stationManager"), true, "stationManager can assign"],
       [user("dj", ["webmaster"]), true, "webmaster capability can assign"],
       [user("member", ["webmaster"]), true, "member with webmaster can assign"],
@@ -91,7 +88,6 @@ describe("canAssignCapability", () => {
     it.each<
       [{ role: WXYCRole; capabilities: Capability[] }, boolean, string]
     >([
-      [user("admin"), true, "admin can assign"],
       [user("stationManager"), true, "stationManager can assign"],
       [user("dj", ["webmaster"]), false, "webmaster cannot assign webmaster"],
       [user("musicDirector"), false, "musicDirector cannot assign"],

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
   hasPermission,
-  canPromoteToAdmin,
   canAssignRoles,
   canManageRoster,
   getAssignableRoles,
@@ -11,12 +10,7 @@ import {
 
 describe("hasPermission", () => {
   const permissionCases = [
-    // Admin has everything
-    { role: "admin", resource: "roster", action: "read", expected: true },
-    { role: "admin", resource: "roster", action: "write", expected: true },
-    { role: "admin", resource: "catalog", action: "write", expected: true },
-
-    // SM has roster access
+    // SM has roster access (top of hierarchy)
     {
       role: "stationManager",
       resource: "roster",
@@ -76,7 +70,6 @@ describe("hasPermission", () => {
 
 describe("canManageRoster", () => {
   const cases = [
-    { role: "admin", expected: true },
     { role: "stationManager", expected: true },
     { role: "musicDirector", expected: false },
     { role: "dj", expected: false },
@@ -89,27 +82,8 @@ describe("canManageRoster", () => {
   });
 });
 
-describe("canPromoteToAdmin", () => {
-  const cases = [
-    { role: "admin", expected: true },
-    { role: "stationManager", expected: false },
-    { role: "musicDirector", expected: false },
-    { role: "dj", expected: false },
-    { role: "member", expected: false },
-    { role: null, expected: false },
-  ] as const;
-
-  it.each(cases)(
-    "$role can promote to admin = $expected",
-    ({ role, expected }) => {
-      expect(canPromoteToAdmin(role)).toBe(expected);
-    }
-  );
-});
-
 describe("canAssignRoles", () => {
   const cases = [
-    { role: "admin", expected: true },
     { role: "stationManager", expected: true },
     { role: "musicDirector", expected: false },
     { role: "dj", expected: false },
@@ -123,17 +97,8 @@ describe("canAssignRoles", () => {
 });
 
 describe("getAssignableRoles", () => {
-  it("admin can assign all roles", () => {
-    expect(getAssignableRoles("admin")).toEqual([...ROLES]);
-  });
-
-  it("stationManager can assign all except admin", () => {
-    const assignable = getAssignableRoles("stationManager");
-    expect(assignable).toContain("stationManager");
-    expect(assignable).toContain("musicDirector");
-    expect(assignable).toContain("dj");
-    expect(assignable).toContain("member");
-    expect(assignable).not.toContain("admin");
+  it("stationManager can assign all roles", () => {
+    expect(getAssignableRoles("stationManager")).toEqual([...ROLES]);
   });
 
   const nonAssignerRoles = ["musicDirector", "dj", "member", null] as const;

--- a/tests/system-admin.test.ts
+++ b/tests/system-admin.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { isSystemAdmin } from "../src/auth-client/auth.js";
+
+describe("isSystemAdmin", () => {
+  const cases: [{ role?: string | null }, boolean, string][] = [
+    [{ role: "admin" }, true, "admin user"],
+    [{ role: "user" }, false, "regular user"],
+    [{ role: "stationManager" }, false, "station manager is not system admin"],
+    [{ role: null }, false, "null role"],
+    [{ role: undefined }, false, "undefined role"],
+  ];
+
+  it.each(cases)("given %j returns %s (%s)", (user, expected) => {
+    expect(isSystemAdmin(user)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Removes `admin` from the WXYC station role hierarchy, aligning wxyc-shared with Backend-Service and dj-site which already use a 4-role model
- `admin` is a better-auth system role (`auth_user.role`), orthogonal to station roles (`auth_member.role`); conflating them caused the 403 bug documented in the auth convergence proposal
- Adds `isSystemAdmin(user)` utility for checking better-auth admin status
- Maps `"admin"` and `"owner"` role strings to `Authorization.SM` as a safe fallback in `roleToAuthorization()`

## Breaking changes

- `ROLES` is now 4 elements (was 5)
- `WXYCRole` type no longer includes `"admin"`
- `Authorization.ADMIN` (value 4) removed from enum
- `canPromoteToAdmin()` removed
- `canAssignRoles()` only returns true for `stationManager`
- `CAPABILITY_ASSIGNERS` role arrays contain only `["stationManager"]`
- `DJ_ROLES` no longer includes `"admin"`

## Test plan

- [x] All 103 auth tests pass (roles, branded-auth, capabilities, system-admin)
- [x] New `isSystemAdmin` tests cover admin/user/stationManager/null/undefined
- [x] Auth-client entry points build successfully via tsup
- [ ] Verify no downstream consumers reference `Authorization.ADMIN` or `canPromoteToAdmin`