### PR TITLE
feat: bump version to 0.3.0 for V2 flowsheet type exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "better-auth": "^1.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump package version from 0.2.0 to 0.3.0 to signal V2 flowsheet type exports to consumers
- V2 schemas are already defined in `api.yaml` and generated at install time via `prepare`; no code changes needed beyond the version bump

## Test plan

- [x] All 319 unit tests pass (including 86 V2-specific tests in `tests/v2-flowsheet.test.ts`)
- [x] `tsc --noEmit` passes
- [ ] Verify `npm pack` includes expected types after install

Closes #17