### PR TITLE
Add genres, styles, tracklist, and artist image to proxy response schemas

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2010,6 +2010,22 @@ components:
           type: string
           description: Backend API base URL
 
+    TrackListItem:
+      type: object
+      required:
+        - position
+        - title
+      properties:
+        position:
+          type: string
+          description: Track position (e.g. "1", "A1")
+        title:
+          type: string
+          description: Track title
+        duration:
+          type: string
+          description: Track duration (e.g. "5:23")
+
     AlbumMetadataResponse:
       type: object
       properties:
@@ -2025,6 +2041,30 @@ components:
         artworkUrl:
           type: string
           description: Album artwork image URL
+        genres:
+          type: array
+          items:
+            type: string
+          description: Discogs genre classifications
+        styles:
+          type: array
+          items:
+            type: string
+          description: Discogs style classifications (more specific than genres)
+        label:
+          type: string
+          description: Primary record label name
+        discogsArtistId:
+          type: integer
+          description: Discogs artist ID, for linking to artist metadata
+        fullReleaseDate:
+          type: string
+          description: Full release date when available (e.g. "2024-03-15")
+        tracklist:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackListItem'
+          description: Release tracklist
         spotifyUrl:
           type: string
           description: Spotify URL for the album or track
@@ -2049,10 +2089,13 @@ components:
           description: Discogs artist ID
         bio:
           type: string
-          description: Artist biography from Discogs (markup cleaned)
+          description: Artist biography from Discogs
         wikipediaUrl:
           type: string
           description: Wikipedia URL for the artist
+        imageUrl:
+          type: string
+          description: Artist image URL from Discogs
 
     ArtworkSearchResponse:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "better-auth": "^1.4.9",
@@ -20,12 +20,12 @@
         "openapi-diff": "^0.24.1",
         "openapi-typescript": "^7.13.0",
         "tsup": "^8.4.0",
-        "typescript": "^5.6.2",
+        "typescript": "^5.6.2 || ^6.0.0",
         "vitest": "^2.0.0",
         "yaml": "^2.6.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -214,6 +214,49 @@ describe('OpenAPI Specification', () => {
     it('should define DiscogsRelease', () => {
       expect(spec.components.schemas.DiscogsRelease).toBeDefined();
     });
