### PR TITLE
Add StreamingLinks schema and enrich DiscogsMatchResult

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1876,13 +1876,43 @@ components:
             $ref: '#/components/schemas/DiscogsImage'
 
     # ============================
+    # Shared Streaming Types
+    # ============================
+
+    StreamingLinks:
+      type: object
+      description: >
+        Streaming service URLs for a release. Used across multiple schemas
+        (DiscogsMatchResult, DiscogsEnrichedSearchResult, AlbumMetadata, etc.)
+        to canonicalize the set of streaming fields.
+      properties:
+        spotify_url:
+          type: string
+          nullable: true
+          description: Spotify album URL
+        apple_music_url:
+          type: string
+          nullable: true
+          description: Apple Music album URL
+        youtube_music_url:
+          type: string
+          nullable: true
+          description: YouTube Music search URL
+        bandcamp_url:
+          type: string
+          nullable: true
+          description: Bandcamp album URL
+        soundcloud_url:
+          type: string
+          nullable: true
+          description: SoundCloud search URL
+
+    # ============================
     # Lookup Service Types
     # ============================
 
     LookupRequest:
       type: object
-      required:
-        - raw_message
       properties:
         artist:
           type: string
@@ -1895,7 +1925,9 @@ components:
           description: Parsed album name
         raw_message:
           type: string
-          description: Original request message (needed for ambiguous format detection)
+          description: >
+            Original request message (used for ambiguous format detection).
+            Optional when structured fields (artist, album, song) are provided.
 
     LibraryCatalogItem:
       type: object
@@ -1951,8 +1983,10 @@ components:
     DiscogsMatchResult:
       type: object
       description: >
-        A processed Discogs search result with artwork. Distinct from the raw
-        DiscogsSearchResult which mirrors the Discogs API response directly.
+        A processed Discogs search result with artwork and enriched metadata.
+        Distinct from the raw DiscogsSearchResult which mirrors the Discogs
+        API response directly. Streaming URL fields match the StreamingLinks
+        schema and will be migrated to use $ref in a future version.
       required:
         - release_id
         - release_url
@@ -1978,6 +2012,38 @@ components:
           maximum: 1
           default: 0
           description: Match confidence score
+        release_year:
+          type: integer
+          nullable: true
+          description: Release year from Discogs
+        artist_bio:
+          type: string
+          nullable: true
+          description: Artist biography from Discogs profile
+        wikipedia_url:
+          type: string
+          nullable: true
+          description: Wikipedia URL for the artist
+        spotify_url:
+          type: string
+          nullable: true
+          description: Spotify album URL
+        apple_music_url:
+          type: string
+          nullable: true
+          description: Apple Music album URL
+        youtube_music_url:
+          type: string
+          nullable: true
+          description: YouTube Music search URL
+        bandcamp_url:
+          type: string
+          nullable: true
+          description: Bandcamp album URL
+        soundcloud_url:
+          type: string
+          nullable: true
+          description: SoundCloud search URL
 
     LookupResultItem:
       type: object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Add `StreamingLinks` shared schema canonicalizing the 5 streaming URL fields (`spotify_url`, `apple_music_url`, `youtube_music_url`, `bandcamp_url`, `soundcloud_url`) that are currently defined independently across multiple schemas
- Enrich `DiscogsMatchResult` with `StreamingLinks` (via `allOf`) plus `release_year`, `artist_bio`, and `wikipedia_url` — these fields are already returned at runtime by LML's `/lookup` endpoint via `EnrichedDiscogsMatchResult`, but were missing from the schema
- Make `LookupRequest.raw_message` optional — callers with structured fields (`artist`, `album`, `song`) don't need to construct a synthetic raw message
- Bump version to 0.6.0

Partially addresses WXYC/wxyc-shared#41 (StreamingLinks from Shared Types Consolidation project #16).

Closes WXYC/wxyc-shared#67

## Test plan

- [x] `npm run lint` (tsc --noEmit) passes
- [x] All 341 tests pass, including breaking-changes tests
- [x] `npm run generate:typescript` produces correct types: `DiscogsMatchResult` is `StreamingLinks & { ... }` with all enriched fields
- [x] `StreamingLinks` exported as reusable type from `@wxyc/shared/dtos`
- [x] `LookupRequest.raw_message` generated as optional (`raw_message?: string`)