### PR TITLE
Fix album_name to album_title in CatalogSearchParams

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -978,7 +978,7 @@ components:
       properties:
         artist_name:
           type: string
-        album_name:
+        album_title:
           type: string
         n:
           type: integer

--- a/e2e/catalog.test.ts
+++ b/e2e/catalog.test.ts
@@ -55,8 +55,8 @@ describe('Catalog E2E', () => {
       expect(Array.isArray(response.body)).toBe(true);
     });
 
-    it.skipIf(!hasCredentials)('should search albums by album name', async () => {
-      const response = await client.get<AlbumSearchResult[]>('/library?album_name=test');
+    it.skipIf(!hasCredentials)('should search albums by album title', async () => {
+      const response = await client.get<AlbumSearchResult[]>('/library?album_title=test');
 
       expect(response.ok).toBe(true);
       expect(Array.isArray(response.body)).toBe(true);


### PR DESCRIPTION
## Summary

- Renames `album_name` to `album_title` in the `CatalogSearchParams` schema to match every other schema, endpoint definition, and the Backend-Service controller
- Updates the E2E catalog search test to use the corrected field name
- Regenerates TypeScript types

Closes #25

## Context

`CatalogSearchParams` was the only schema using `album_name` — all 15+ other schemas and both API endpoint definitions use `album_title`. This caused album-only catalog searches from dj-site to silently fail: the frontend sent `album_name` as a query parameter but the backend expected `album_title`.

Companion PR: WXYC/dj-site (fix/catalog-search-album-title)

## Test plan

- [ ] Verify generated TypeScript types use `album_title` in `CatalogSearchParams`
- [ ] Verify album-only catalog search works end-to-end after both PRs merge
- [ ] Regenerate Python/Swift/Kotlin types in downstream repos