### PR TITLE
fix: prevent orphan processes and port mismatch in setup script

### DIFF
--- a/scripts/setup-dev-environment.sh
+++ b/scripts/setup-dev-environment.sh
@@ -107,6 +107,61 @@ find_available_port() {
     return 1
 }
 
+# Kill a process and all its children
+kill_tree() {
+    local pid=$1
+    if kill -0 "$pid" 2>/dev/null; then
+        # Kill children first, then parent
+        pkill -P "$pid" 2>/dev/null || true
+        kill "$pid" 2>/dev/null || true
+    fi
+}
+
+# Stop services left running from a previous invocation. Reads PIDs from the
+# state file written by save_state() and kills any that are still alive, then
+# waits briefly for ports to be released before port resolution runs.
+stop_previous_services() {
+    if [[ ! -f "$STATE_FILE" ]]; then
+        return
+    fi
+
+    log_info "Cleaning up services from a previous run..."
+    local prev_backend_pid="" prev_frontend_pid="" prev_backend_dir=""
+    # Source is safe here: we wrote this file ourselves
+    source "$STATE_FILE"
+
+    if [[ -n "$prev_backend_pid" ]] && kill -0 "$prev_backend_pid" 2>/dev/null; then
+        log_info "  Stopping previous backend (PID $prev_backend_pid)..."
+        kill_tree "$prev_backend_pid"
+    fi
+
+    if [[ -n "$prev_frontend_pid" ]] && kill -0 "$prev_frontend_pid" 2>/dev/null; then
+        log_info "  Stopping previous frontend (PID $prev_frontend_pid)..."
+        kill_tree "$prev_frontend_pid"
+    fi
+
+    # Stop the previous Docker database if the backend dir is known
+    if [[ -n "$prev_backend_dir" && -d "$prev_backend_dir" ]]; then
+        log_info "  Stopping previous database..."
+        (cd "$prev_backend_dir" && npm run db:stop 2>/dev/null) || true
+    fi
+
+    rm -f "$STATE_FILE"
+
+    # Brief pause so OS releases the ports
+    sleep 1
+    log_success "Previous services stopped"
+}
+
+# Persist PIDs so the next invocation can clean them up
+save_state() {
+    cat > "$STATE_FILE" << EOF
+prev_backend_pid=${BACKEND_PID:-}
+prev_frontend_pid=${FRONTEND_PID:-}
+prev_backend_dir=${BACKEND_DIR:-}
+EOF
+}
+
 # Default configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Default to parent of wxyc-shared (so repos are siblings)
@@ -119,10 +174,14 @@ SKIP_CLONE=false
 SKIP_DEPS=false
 BACKEND_ONLY=false
 FRONTEND_ONLY=false
+SERVICES_STARTED=false
 
 # Directory overrides (e.g., for worktrees)
 BACKEND_DIR=""
 FRONTEND_DIR=""
+
+# State file for tracking PIDs across runs
+STATE_FILE=""  # Set after WXYC_DEV_ROOT is resolved
 
 # Repository URLs
 BACKEND_REPO="git@github.com:WXYC/Backend-Service.git"
