### PR TITLE
Add curated WXYC example music data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -56,7 +56,8 @@
   },
   "files": [
     "dist",
-    "api.yaml"
+    "api.yaml",
+    "src/test-utils/wxyc-example-data.json"
   ],
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.15.3",

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -9,3 +9,4 @@ export * from './factories.js';
 export * from './assertions.js';
 export * from './constants.js';
 export * from './time.js';
+export * from './wxyc-example-data.js';

--- a/src/test-utils/wxyc-example-data.json
+++ b/src/test-utils/wxyc-example-data.json
@@ -1,0 +1,52 @@
+{
+  "meta": {
+    "source": "tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql",
+    "description": "Curated WXYC example data for tests and documentation across all repos. WXYC is a freeform college radio station -- use these instead of mainstream artists like Queen or Radiohead."
+  },
+  "genres": {
+    "Africa": 1,
+    "Asia": 2,
+    "Blues": 3,
+    "Classical": 4,
+    "Hiphop": 6,
+    "Jazz": 7,
+    "Latin": 8,
+    "OCS": 9,
+    "Reggae": 10,
+    "Rock": 11,
+    "Soundtracks": 12,
+    "Electronic": 15
+  },
+  "formats": {
+    "CD": 1,
+    "Vinyl 7\"": 30,
+    "Vinyl 10\"": 40,
+    "Vinyl 12\"": 51,
+    "Vinyl LP": 60
+  },
+  "artists": [
+    { "id": 8001, "artist_name": "Juana Molina", "code_letters": "RO", "code_artist_number": 42, "genre_id": 11 },
+    { "id": 8002, "artist_name": "Stereolab", "code_letters": "RO", "code_artist_number": 87, "genre_id": 11 },
+    { "id": 8003, "artist_name": "Cat Power", "code_letters": "RO", "code_artist_number": 23, "genre_id": 11 },
+    { "id": 8004, "artist_name": "Jessica Pratt", "code_letters": "RO", "code_artist_number": 112, "genre_id": 11 },
+    { "id": 8005, "artist_name": "Chuquimamani-Condori", "code_letters": "EL", "code_artist_number": 15, "genre_id": 15 },
+    { "id": 8006, "artist_name": "Duke Ellington & John Coltrane", "code_letters": "JA", "code_artist_number": 7, "genre_id": 7 }
+  ],
+  "albums": [
+    { "id": 9001, "artist_id": 8001, "album_title": "DOGA", "code_number": 1, "genre_id": 11, "format_id": 1, "label": "Sonamos", "add_date": "2023-11-01T00:00:00.000Z" },
+    { "id": 9002, "artist_id": 8002, "album_title": "Aluminum Tunes", "code_number": 5, "genre_id": 11, "format_id": 1, "label": "Duophonic", "add_date": "1998-09-01T00:00:00.000Z" },
+    { "id": 9003, "artist_id": 8003, "album_title": "Moon Pix", "code_number": 2, "genre_id": 11, "format_id": 1, "label": "Matador Records", "add_date": "1998-10-15T00:00:00.000Z" },
+    { "id": 9004, "artist_id": 8004, "album_title": "On Your Own Love Again", "code_number": 1, "genre_id": 11, "format_id": 60, "label": "Drag City", "add_date": "2015-01-27T00:00:00.000Z" },
+    { "id": 9005, "artist_id": 8005, "album_title": "Edits", "code_number": 1, "genre_id": 15, "format_id": 60, "label": "self-released", "add_date": "2024-06-01T00:00:00.000Z" }
+  ],
+  "flowsheetEntries": [
+    { "id": 10001, "show_id": 1, "play_order": 1, "artist_name": "Juana Molina", "album_title": "DOGA", "track_title": "la paradoja", "record_label": "Sonamos", "request_flag": false, "album_id": 9001 },
+    { "id": 10002, "show_id": 1, "play_order": 2, "artist_name": "Jessica Pratt", "album_title": "On Your Own Love Again", "track_title": "Back, Baby", "record_label": "Drag City", "request_flag": false, "album_id": 9004 },
+    { "id": 10003, "show_id": 1, "play_order": 3, "artist_name": "Chuquimamani-Condori", "album_title": "Edits", "track_title": "Call Your Name", "record_label": "self-released", "request_flag": false, "album_id": 9005 },
+    { "id": 10004, "show_id": 1, "play_order": 4, "artist_name": "Duke Ellington & John Coltrane", "album_title": "Duke Ellington & John Coltrane", "track_title": "In a Sentimental Mood", "record_label": "Impulse Records", "request_flag": true }
+  ],
+  "searchResults": [
+    { "id": 9001, "add_date": "2023-11-01T00:00:00.000Z", "album_title": "DOGA", "artist_name": "Juana Molina", "code_letters": "RO", "code_number": 1, "code_artist_number": 42, "format_name": "CD", "genre_name": "Rock", "label": "Sonamos" },
+    { "id": 9003, "add_date": "1998-10-15T00:00:00.000Z", "album_title": "Moon Pix", "artist_name": "Cat Power", "code_letters": "RO", "code_number": 2, "code_artist_number": 23, "format_name": "CD", "genre_name": "Rock", "label": "Matador Records" }
+  ]
+}

