### PR TITLE
Add mirror E2E test and MIRROR_API_KEY local dev config

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -35,6 +35,13 @@ npm run test:e2e -- e2e/flowsheet.test.ts
 - Pagination and filtering
 - On-air status
 
+### Mirror E2E (`mirror.test.ts`)
+- Verifies the full mirror round-trip: entry added via Backend-Service appears on tubafrenzy's public JSON API
+- Tests POST mirroring (freeform track entry appears on tubafrenzy `/playlists/recentEntries`)
+- Tests PATCH mirroring (updated entry reflects on tubafrenzy)
+- Requires Backend-Service, Auth, and tubafrenzy all running
+- Additional env var: `E2E_TUBAFRENZY_URL` (default: `http://localhost:8080`)
+
 ### Catalog E2E (`catalog.test.ts`)
 - Album and artist search (requires `catalog:read` auth)
 - Format and genre listing
@@ -54,6 +61,7 @@ E2E tests use environment variables:
 ```env
 E2E_BASE_URL=http://localhost:8080       # Backend API
 E2E_AUTH_URL=http://localhost:8081/auth   # Better-auth service
+E2E_TUBAFRENZY_URL=http://localhost:8080  # Tubafrenzy (mirror target)
 E2E_TEST_DJ_EMAIL=test@wxyc.org          # Test DJ account email
 E2E_TEST_DJ_PASSWORD=testpassword        # Test DJ account password
 ```

