### PR TITLE
Add ReconciledIdentity schema to api.yaml

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1907,6 +1907,41 @@ components:
           nullable: true
           description: SoundCloud search URL
 
+    ReconciledIdentity:
+      type: object
+      description: >
+        External identifiers for a real-world artist, suitable for joining
+        records across services. All fields are bare platform IDs; URL
+        construction is the consumer's responsibility (templates are stable
+        for Spotify, Apple Music, and Bandcamp; YouTube Music and SoundCloud
+        do not have stable per-ID URLs and are intentionally absent — those
+        belong on `StreamingLinks`, which serves the playback/result layer).
+      properties:
+        discogs_artist_id:
+          type: integer
+          nullable: true
+          description: Discogs artist ID
+        musicbrainz_artist_id:
+          type: string
+          nullable: true
+          description: MusicBrainz artist UUID
+        wikidata_qid:
+          type: string
+          nullable: true
+          description: Wikidata QID (e.g. "Q12345")
+        spotify_artist_id:
+          type: string
+          nullable: true
+          description: Spotify artist ID (the Spotify URI suffix)
+        apple_music_artist_id:
+          type: string
+          nullable: true
+          description: Apple Music artist ID
+        bandcamp_id:
+          type: string
+          nullable: true
+          description: Bandcamp slug (the subdomain in `<slug>.bandcamp.com`)
+
     # ============================
     # Lookup Service Types
     # ============================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -228,6 +228,29 @@ describe('OpenAPI Specification', () => {
       expect(schema.properties.title.type).toBe('string');
       expect(schema.properties.duration.type).toBe('string');
     });
+
+    it('should define ReconciledIdentity with bare external IDs', () => {
+      const schema = spec.components.schemas.ReconciledIdentity as {
+        type: string;
+        properties: Record<string, { type: string; nullable?: boolean }>;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+      // All six identifier fields are bare IDs, all nullable.
+      // URL construction is the consumer's job — see WXYC/wxyc-shared#42.
+      expect(schema.properties.discogs_artist_id.type).toBe('integer');
+      expect(schema.properties.discogs_artist_id.nullable).toBe(true);
+      expect(schema.properties.musicbrainz_artist_id.type).toBe('string');
+      expect(schema.properties.musicbrainz_artist_id.nullable).toBe(true);
+      expect(schema.properties.wikidata_qid.type).toBe('string');
+      expect(schema.properties.wikidata_qid.nullable).toBe(true);
+      expect(schema.properties.spotify_artist_id.type).toBe('string');
+      expect(schema.properties.spotify_artist_id.nullable).toBe(true);
+      expect(schema.properties.apple_music_artist_id.type).toBe('string');
+      expect(schema.properties.apple_music_artist_id.nullable).toBe(true);
+      expect(schema.properties.bandcamp_id.type).toBe('string');
+      expect(schema.properties.bandcamp_id.nullable).toBe(true);
+    });
   });
 
   describe('Proxy Response Schemas', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -16,6 +16,7 @@ import {
   type AlbumMetadataResponse,
   type ArtistMetadataResponse,
   type TrackListItem,
+  type ReconciledIdentity,
   RotationBin,
   DayOfWeek,
   Genre,
@@ -274,6 +275,43 @@ describe('Generated TypeScript Types', () => {
       };
 
       expect(track.duration).toBe('5:23');
+    });
+  });
+
+  describe('ReconciledIdentity', () => {
+    it('should accept all six external identifiers', () => {
+      const identity: ReconciledIdentity = {
+        discogs_artist_id: 7894,
+        musicbrainz_artist_id: 'd7b8a3a5-9080-487c-8c3c-2f6a3a3d44b2',
+        wikidata_qid: 'Q470892',
+        spotify_artist_id: '4uSftVc3FPWe6RJuMZNEe9',
+        apple_music_artist_id: '88495919',
+        bandcamp_id: 'stereolab',
+      };
+
+      expect(identity.discogs_artist_id).toBe(7894);
+      expect(identity.bandcamp_id).toBe('stereolab');
+    });
+
+    it('should allow all fields to be omitted (fully unresolved identity)', () => {
+      const identity: ReconciledIdentity = {};
+
+      expect(identity.discogs_artist_id).toBeUndefined();
+      expect(identity.spotify_artist_id).toBeUndefined();
+    });
+
+    it('should allow null for any identifier (resolved-but-absent)', () => {
+      const identity: ReconciledIdentity = {
+        discogs_artist_id: 7894,
+        musicbrainz_artist_id: null,
+        wikidata_qid: null,
+        spotify_artist_id: null,
+        apple_music_artist_id: null,
+        bandcamp_id: null,
+      };
+
+      expect(identity.discogs_artist_id).toBe(7894);
+      expect(identity.musicbrainz_artist_id).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `ReconciledIdentity` to `api.yaml` — a lightweight bundle of external IDs (Discogs, MusicBrainz, Wikidata, Spotify, Apple Music, Bandcamp) for an artist. Field shape mirrors what `library-metadata-lookup`'s `/identity/resolve` already returns and what `semantic-index`'s `ArtistDetail` already exposes — both repos store and serve bare platform IDs from their entity tables, so adopting this schema requires no representational change in either repo.

Bumps `@wxyc/shared` to 0.8.0 (additive, new public type).

Closes #42. Part of [Shared Types Consolidation](https://github.com/orgs/WXYC/projects/16). Unblocks #112, WXYC/Backend-Service#317, WXYC/semantic-index#132.

## Design rationale

The original draft in #42 mixed representations: bare IDs for Discogs/MusicBrainz/Wikidata, but `streaming_links: $ref StreamingLinks` (URLs) for the streaming half. That mismatched what consumers actually store:

| Repo | Storage | Wire format on identity endpoint |
|---|---|---|
| `library-metadata-lookup` (`/identity/resolve`) | `entity.identity` PG: bare IDs | Bare IDs |
| `semantic-index` (`ArtistDetail`) | SQLite: bare IDs | Bare IDs |
| `Backend-Service` (`flowsheet.spotify_url` ...) | URLs (denormalized at write) | URLs |

URL construction is intentionally kept off this schema. `StreamingLinks` (URLs, already in `api.yaml`) serves the playback/result layer where consumers want a one-shot click; `ReconciledIdentity` serves the identity/reconciliation layer where consumers want to join records. The three platforms with stable per-ID URL templates (Spotify, Apple Music, Bandcamp) are the consumer's responsibility to format at the edge — the same way Backend-Service already constructs Discogs URLs from IDs.

YouTube Music and SoundCloud have no stable per-ID URL (they currently appear in `StreamingLinks` only as search-URL constructions) and are intentionally absent from this schema.

## Test plan

- [x] `npm run check:breaking` — no breaking changes
- [x] `npm test` — 364 passed (added 4 new tests: 1 OpenAPI structural, 3 typed)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] TS regen produces `ReconciledIdentity` in `src/generated/`