--- a/src/test-utils/wxyc-example-data.ts
+++ b/src/test-utils/wxyc-example-data.ts
@@ -1,0 +1,78 @@
+/**
+ * WXYC Example Music Data
+ *
+ * Representative test data from real WXYC flowsheets and rotation.
+ * Use this data when creating realistic test scenarios. These are NOT
+ * replacements for the generic test fixtures (testArtist, testAlbum, etc.)
+ * which remain stable for existing test assertions.
+ *
+ * Source: tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql
+ * Canonical JSON: src/test-utils/wxyc-example-data.json
+ */
+
+import type {
+  Artist,
+  Album,
+  AlbumSearchResult,
+  FlowsheetSongEntry,
+} from '../dtos/index.js';
+
+import data from './wxyc-example-data.json' with { type: 'json' };
+
+const artists = data.artists as Artist[];
+const albums = data.albums as Album[];
+const flowsheetEntries = data.flowsheetEntries as FlowsheetSongEntry[];
+const searchResults = data.searchResults as AlbumSearchResult[];
+
+// ============================================================================
+// Artists
+// ============================================================================
+
+export const wxycExampleArtists = {
+  juanaMolina: artists[0]!,
+  stereolab: artists[1]!,
+  catPower: artists[2]!,
+  jessicaPratt: artists[3]!,
+  chuquimamaniCondori: artists[4]!,
+  dukeEllingtonAndJohnColtrane: artists[5]!,
+} as const;
+
+// ============================================================================
+// Albums
+// ============================================================================
+
+export const wxycExampleAlbums = {
+  doga: albums[0]!,
+  aluminumTunes: albums[1]!,
+  moonPix: albums[2]!,
+  onYourOwnLoveAgain: albums[3]!,
+  edits: albums[4]!,
+} as const;
+
+// ============================================================================
+// Flowsheet Entries (FlowsheetSongEntry -- narrower type, all required fields)
+// ============================================================================
+
+export const wxycExampleFlowsheetEntries = {
+  juanaMolinaLaParadoja: flowsheetEntries[0]!,
+  jessicaPrattBackBaby: flowsheetEntries[1]!,
+  chuquimamaniCondoriCallYourName: flowsheetEntries[2]!,
+  dukeEllingtonSentimentalMood: flowsheetEntries[3]!,
+} as const;
+
+// ============================================================================
+// Album Search Results
+// ============================================================================
+
+export const wxycExampleSearchResults = {
+  doga: searchResults[0]!,
+  moonPix: searchResults[1]!,
+} as const;
+
+// ============================================================================
+// Convenience arrays for iteration / random selection
+// ============================================================================
+
+export const wxycExampleArtistList = Object.values(wxycExampleArtists);
+export const wxycExampleAlbumList = Object.values(wxycExampleAlbums);
+export const wxycExampleFlowsheetList = Object.values(wxycExampleFlowsheetEntries);

