### PR TITLE
Attach reconciled_identity to LookupResultItem

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2082,7 +2082,7 @@ components:
 
     LookupResultItem:
       type: object
-      description: A single lookup result pairing a library item with optional artwork
+      description: A single lookup result pairing a library item with optional artwork and reconciled identity
       required:
         - library_item
       properties:
@@ -2090,6 +2090,8 @@ components:
           $ref: '#/components/schemas/LibraryCatalogItem'
         artwork:
           $ref: '#/components/schemas/DiscogsMatchResult'
+        reconciled_identity:
+          $ref: '#/components/schemas/ReconciledIdentity'
 
     LookupResponse:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -251,6 +251,21 @@ describe('OpenAPI Specification', () => {
       expect(schema.properties.bandcamp_id.type).toBe('string');
       expect(schema.properties.bandcamp_id.nullable).toBe(true);
     });
+
+    it('should attach optional reconciled_identity to LookupResultItem', () => {
+      const schema = spec.components.schemas.LookupResultItem as {
+        type: string;
+        required: string[];
+        properties: Record<string, { $ref?: string }>;
+      };
+      expect(schema).toBeDefined();
+      // reconciled_identity is optional (not in `required`) and refs the shared schema
+      expect(schema.required).toEqual(['library_item']);
+      expect(schema.properties.reconciled_identity).toBeDefined();
+      expect(schema.properties.reconciled_identity.$ref).toBe(
+        '#/components/schemas/ReconciledIdentity',
+      );
+    });
   });
 
   describe('Proxy Response Schemas', () => {


### PR DESCRIPTION
## Summary

Adds optional `reconciled_identity: ReconciledIdentity` to `LookupResultItem` so `library-metadata-lookup`'s `/lookup` endpoint can return external IDs (Discogs, MusicBrainz, Wikidata, Spotify, Apple Music, Bandcamp) for the artist of each match. The field is optional — when LML's entity store is unavailable or the artist is not yet reconciled, the field is simply omitted.

Bumps `@wxyc/shared` to 0.9.0. Additive; existing consumers ignoring the new field continue to work unchanged.

Unblocks WXYC/library-metadata-lookup#112. Part of [Shared Types Consolidation](https://github.com/orgs/WXYC/projects/16).

## Test plan

- [x] `npm run check:breaking` — no breaking changes
- [x] `npm test` — 365 passed (added 1 structural test)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] TS regen shows `reconciled_identity?: components["schemas"]["ReconciledIdentity"]` on `LookupResultItem`