@@ -292,7 +351,7 @@ resolve_ports() {
 
     if [[ "$FRONTEND_ONLY" == true ]]; then
         # Backend is already running -- read its ports from existing .env
-        local backend_env="$WXYC_DEV_ROOT/Backend-Service/.env"
+        local backend_env="$BACKEND_DIR/.env"
         if [[ -f "$backend_env" ]]; then
             BACKEND_PORT=$(grep '^PORT=' "$backend_env" | cut -d= -f2)
             AUTH_PORT=$(grep '^AUTH_PORT=' "$backend_env" | cut -d= -f2)
@@ -448,6 +507,21 @@ NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD=temppass123
 EOF
     log_success ".env.local written"
 
+    # Remove stale Next.js lock file from a previous crash
+    local lock_file="$frontend_dir/.next/dev/lock"
+    if [[ -f "$lock_file" ]]; then
+        # Check whether the holder is still alive by reading the lock's PID
+        local holder_pid
+        holder_pid=$(lsof -t "$lock_file" 2>/dev/null || true)
+        if [[ -n "$holder_pid" ]]; then
+            log_error "Another Next.js dev server is running in $(basename "$frontend_dir") (PID $holder_pid)"
+            log_error "Stop it first, or use a different directory with --frontend-dir"
+            return 1
+        fi
+        log_warn "Removing stale Next.js lock file"
+        rm -f "$lock_file"
+    fi
+
     log_info "Starting frontend on port $FRONTEND_PORT..."
     cd "$frontend_dir"
     PORT=$FRONTEND_PORT npm run dev &
@@ -496,23 +570,35 @@ print_success_banner() {
 }
 
 cleanup() {
+    # Prevent recursive invocation from the EXIT trap
+    trap - EXIT INT TERM
+
+    local exit_code=$?
+    # Nothing to tear down if services were never started
+    if [[ "$SERVICES_STARTED" != true ]]; then
+        exit "$exit_code"
+    fi
+
     log_info "Shutting down services..."
 
-    # Kill background processes
-    if [[ -n "${BACKEND_PID:-}" ]]; then
-        kill $BACKEND_PID 2>/dev/null || true
-    fi
+    # Kill background process trees (parent + children)
     if [[ -n "${FRONTEND_PID:-}" ]]; then
-        kill $FRONTEND_PID 2>/dev/null || true
+        kill_tree "$FRONTEND_PID"
+    fi
+    if [[ -n "${BACKEND_PID:-}" ]]; then
+        kill_tree "$BACKEND_PID"
     fi
 
     # Stop database
-    if [[ "$FRONTEND_ONLY" != true ]]; then
-        cd "$BACKEND_DIR" 2>/dev/null && npm run db:stop 2>/dev/null || true
+    if [[ "$FRONTEND_ONLY" != true && -n "${BACKEND_DIR:-}" ]]; then
+        (cd "$BACKEND_DIR" 2>/dev/null && npm run db:stop 2>/dev/null) || true
     fi
 
+    # Remove state file since we've cleaned up
+    rm -f "${STATE_FILE:-}"
+
     log_info "Cleanup complete"
-    exit 0
+    exit "$exit_code"
 }
 
 main() {
@@ -525,12 +611,18 @@ main() {
     # Check dependencies
     check_dependencies
 
-    # Resolve available ports before any env file generation
-    resolve_ports
-
-    # Resolve effective directories (--backend-dir/--frontend-dir override defaults)
+    # Resolve effective directories first (needed by resolve_ports and
+    # stop_previous_services)
     BACKEND_DIR="${BACKEND_DIR:-$WXYC_DEV_ROOT/Backend-Service}"
     FRONTEND_DIR="${FRONTEND_DIR:-$WXYC_DEV_ROOT/dj-site}"
+    STATE_FILE="$WXYC_DEV_ROOT/.wxyc-dev-pids"
+
+    # Kill orphan processes from a previous run so their ports are freed
+    # before we resolve new ports
+    stop_previous_services
+
+    # Resolve available ports before any env file generation
+    resolve_ports
 
     # Set up repositories
     if [[ "$FRONTEND_ONLY" != true ]]; then
@@ -543,8 +635,10 @@ main() {
         install_dependencies "$FRONTEND_DIR"
     fi
 
-    # Set up trap for cleanup
-    trap cleanup SIGINT SIGTERM
+    # Set up trap for cleanup — EXIT fires on errors, signals, and normal
+    # exit, preventing orphan processes
+    trap cleanup EXIT INT TERM
+    SERVICES_STARTED=true
 
     # Start services
     if [[ "$FRONTEND_ONLY" != true ]]; then
@@ -561,6 +655,9 @@ main() {
         fi
         start_frontend
     fi
+
+    # Save PIDs so the next run can clean up if we get killed ungracefully
+    save_state
 
     print_success_banner
 

--- a/scripts/teardown-dev-environment.sh
+++ b/scripts/teardown-dev-environment.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# WXYC Development Environment Teardown
+#
+# Kills all WXYC-related node processes and Docker containers left behind by
+# setup-dev-environment.sh. Safe to run at any time — only targets processes in
+# known WXYC directories and Docker containers from the dev_env compose file.
+#
+# Usage: ./teardown-dev-environment.sh [OPTIONS]
+#
+# Options:
+#   --dry-run   Show what would be killed without actually killing anything
+#   --help      Show this help message
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+DRY_RUN=false
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WXYC_DEV_ROOT="${WXYC_DEV_ROOT:-$(dirname "$(dirname "$SCRIPT_DIR")")}"
+STATE_FILE="$WXYC_DEV_ROOT/.wxyc-dev-pids"
+
+show_help() {
+    cat << 'EOF'
+WXYC Development Environment Teardown
+
+Kills all WXYC-related node processes and Docker containers from the dev
+environment. Targets only processes whose working directory is inside the
+WXYC dev root.
+
+Usage: teardown-dev-environment.sh [OPTIONS]
+
+Options:
+  --dry-run   Show what would be killed without doing it
+  --help      Show this help message
+
+Environment Variables:
+  WXYC_DEV_ROOT   WXYC repositories directory (default: auto-detected)
+
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run) DRY_RUN=true; shift ;;
+        --help|-h) show_help; exit 0 ;;
+        *) log_error "Unknown option: $1"; show_help; exit 1 ;;
+    esac
+done
+
+killed=0
+
+# 1. Kill processes saved in the state file from setup-dev-environment.sh
+if [[ -f "$STATE_FILE" ]]; then
+    log_info "Reading state file: $STATE_FILE"
+    source "$STATE_FILE"
+    for var in prev_backend_pid prev_frontend_pid; do
+        pid="${!var:-}"
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            if [[ "$DRY_RUN" == true ]]; then
+                log_warn "Would kill $var (PID $pid)"
+            else
+                log_info "Killing $var (PID $pid)..."
+                pkill -P "$pid" 2>/dev/null || true
+                kill "$pid" 2>/dev/null || true
+                killed=$((killed + 1))
+            fi
+        fi
+    done
+    if [[ "$DRY_RUN" != true ]]; then
+        rm -f "$STATE_FILE"
+    fi
+fi
+
+# 2. Find and kill node processes whose cwd is inside WXYC_DEV_ROOT
+log_info "Scanning for node processes in $WXYC_DEV_ROOT..."
+while IFS= read -r line; do
+    pid=$(echo "$line" | awk '{print $2}')
+    # Resolve the process's working directory
+    cwd=$(lsof -p "$pid" -Fn 2>/dev/null | grep '^n/' | grep '^n'"$WXYC_DEV_ROOT" | head -1 || true)
+    if [[ -z "$cwd" ]]; then
+        # Fallback: check the command line for WXYC paths
+        cmdline=$(ps -p "$pid" -o command= 2>/dev/null || true)
+        if [[ "$cmdline" != *"$WXYC_DEV_ROOT"* ]]; then
+            continue
+        fi
+    fi
+    cmd=$(ps -p "$pid" -o command= 2>/dev/null | head -c 80 || true)
+    if [[ "$DRY_RUN" == true ]]; then
+        log_warn "Would kill PID $pid: $cmd"
+    else
+        log_info "Killing PID $pid: $cmd"
+        kill "$pid" 2>/dev/null || true
+        killed=$((killed + 1))
+    fi
+done < <(lsof -iTCP -sTCP:LISTEN -P -n 2>/dev/null | grep '^node' | awk '!seen[$2]++ {print}' || true)
+
+# 3. Stop Docker containers from the dev_env compose file
+for backend_dir in "$WXYC_DEV_ROOT"/Backend-Service "$WXYC_DEV_ROOT"/Backend-Service/.claude/worktrees/*/; do
+    local_compose="$backend_dir/dev_env/docker-compose.yml"
+    if [[ -f "$local_compose" ]]; then
+        # Check if any containers from this compose project are running
+        if docker compose -f "$local_compose" ps -q 2>/dev/null | grep -q .; then
+            if [[ "$DRY_RUN" == true ]]; then
+                log_warn "Would stop Docker containers from: $local_compose"
+            else
+                log_info "Stopping Docker containers from: $(basename "$backend_dir")"
+                docker compose -f "$local_compose" --profile dev down -v --remove-orphans 2>/dev/null || true
+                killed=$((killed + 1))
+            fi
+        fi
+    fi
+done
+
+# 4. Clean up stale Next.js lock files
+for dj_dir in "$WXYC_DEV_ROOT"/dj-site "$WXYC_DEV_ROOT"/dj-site-*; do
+    lock_file="$dj_dir/.next/dev/lock"
+    if [[ -f "$lock_file" ]]; then
+        holder=$(lsof -t "$lock_file" 2>/dev/null || true)
+        if [[ -n "$holder" ]]; then
+            if [[ "$DRY_RUN" == true ]]; then
+                log_warn "Would remove active Next.js lock at $lock_file (PID $holder)"
+            else
+                log_info "Next.js lock at $(basename "$dj_dir") held by PID $holder — killing"
+                kill "$holder" 2>/dev/null || true
+                rm -f "$lock_file"
+                killed=$((killed + 1))
+            fi
+        else
+            if [[ "$DRY_RUN" == true ]]; then
+                log_warn "Would remove stale lock file: $lock_file"
+            else
+                log_info "Removing stale lock file: $(basename "$dj_dir")/.next/dev/lock"
+                rm -f "$lock_file"
+            fi
+        fi
+    fi
+done
+
+echo ""
+if [[ "$DRY_RUN" == true ]]; then
+    log_info "Dry run complete. Re-run without --dry-run to execute."
+elif [[ $killed -eq 0 ]]; then
+    log_success "No WXYC services were running."
+else
+    log_success "Teardown complete ($killed processes/containers stopped)."
+fi


### PR DESCRIPTION
## Summary

- Trap EXIT (not just SIGINT/SIGTERM) so cleanup always fires, even on errors
- Save PIDs to `.wxyc-dev-pids` state file; kill leftover processes on re-run before resolving ports
- Resolve `BACKEND_DIR`/`FRONTEND_DIR` before `resolve_ports()` so `--backend-dir` and `--frontend-dir` are respected in all code paths
- Use `kill_tree()` with `pkill -P` to kill child processes spawned by `concurrently`
- Detect stale Next.js lock files and either clean them up or give a clear error
- Add `teardown-dev-environment.sh` for standalone cleanup (supports `--dry-run`)

Closes #64

## Test plan

- [ ] Run `setup-dev-environment.sh --skip-clone --skip-deps` — verify all ports are coordinated and services start on defaults
- [ ] Kill the script with Ctrl+C — verify all node processes and Docker containers are cleaned up
- [ ] Kill the script with `kill <pid>` (simulating a crash) — verify the next run cleans up orphans before resolving ports
- [ ] Run `teardown-dev-environment.sh --dry-run` — verify it lists all WXYC processes without killing them
- [ ] Run `teardown-dev-environment.sh` — verify all WXYC node processes, Docker containers, and stale lock files are cleaned up
- [ ] Run with `--backend-only`, then `--frontend-only` — verify frontend reads the correct ports from the backend's `.env`
- [ ] Start a second Next.js instance in a worktree, then run the setup script pointing to that directory — verify it detects the lock and gives a clear error