### PR TITLE
Add entry_type to FlowsheetCreateMessage

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -315,6 +315,10 @@ components:
       properties:
         message:
           type: string
+        entry_type:
+          type: string
+          enum: [talkset, breakpoint, message]
+          description: Explicit entry type. If omitted, the backend infers from message content.
 
     FlowsheetUpdateRequest:
       type: object


### PR DESCRIPTION
## Summary
- Adds an optional `entry_type` enum (`talkset`, `breakpoint`, `message`) to `FlowsheetCreateMessage` in the OpenAPI spec, allowing callers to explicitly specify the entry type instead of relying on backend inference from message content.

## Test plan
- [x] TypeScript types regenerated and `tsc --noEmit` passes
- [ ] Downstream consumers (Backend-Service, dj-site) adopt the new field as needed