+
+    it('should define TrackListItem schema', () => {
+      const schema = spec.components.schemas.TrackListItem as {
+        type: string;
+        required: string[];
+        properties: Record<string, { type: string }>;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+      expect(schema.required).toEqual(['position', 'title']);
+      expect(schema.properties.position.type).toBe('string');
+      expect(schema.properties.title.type).toBe('string');
+      expect(schema.properties.duration.type).toBe('string');
+    });
+  });
+
+  describe('Proxy Response Schemas', () => {
+    it('should define AlbumMetadataResponse with enriched fields', () => {
+      const schema = spec.components.schemas.AlbumMetadataResponse as {
+        properties: Record<string, { type: string; items?: { $ref?: string } }>;
+      };
+      expect(schema.properties.genres).toBeDefined();
+      expect(schema.properties.genres.type).toBe('array');
+      expect(schema.properties.styles).toBeDefined();
+      expect(schema.properties.styles.type).toBe('array');
+      expect(schema.properties.label).toBeDefined();
+      expect(schema.properties.label.type).toBe('string');
+      expect(schema.properties.discogsArtistId).toBeDefined();
+      expect(schema.properties.discogsArtistId.type).toBe('integer');
+      expect(schema.properties.fullReleaseDate).toBeDefined();
+      expect(schema.properties.fullReleaseDate.type).toBe('string');
+      expect(schema.properties.tracklist).toBeDefined();
+      expect(schema.properties.tracklist.type).toBe('array');
+      expect(schema.properties.tracklist.items?.$ref).toBe('#/components/schemas/TrackListItem');
+    });
+
+    it('should define ArtistMetadataResponse with imageUrl', () => {
+      const schema = spec.components.schemas.ArtistMetadataResponse as {
+        properties: Record<string, { type: string }>;
+      };
+      expect(schema.properties.imageUrl).toBeDefined();
+      expect(schema.properties.imageUrl.type).toBe('string');
+    });
   });
 
   describe('API Endpoints', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -13,6 +13,9 @@ import {
   type DJ,
   type ScheduleShift,
   type SongRequest,
+  type AlbumMetadataResponse,
+  type ArtistMetadataResponse,
+  type TrackListItem,
   RotationBin,
   DayOfWeek,
   Genre,
@@ -181,6 +184,93 @@ describe('Generated TypeScript Types', () => {
       };
 
       expect(request.status).toBe('pending');
+    });
+  });
+
+  describe('AlbumMetadataResponse', () => {
+    it('should accept enriched metadata fields', () => {
+      const response: AlbumMetadataResponse = {
+        discogsReleaseId: 12345,
+        releaseYear: 2024,
+        artworkUrl: 'https://example.com/art.jpg',
+        genres: ['Electronic', 'Experimental'],
+        styles: ['IDM', 'Ambient'],
+        label: 'Warp',
+        discogsArtistId: 67890,
+        fullReleaseDate: '2024-03-15',
+        tracklist: [
+          { position: '1', title: 'VI Scose Poise', duration: '5:23' },
+          { position: '2', title: 'Cfern' },
+        ],
+      };
+
+      expect(response.genres).toEqual(['Electronic', 'Experimental']);
+      expect(response.styles).toEqual(['IDM', 'Ambient']);
+      expect(response.label).toBe('Warp');
+      expect(response.discogsArtistId).toBe(67890);
+      expect(response.fullReleaseDate).toBe('2024-03-15');
+      expect(response.tracklist).toHaveLength(2);
+      expect(response.tracklist![0].duration).toBe('5:23');
+      expect(response.tracklist![1].duration).toBeUndefined();
+    });
+
+    it('should allow omitting all new optional fields', () => {
+      const response: AlbumMetadataResponse = {
+        discogsReleaseId: 12345,
+        artworkUrl: 'https://example.com/art.jpg',
+      };
+
+      expect(response.genres).toBeUndefined();
+      expect(response.styles).toBeUndefined();
+      expect(response.label).toBeUndefined();
+      expect(response.discogsArtistId).toBeUndefined();
+      expect(response.fullReleaseDate).toBeUndefined();
+      expect(response.tracklist).toBeUndefined();
+    });
+  });
+
+  describe('ArtistMetadataResponse', () => {
+    it('should accept imageUrl field', () => {
+      const response: ArtistMetadataResponse = {
+        discogsArtistId: 67890,
+        bio: 'Autechre are an English electronic music duo...',
+        wikipediaUrl: 'https://en.wikipedia.org/wiki/Autechre',
+        imageUrl: 'https://example.com/artist.jpg',
+      };
+
+      expect(response.imageUrl).toBe('https://example.com/artist.jpg');
+    });
+
+    it('should allow omitting imageUrl', () => {
+      const response: ArtistMetadataResponse = {
+        discogsArtistId: 67890,
+        bio: 'Autechre are an English electronic music duo...',
+      };
+
+      expect(response.imageUrl).toBeUndefined();
+    });
+  });
+
+  describe('TrackListItem', () => {
+    it('should require position and title', () => {
+      const track: TrackListItem = {
+        position: 'A1',
+        title: 'VI Scose Poise',
+      };
+
+      expect(track.position).toBe('A1');
+      expect(track.title).toBe('VI Scose Poise');
+      expect(track.duration).toBeUndefined();
+    });
+
+    it('should accept optional duration', () => {
+      const track: TrackListItem = {
+        position: '1',
+        title: 'VI Scose Poise',
+        duration: '5:23',
+      };
+
+      expect(track.duration).toBe('5:23');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `TrackListItem` schema with required `position`/`title` and optional `duration`
- Expand `AlbumMetadataResponse` with optional `genres`, `styles`, `label`, `discogsArtistId`, `fullReleaseDate`, and `tracklist` fields
- Expand `ArtistMetadataResponse` with optional `imageUrl` field
- All new fields are optional, preserving backward compatibility for existing consumers

## Test plan

- [x] Tests for new schema fields in `api-spec.test.ts` (TrackListItem structure, AlbumMetadataResponse enriched fields, ArtistMetadataResponse imageUrl)
- [x] Tests for generated TypeScript types in `generated-types.test.ts` (AlbumMetadataResponse, ArtistMetadataResponse, TrackListItem type-level and runtime tests)
- [x] `npm run lint` passes
- [x] `npm test` passes (338 tests)
- [x] Verified no breaking changes (all additions are optional fields or new schemas)

Closes #31