### PR TITLE
fix: setup script env file bugs and missing vars

### DIFF
--- a/scripts/setup-dev-environment.sh
+++ b/scripts/setup-dev-environment.sh
@@ -61,6 +61,7 @@ BETTER_AUTH_JWKS_URL=http://localhost:${auth_port}/auth/jwks
 BETTER_AUTH_ISSUER=http://localhost:${auth_port}
 BETTER_AUTH_AUDIENCE=http://localhost:${auth_port}
 BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:${frontend_port}
+FRONTEND_SOURCE=http://localhost:${frontend_port}
 TEST_HOST=http://localhost
 AUTH_BYPASS=true
 AUTH_USERNAME=test_dj1
@@ -98,7 +99,7 @@ find_available_port() {
             echo "$port"
             return 0
         fi
-        log_warn "Port $port is in use, trying $((port + 1))..."
+        log_warn "Port $port is in use, trying $((port + 1))..." >&2
         port=$((port + 1))
     done
     log_error "Could not find an available port starting from $1"
@@ -420,6 +421,7 @@ NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/flowsheet
 NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
 NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
 NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
+NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD=temppass123
 EOF
     log_success ".env.local written"
 


### PR DESCRIPTION
## Summary

- **Fix .env corruption**: `find_available_port()` wrote ANSI-colored `log_warn` output to stdout, which got captured by `$()` command substitution and injected into `.env` values (e.g., `PORT=[WARN] Port 8080 is in use...`). Fix: redirect `log_warn` to stderr.
- **Add `FRONTEND_SOURCE`** to Backend-Service `.env` template. Required for Express CORS middleware when `credentials: true` — without it, the wildcard `*` origin is rejected by browsers for credentialed requests.
- **Add `NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD`** to dj-site `.env.local` template. Required for the onboarding password change flow — without it, the form shows "Missing onboarding temp password configuration."

## Test plan

- [ ] Run `./scripts/setup-dev-environment.sh` with a process occupying port 8080 — verify `.env` values are clean (no ANSI escape codes)
- [ ] Verify `FRONTEND_SOURCE` appears in generated Backend-Service `.env`
- [ ] Verify `NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD` appears in generated dj-site `.env.local`
- [ ] Full setup: log in as `test_incomplete` / `temppass123`, complete onboarding, verify no CORS errors