### PR TITLE
Use canonical Juana Molina fixture in V2 flowsheet test

### DIFF
--- a/tests/v2-flowsheet.test.ts
+++ b/tests/v2-flowsheet.test.ts
@@ -44,13 +44,15 @@ const baseFields = {
   add_time: '2024-06-15T14:30:00.000Z',
 };
 
+// Values drawn from the canonical Juana Molina / "la paradoja" fixture
+// in @wxyc/shared/test-utils (wxycExampleFlowsheetEntries).
 const sampleTrack: FlowsheetV2TrackEntry = {
   ...baseFields,
   entry_type: 'track',
-  artist_name: 'Radiohead',
-  album_title: 'OK Computer',
-  track_title: 'Paranoid Android',
-  record_label: 'Parlophone',
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  track_title: 'la paradoja',
+  record_label: 'Sonamos',
   request_flag: false,
   segue: false,
   rotation_bin: 'H',
@@ -135,8 +137,8 @@ describe('V2 Generated Types', () => {
   describe('FlowsheetV2TrackEntry', () => {
     it('should accept a valid track entry', () => {
       expect(sampleTrack.entry_type).toBe('track');
-      expect(sampleTrack.artist_name).toBe('Radiohead');
-      expect(sampleTrack.track_title).toBe('Paranoid Android');
+      expect(sampleTrack.artist_name).toBe('Juana Molina');
+      expect(sampleTrack.track_title).toBe('la paradoja');
       expect(sampleTrack.rotation_bin).toBe(RotationBin.H);
       expect(sampleTrack.request_flag).toBe(false);
       expect(typeof sampleTrack.add_time).toBe('string');


### PR DESCRIPTION
Closes #77.

## Summary

`tests/v2-flowsheet.test.ts` previously defined `sampleTrack` using Radiohead / OK Computer / Paranoid Android / Parlophone — mainstream stand-ins that violate the WXYC-representative-artist convention. Switches to the canonical Juana Molina / DOGA / la paradoja / Sonamos values from `wxycExampleFlowsheetEntries.juanaMolinaLaParadoja`. The two assertions that pinned the old strings are updated.

The literal values are kept (rather than importing the canonical export) because the test is about V2 type structure — a comment pointing at the canonical source keeps the test self-contained.

## Test plan

- [x] `npm test` — 360 tests pass (87 in `v2-flowsheet.test.ts`)
- [x] `npm run lint` — clean
- [ ] CI passes