### PR TITLE
Add on_streaming flag to AlbumSearchResult and LibraryCatalogItem

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -908,6 +908,9 @@ components:
           type: integer
         plays:
           type: integer
+        on_streaming:
+          type: boolean
+          description: True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.
 
     AddAlbumRequest:
       type: object
@@ -1905,6 +1908,9 @@ components:
         library_url:
           type: string
           description: URL to view this release in the WXYC library
+        on_streaming:
+          type: boolean
+          description: True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.
 
     DiscogsMatchResult:
       type: object


### PR DESCRIPTION
## Summary

Add `on_streaming: boolean` (nullable) to both `AlbumSearchResult` and `LibraryCatalogItem` schemas in `api.yaml`.

When `true`, the release is available on at least one streaming service. When `false`, it's only available in the WXYC physical library — a "WXYC Exclusive." When `null`, streaming status is unknown.

Enables downstream UIs (dj-site, tubafrenzy) to display "WXYC Exclusive" badges for non-streaming albums, helping DJs discover unique assets in the physical collection.

## Consumers

- **Backend-Service** — populates `on_streaming` on `AlbumSearchResult` from PostgreSQL
- **library-metadata-lookup** — populates `on_streaming` on `LibraryCatalogItem` from `streaming_links` table
- **dj-site** — displays badge when `on_streaming === false`
- **tubafrenzy** — displays capsule badge when `onStreaming === false`