### PR TITLE
Add segue boolean to flowsheet track entry schemas

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -171,6 +171,8 @@ components:
               $ref: '#/components/schemas/RotationBin'
             request_flag:
               type: boolean
+            segue:
+              type: boolean
             # Message/breakpoint fields
             message:
               type: string
@@ -230,6 +232,8 @@ components:
               type: integer
             request_flag:
               type: boolean
+            segue:
+              type: boolean
             album_id:
               type: integer
             rotation_id:
@@ -284,6 +288,8 @@ components:
           type: integer
         request_flag:
           type: boolean
+        segue:
+          type: boolean
         record_label:
           type: string
 
@@ -302,6 +308,8 @@ components:
         track_title:
           type: string
         request_flag:
+          type: boolean
+        segue:
           type: boolean
         record_label:
           type: string
@@ -334,6 +342,8 @@ components:
         label_id:
           type: integer
         request_flag:
+          type: boolean
+        segue:
           type: boolean
 
     FlowsheetQueryParams:
@@ -498,6 +508,8 @@ components:
               type: string
               nullable: true
             request_flag:
+              type: boolean
+            segue:
               type: boolean
             rotation_bin:
               $ref: '#/components/schemas/RotationBin'

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -118,6 +118,7 @@ export const testFlowsheetEntry: FlowsheetEntryResponse = {
   rotation_id: undefined,
   rotation_bin: undefined,
   request_flag: false,
+  segue: false,
 };
 
 export const testFlowsheetSongEntry: FlowsheetSongEntry = {
@@ -129,6 +130,7 @@ export const testFlowsheetSongEntry: FlowsheetSongEntry = {
   artist_name: 'Test Artist',
   record_label: 'Test Label',
   request_flag: false,
+  segue: false,
   album_id: 1,
 };
 
@@ -156,6 +158,7 @@ export const testV2TrackEntry: FlowsheetV2TrackEntry = {
   track_title: 'Test Track',
   record_label: 'Test Label',
   request_flag: false,
+  segue: false,
   rotation_bin: 'H',
 };
 

--- a/tests/extensions.test.ts
+++ b/tests/extensions.test.ts
@@ -29,6 +29,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         track_title: 'Test Song',
         artist_name: 'Test Artist',
         album_title: 'Test Album',
@@ -44,6 +45,7 @@ describe('Type Guards', () => {
         play_order: 101,
         show_id: 1,
         request_flag: false,
+        segue: false,
         message: 'Talkset - station ID',
       };
 
@@ -56,6 +58,7 @@ describe('Type Guards', () => {
         play_order: 102,
         show_id: 1,
         request_flag: false,
+        segue: false,
       };
 
       expect(isFlowsheetSongEntry(entry)).toBe(false);
@@ -83,6 +86,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         track_title: 'Test Song',
       };
 
@@ -157,6 +161,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         message: 'Station announcement',
       };
 
@@ -169,6 +174,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         track_title: 'Test Song',
       };
 
@@ -197,6 +203,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         message: 'Talkset - station ID',
       };
 
@@ -209,6 +216,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         message: 'General announcement',
       };
 
@@ -223,6 +231,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         message: 'Breakpoint - 3:00 PM',
       };
 
@@ -235,6 +244,7 @@ describe('Type Guards', () => {
         play_order: 100,
         show_id: 1,
         request_flag: false,
+        segue: false,
         message: 'Regular message',
       };
 
@@ -291,6 +301,7 @@ describe('Union Types', () => {
         album_title: 'Album',
         record_label: 'Label',
         request_flag: false,
+        segue: false,
       };
 
       expect(isFlowsheetSongEntry(entry)).toBe(true);

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -29,6 +29,7 @@ describe('Generated TypeScript Types', () => {
         play_order: 100,
         show_id: 42,
         request_flag: false,
+        segue: false,
         track_title: 'Test Song',
         album_title: 'Test Album',
         artist_name: 'Test Artist',
@@ -47,6 +48,7 @@ describe('Generated TypeScript Types', () => {
         play_order: 1,
         show_id: 1,
         request_flag: false,
+        segue: false,
         artwork_url: null,
         spotify_url: null,
         release_year: null,
@@ -62,6 +64,7 @@ describe('Generated TypeScript Types', () => {
         play_order: 50,
         show_id: 42,
         request_flag: false,
+        segue: false,
         message: 'Talkset - station ID',
       };
 

--- a/tests/v2-flowsheet.test.ts
+++ b/tests/v2-flowsheet.test.ts
@@ -52,6 +52,7 @@ const sampleTrack: FlowsheetV2TrackEntry = {
   track_title: 'Paranoid Android',
   record_label: 'Parlophone',
   request_flag: false,
+  segue: false,
   rotation_bin: 'H',
   album_id: 1001,
   rotation_id: 5001,
@@ -167,6 +168,15 @@ describe('V2 Generated Types', () => {
       };
 
       expect(entry.show_id).toBeNull();
+    });
+
+    it('should accept segue: true on a track entry', () => {
+      const entry: FlowsheetV2TrackEntry = {
+        ...sampleTrack,
+        segue: true,
+      };
+
+      expect(entry.segue).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add optional `segue` boolean to 6 flowsheet schemas in the OpenAPI spec (`FlowsheetEntryResponse`, `FlowsheetSongEntry`, `FlowsheetCreateSongFromCatalog`, `FlowsheetCreateSongFreeform`, `FlowsheetUpdateRequest`, `FlowsheetV2TrackEntry`)
- Regenerate TypeScript types
- Update test fixtures and tests

Closes #28

## Test plan

- [x] `npm test` passes (330 tests)
- [ ] `npm run check:breaking` confirms non-breaking change
- [ ] Publish patch version after merge