### PR TITLE
Remove deprecated Discogs search schemas from api.yaml

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1883,8 +1883,8 @@ components:
       type: object
       description: >
         Streaming service URLs for a release. Used across multiple schemas
-        (DiscogsMatchResult, DiscogsEnrichedSearchResult, AlbumMetadata, etc.)
-        to canonicalize the set of streaming fields.
+        (DiscogsMatchResult, AlbumMetadata, etc.) to canonicalize the set of
+        streaming fields.
       properties:
         spotify_url:
           type: string
@@ -2100,83 +2100,6 @@ components:
     # ====================================
     # LML Discogs & Metadata Service Types
     # ====================================
-
-    DiscogsSearchRequest:
-      type: object
-      properties:
-        artist:
-          type: string
-        album:
-          type: string
-        track:
-          type: string
-        label:
-          type: string
-        format:
-          type: string
-
-    DiscogsEnrichedSearchResult:
-      type: object
-      description: A single search result from LML's Discogs search, enriched with streaming URLs and metadata.
-      required:
-        - release_id
-        - release_url
-      properties:
-        album:
-          type: string
-          nullable: true
-        artist:
-          type: string
-          nullable: true
-        release_id:
-          type: integer
-        release_url:
-          type: string
-        artwork_url:
-          type: string
-          nullable: true
-        confidence:
-          type: number
-          default: 0
-        release_year:
-          type: integer
-          nullable: true
-        artist_bio:
-          type: string
-          nullable: true
-        wikipedia_url:
-          type: string
-          nullable: true
-        spotify_url:
-          type: string
-          nullable: true
-        apple_music_url:
-          type: string
-          nullable: true
-        youtube_music_url:
-          type: string
-          nullable: true
-        bandcamp_url:
-          type: string
-          nullable: true
-        soundcloud_url:
-          type: string
-          nullable: true
-
-    DiscogsSearchResponse:
-      type: object
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/DiscogsEnrichedSearchResult'
-          default: []
-        total:
-          type: integer
-          default: 0
-        cached:
-          type: boolean
-          default: false
 
     DiscogsTrackItem:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.5.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Drop `DiscogsSearchRequest`, `DiscogsEnrichedSearchResult`, and `DiscogsSearchResponse` from `api.yaml`. They existed solely to describe LML's `/api/v1/discogs/search` endpoint, which was removed in WXYC/library-metadata-lookup#144
- Update the `StreamingLinks` description to drop its lingering `DiscogsEnrichedSearchResult` reference
- Bump `@wxyc/shared` to 0.7.0 — this removes public types from the generated TypeScript output

LML's adoption of the shared Discogs schemas (#111) and request-o-matic's switch to the codegenerated `/lookup` contract (#80) were the listed blockers; both are merged.

`npm run check:breaking` reports no breaking changes (no consumer paths reference the removed schemas), and tests/lint/build are green locally.

Closes #69. Part of [Shared Types Consolidation](https://github.com/orgs/WXYC/projects/16).

## Test plan

- [x] `npm run check:breaking` — no breaking changes
- [x] `npm run generate:typescript` — no references to the removed schemas remain in `src/generated/`
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 360 passed