--- a/tests/wxyc-example-data.test.ts
+++ b/tests/wxyc-example-data.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  wxycExampleArtists,
+  wxycExampleAlbums,
+  wxycExampleFlowsheetEntries,
+  wxycExampleSearchResults,
+  wxycExampleArtistList,
+  wxycExampleAlbumList,
+  wxycExampleFlowsheetList,
+} from '../src/test-utils/wxyc-example-data.js';
+
+describe('WXYC Example Data', () => {
+  it('provides exactly 6 example artists', () => {
+    expect(wxycExampleArtistList).toHaveLength(6);
+  });
+
+  it('provides exactly 5 example albums', () => {
+    expect(wxycExampleAlbumList).toHaveLength(5);
+  });
+
+  it('provides exactly 4 example flowsheet entries', () => {
+    expect(wxycExampleFlowsheetList).toHaveLength(4);
+  });
+
+  it('artist IDs are in the 8000 range', () => {
+    for (const artist of wxycExampleArtistList) {
+      expect(artist.id).toBeGreaterThanOrEqual(8000);
+      expect(artist.id).toBeLessThan(9000);
+    }
+  });
+
+  it('album IDs are in the 9000 range', () => {
+    for (const album of wxycExampleAlbumList) {
+      expect(album.id).toBeGreaterThanOrEqual(9000);
+      expect(album.id).toBeLessThan(10000);
+    }
+  });
+
+  it('flowsheet entry IDs are in the 10000 range', () => {
+    for (const entry of wxycExampleFlowsheetList) {
+      expect(entry.id).toBeGreaterThanOrEqual(10000);
+      expect(entry.id).toBeLessThan(11000);
+    }
+  });
+
+  it('album artist_ids reference valid example artists', () => {
+    const artistIds = new Set(wxycExampleArtistList.map(a => a.id));
+    for (const album of wxycExampleAlbumList) {
+      expect(artistIds.has(album.artist_id)).toBe(true);
+    }
+  });
+
+  it('does not include mainstream artists', () => {
+    const mainstream = ['Queen', 'Radiohead', 'Beatles', 'Led Zeppelin', 'Nirvana'];
+    for (const artist of wxycExampleArtistList) {
+      for (const name of mainstream) {
+        expect(artist.artist_name).not.toContain(name);
+      }
+    }
+  });
+
+  it('named objects match convenience arrays', () => {
+    expect(Object.values(wxycExampleArtists)).toEqual(wxycExampleArtistList);
+    expect(Object.values(wxycExampleAlbums)).toEqual(wxycExampleAlbumList);
+    expect(Object.values(wxycExampleFlowsheetEntries)).toEqual(wxycExampleFlowsheetList);
+  });
+
+  it('search results reference valid artist names', () => {
+    const artistNames = new Set(wxycExampleArtistList.map(a => a.artist_name));
+    for (const result of Object.values(wxycExampleSearchResults)) {
+      expect(artistNames.has(result.artist_name)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add language-agnostic JSON file with curated WXYC example data from real flowsheet entries
- TypeScript wrapper re-exported through `@wxyc/shared/test-utils`
- JSON included in npm package for non-TypeScript consumers
- Bump version 0.3.0 -> 0.3.1

Closes #21

## Test plan

- [x] All 330 existing tests pass (no regressions)
- [x] 10 new tests verify data integrity, ID ranges, referential integrity, absence of mainstream artists
- [x] `npm run build` succeeds with declaration files
- [x] `npm pack --dry-run` confirms JSON in tarball