### PR TITLE
Accept TypeScript 6 in peer and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -67,12 +67,12 @@
     "openapi-diff": "^0.24.1",
     "openapi-typescript": "^7.13.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.6.2",
+    "typescript": "^5.6.2 || ^6.0.0",
     "vitest": "^2.0.0",
     "yaml": "^2.6.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0 || ^6.0.0"
   },
   "keywords": [
     "wxyc",


### PR DESCRIPTION
## Summary

- Widen `peerDependencies.typescript` from `^5.0.0` to `^5.0.0 || ^6.0.0`
- Widen `devDependencies.typescript` from `^5.6.2` to `^5.6.2 || ^6.0.0`
- Bump version to 0.3.2

## Context

TypeScript 6 was released and Dependabot PRs in downstream consumers (e.g., [WXYC/archive#39](https://github.com/WXYC/archive/pull/39)) fail `npm ci` because this package's peer dependency only accepted ^5.0.0. This widens the range so consumers can upgrade at their own pace.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (329 tests)
- [ ] After merge, re-run archive Dependabot PR #39 CI to confirm resolution