### PR TITLE
Add artwork_url to AlbumSearchResult

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -941,6 +941,10 @@ components:
           type: string
           format: date-time
           description: When a previously missing release was found. Null if never lost.
+        artwork_url:
+          type: string
+          nullable: true
+          description: Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.
 
     AddAlbumRequest:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Add nullable `artwork_url` field to `AlbumSearchResult` schema in `api.yaml`
- Bump version 0.5.0 -> 0.5.1
- No breaking changes (verified via `npm run check:breaking`)

Closes #61

## Test plan

- [x] `npm run check:breaking` — no breaking changes
- [x] `npm run generate:typescript` — types regenerated
- [x] `npm run build` — build passes
- [x] All 341 tests pass