### PR TITLE
Add on_streaming to FlowsheetV2TrackEntry schema

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -543,6 +543,10 @@ components:
             artist_wikipedia_url:
               type: string
               nullable: true
+            on_streaming:
+              type: boolean
+              nullable: true
+              description: Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.
 
     FlowsheetV2ShowStartEntry:
       description: V2 show start event - when a show begins


### PR DESCRIPTION
## Summary

- Add `on_streaming` optional nullable boolean to `FlowsheetV2TrackEntry` in `api.yaml`
- Regenerated TypeScript types include the field

Closes #54

## Test plan

- [x] `npm run check:breaking` confirms no breaking changes
- [x] All 341 tests pass
- [x] Generated `openapi-types.d.ts` includes `on_streaming?: boolean | null` on the track entry type