### PR TITLE
Cover case/whitespace/dash variants in roleToAuthorization tests

### DIFF
--- a/tests/branded-auth.test.ts
+++ b/tests/branded-auth.test.ts
@@ -43,13 +43,29 @@ describe("roleToAuthorization", () => {
     ["station_manager", Authorization.SM, "snake_case variant"],
     ["musicDirector", Authorization.MD, "musicDirector role"],
     ["music_director", Authorization.MD, "snake_case variant"],
+    ["music-director", Authorization.MD, "kebab-case variant"],
     ["dj", Authorization.DJ, "dj role"],
     ["member", Authorization.NO, "member role"],
     ["user", Authorization.NO, "user fallback"],
     ["owner", Authorization.SM, "owner maps to SM"],
     [null, Authorization.NO, "null defaults to NO"],
     [undefined, Authorization.NO, "undefined defaults to NO"],
+    ["", Authorization.NO, "empty string defaults to NO"],
     ["unknown", Authorization.NO, "unknown defaults to NO"],
+    // Case insensitivity
+    ["STATIONMANAGER", Authorization.SM, "uppercase stationManager"],
+    ["MusicDirector", Authorization.MD, "PascalCase musicDirector"],
+    ["DJ", Authorization.DJ, "uppercase dj"],
+    ["Dj", Authorization.DJ, "TitleCase dj"],
+    ["Member", Authorization.NO, "TitleCase member"],
+    ["MEMBER", Authorization.NO, "uppercase member"],
+    ["User", Authorization.NO, "TitleCase user"],
+    ["Admin", Authorization.SM, "TitleCase admin"],
+    ["Owner", Authorization.SM, "TitleCase owner"],
+    // Whitespace handling
+    ["  stationManager  ", Authorization.SM, "leading/trailing whitespace stripped"],
+    ["  dj  ", Authorization.DJ, "whitespace around dj"],
+    ["   ", Authorization.NO, "whitespace-only string defaults to NO"],
   ];
 
   it.each(cases)("maps %s to %s (%s)", (role, expected) => {


### PR DESCRIPTION
## Summary

Adds 14 cases to the `roleToAuthorization` test in `tests/branded-auth.test.ts` to pin behavior that the implementation already handles but that wasn't regression-tested:

- **Case insensitivity** (`STATIONMANAGER`, `MusicDirector`, `DJ`, `Dj`, `Member`, `MEMBER`, `User`, `Admin`, `Owner`)
- **Whitespace trimming** (`"  stationManager  "`, `"  dj  "`, `"   "`)
- **Kebab-case music director** (`"music-director"`)
- **Empty string** (`""`)

## Why

These cases were exercised in dj-site by tests against the now-deleted local `mapRoleToAuthorization` (WXYC/dj-site#472). After that migration, the only home for role-mapping behavior is here — so the tests should live here too.

The implementation in `src/auth-client/authorization.ts` already handles every case correctly via `.toLowerCase().trim()` and the explicit `"music-director"` switch arm; this PR just makes that contract explicit in tests.

## Test plan

- [x] `npx vitest run tests/branded-auth.test.ts` — 52 tests pass (was 38; +14)
- [x] All 4 auth-related test files pass (117 total)