### PR TITLE
fix: run generate:typescript before build in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "prepare": "npm run build",
+    "prepare": "npm run generate:typescript && npm run build",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

- Add `npm run generate:typescript` before `npm run build` in the `prepare` script so that the gitignored `src/generated/` directory is populated before tsup tries to bundle it

Closes #10

## Test plan

- [x] Verified `npm run prepare` succeeds locally (generates types, then builds)
- [ ] Confirm the [archive PR #11](https://github.com/WXYC/archive/pull/11) build passes after this fix is published