--- a/e2e/mirror.test.ts
+++ b/e2e/mirror.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Mirror E2E Tests
+ *
+ * Verifies the full mirror round-trip: an entry added via Backend-Service
+ * (POST /flowsheet) appears on tubafrenzy's public JSON API
+ * (GET /playlists/recentEntries).
+ *
+ * Prerequisites:
+ * - Backend-Service running at E2E_BASE_URL
+ * - Auth service running at E2E_AUTH_URL
+ * - Tubafrenzy running at E2E_TUBAFRENZY_URL (default: http://localhost:8080)
+ * - Test DJ account (E2E_TEST_DJ_EMAIL / E2E_TEST_DJ_PASSWORD)
+ *
+ * Run with: npm run test:e2e -- e2e/mirror.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  createE2EClient,
+  createE2EAuthHelper,
+  type E2EClient,
+  type E2EAuthHelper,
+  waitForService,
+  getE2EConfig,
+  pollUntil,
+} from './setup.js';
+import type { FlowsheetEntryResponse } from '../src/dtos/flowsheet.dto.js';
+
+/** Shape of a playcut entry from tubafrenzy's /playlists/recentEntries */
+interface TubafrenzyEntry {
+  id: number;
+  entryType: string;
+  playcut?: {
+    artistName: string;
+    songTitle: string;
+    releaseTitle: string;
+    labelName: string;
+  };
+}
+
+const uniqueSuffix = Date.now().toString(36);
+
+describe('Mirror E2E', () => {
+  let client: E2EClient;
+  let authHelper: E2EAuthHelper;
+  const config = getE2EConfig();
+
+  const hasCredentials = Boolean(config.testDjEmail && config.testDjPassword);
+
+  let tubafrenzyReachable = false;
+
+  beforeAll(async () => {
+    await waitForService(`${config.baseUrl}/healthcheck`);
+
+    // Check tubafrenzy reachability with GET (it may not support HEAD)
+    try {
+      const resp = await fetch(
+        `${config.tubafrenzyUrl}/playlists/recentEntries?n=1`
+      );
+      tubafrenzyReachable = resp.ok;
+    } catch {
+      tubafrenzyReachable = false;
+    }
+
+    client = createE2EClient();
+    authHelper = createE2EAuthHelper();
+
+    if (hasCredentials) {
+      const { payload } = await authHelper.authenticateClient(
+        client,
+        config.testDjEmail!,
+        config.testDjPassword!
+      );
+
+      // Start or join a show so POST /flowsheet can add entries
+      const djId = payload.sub || payload.id;
+      await client.post('/flowsheet/join', { dj_id: djId });
+    }
+  });
+
+  afterAll(async () => {
+    // Best-effort: end the show to clean up
+    if (hasCredentials && tubafrenzyReachable) {
+      try {
+        await client.post('/flowsheet/end', {});
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  /**
+   * Fetch recent entries from tubafrenzy and find one matching
+   * the given artist and song title.
+   */
+  async function findOnTubafrenzy(
+    artistName: string,
+    songTitle: string
+  ): Promise<TubafrenzyEntry | null> {
+    const resp = await fetch(
+      `${config.tubafrenzyUrl}/playlists/recentEntries?n=30`
+    );
+    if (!resp.ok) return null;
+
+    const entries: TubafrenzyEntry[] = await resp.json();
+    return (
+      entries.find(
+        (e) =>
+          e.entryType === 'playcut' &&
+          e.playcut?.artistName === artistName &&
+          e.playcut?.songTitle === songTitle
+      ) ?? null
+    );
+  }
+
+  it.skipIf(!hasCredentials)(
+    'mirrors a freeform track entry to tubafrenzy',
+    async ({ skip }) => {
+      if (!tubafrenzyReachable) skip();
+
+      const testArtist = `E2E Mirror ${uniqueSuffix}`;
+      const testSong = `Test Track ${uniqueSuffix}`;
+      const testAlbum = `Test Album ${uniqueSuffix}`;
+      const testLabel = `Test Label ${uniqueSuffix}`;
+
+      // 1. POST a freeform entry via Backend-Service
+      const postResp = await client.post<FlowsheetEntryResponse>('/flowsheet', {
+        artist_name: testArtist,
+        album_title: testAlbum,
+        track_title: testSong,
+        record_label: testLabel,
+        request_flag: false,
+      });
+
+      expect(postResp.ok).toBe(true);
+      expect(postResp.body.artist_name).toBe(testArtist);
+
+      // 2. Poll tubafrenzy until the entry appears
+      const mirrored = await pollUntil(
+        () => findOnTubafrenzy(testArtist, testSong),
+        15000,
+        500
+      );
+
+      expect(mirrored.playcut!.artistName).toBe(testArtist);
+      expect(mirrored.playcut!.songTitle).toBe(testSong);
+      expect(mirrored.playcut!.releaseTitle).toBe(testAlbum);
+      expect(mirrored.playcut!.labelName).toBe(testLabel);
+    }
+  );
+
+  it.skipIf(!hasCredentials)(
+    'mirrors an updated entry to tubafrenzy',
+    async ({ skip }) => {
+      if (!tubafrenzyReachable) skip();
+
+      const testArtist = `E2E Update ${uniqueSuffix}`;
+      const testSong = `Original Song ${uniqueSuffix}`;
+      const updatedSong = `Updated Song ${uniqueSuffix}`;
+
+      // 1. Create the entry
+      const postResp = await client.post<FlowsheetEntryResponse>('/flowsheet', {
+        artist_name: testArtist,
+        album_title: 'Update Test Album',
+        track_title: testSong,
+        request_flag: false,
+      });
+
+      expect(postResp.ok).toBe(true);
+      const entryId = postResp.body.id;
+
+      // 2. Wait for it to appear on tubafrenzy
+      await pollUntil(
+        () => findOnTubafrenzy(testArtist, testSong),
+        15000,
+        500
+      );
+
+      // 3. PATCH the entry via Backend-Service
+      const patchResp = await client.patch<FlowsheetEntryResponse>(
+        '/flowsheet',
+        {
+          entry_id: entryId,
+          data: { track_title: updatedSong },
+        }
+      );
+
+      expect(patchResp.ok).toBe(true);
+
+      // 4. Poll tubafrenzy until the updated song title appears
+      const updated = await pollUntil(
+        () => findOnTubafrenzy(testArtist, updatedSong),
+        15000,
+        500
+      );
+
+      expect(updated.playcut!.artistName).toBe(testArtist);
+      expect(updated.playcut!.songTitle).toBe(updatedSong);
+    }
+  );
+});

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -8,6 +8,7 @@
 export interface E2EConfig {
   baseUrl: string;
   authUrl: string;
+  tubafrenzyUrl: string;
   testDjEmail?: string;
   testDjPassword?: string;
 }
@@ -19,6 +20,7 @@ export function getE2EConfig(): E2EConfig {
   return {
     baseUrl: process.env.E2E_BASE_URL || 'http://localhost:8080',
     authUrl: process.env.E2E_AUTH_URL || 'http://localhost:8081/auth',
+    tubafrenzyUrl: process.env.E2E_TUBAFRENZY_URL || 'http://localhost:8080',
     testDjEmail: process.env.E2E_TEST_DJ_EMAIL,
     testDjPassword: process.env.E2E_TEST_DJ_PASSWORD,
   };
@@ -290,4 +292,31 @@ function extractSetCookieHeaders(headers: Headers): string[] {
 export function createE2EAuthHelper(config?: Partial<E2EConfig>): E2EAuthHelper {
   const merged = { ...getE2EConfig(), ...config };
   return new E2EAuthHelper(merged.authUrl);
+}
+
+/**
+ * Poll a function until it returns a non-null value or times out.
+ *
+ * @param fn - Async function that returns `null` when the condition is not yet met
+ * @param timeoutMs - Maximum time to wait (default 15s)
+ * @param intervalMs - Delay between polls (default 500ms)
+ * @returns The first non-null value returned by `fn`
+ * @throws Error if the timeout is reached
+ */
+export async function pollUntil<T>(
+  fn: () => Promise<T | null>,
+  timeoutMs = 15000,
+  intervalMs = 500
+): Promise<T> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const result = await fn();
+    if (result !== null) {
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }

--- a/scripts/setup-dev-environment.sh
+++ b/scripts/setup-dev-environment.sh
@@ -55,6 +55,8 @@ TEST_HOST=http://localhost
 AUTH_BYPASS=true
 AUTH_USERNAME=test_dj1
 AUTH_PASSWORD=testpassword123
+TUBAFRENZY_URL=http://localhost:8080
+MIRROR_API_KEY=wxyc-local-dev-mirror-key
 EOF
 }
 


### PR DESCRIPTION
## Summary

- Add `e2e/mirror.test.ts` verifying the full mirror round-trip: freeform entry posted via Backend-Service appears on tubafrenzy's `/playlists/recentEntries` JSON API, and PATCH updates propagate
- Add `tubafrenzyUrl` to `E2EConfig` (`E2E_TUBAFRENZY_URL` env var, default `http://localhost:8080`)
- Add `pollUntil<T>()` generic polling helper to `e2e/setup.ts`
- Add `MIRROR_API_KEY` and `TUBAFRENZY_URL` to the generated `.env` in `setup-dev-environment.sh` so local dev mirroring works out of the box

## Cross-repo dependencies

- **tubafrenzy** [PR #305](https://github.com/WXYC/tubafrenzy/pull/305): Mirror endpoint that receives the mirrored entries
- **Backend-Service** [PR #237](https://github.com/WXYC/Backend-Service/pull/237): HTTP mirror middleware that POSTs/PATCHes to tubafrenzy

## Test plan

- [x] Both E2E tests pass with all three services running locally
- [ ] Tests skip gracefully when tubafrenzy is not running
- [ ] Tests skip gracefully when credentials are not set