### PR TITLE
Add diacritic-bearing structured fixtures and expand canonical pool to 108

### DIFF
--- a/src/test-utils/wxyc-example-data.json
+++ b/src/test-utils/wxyc-example-data.json
@@ -66,6 +66,27 @@
       "code_letters": "JA",
       "code_artist_number": 7,
       "genre_id": 7
+    },
+    {
+      "id": 8007,
+      "artist_name": "Nil\u00fcfer Yanya",
+      "code_letters": "RO",
+      "code_artist_number": 158,
+      "genre_id": 11
+    },
+    {
+      "id": 8008,
+      "artist_name": "Sonido Due\u00f1ez",
+      "code_letters": "LA",
+      "code_artist_number": 1,
+      "genre_id": 8
+    },
+    {
+      "id": 8009,
+      "artist_name": "A\u015f\u0131q Altay",
+      "code_letters": "AS",
+      "code_artist_number": 1,
+      "genre_id": 2
     }
   ],
   "albums": [
@@ -118,6 +139,36 @@
       "format_id": 60,
       "label": "self-released",
       "add_date": "2024-06-01T00:00:00.000Z"
+    },
+    {
+      "id": 9006,
+      "artist_id": 8007,
+      "album_title": "PAINLESS",
+      "code_number": 1,
+      "genre_id": 11,
+      "format_id": 60,
+      "label": "ATO Records",
+      "add_date": "2022-03-04T00:00:00.000Z"
+    },
+    {
+      "id": 9007,
+      "artist_id": 8008,
+      "album_title": "Rebajadas 2",
+      "code_number": 1,
+      "genre_id": 8,
+      "format_id": 60,
+      "label": "self-released",
+      "add_date": "2023-09-15T00:00:00.000Z"
+    },
+    {
+      "id": 9008,
+      "artist_id": 8009,
+      "album_title": "Music from the Caucasus \u2013 The Archive of ORED Recordings, 2013\u20132023",
+      "code_number": 1,
+      "genre_id": 2,
+      "format_id": 60,
+      "label": "TAL",
+      "add_date": "2023-11-20T00:00:00.000Z"
     }
   ],
   "flowsheetEntries": [
@@ -163,6 +214,39 @@
       "track_title": "In a Sentimental Mood",
       "record_label": "Impulse Records",
       "request_flag": true
+    },
+    {
+      "id": 10005,
+      "show_id": 1,
+      "play_order": 5,
+      "artist_name": "Nil\u00fcfer Yanya",
+      "album_title": "PAINLESS",
+      "track_title": "Midnight Sun",
+      "record_label": "ATO Records",
+      "request_flag": false,
+      "album_id": 9006
+    },
+    {
+      "id": 10006,
+      "show_id": 1,
+      "play_order": 6,
+      "artist_name": "Sonido Due\u00f1ez",
+      "album_title": "Rebajadas 2",
+      "track_title": "Mentiroso Boquisabroso",
+      "record_label": "self-released",
+      "request_flag": false,
+      "album_id": 9007
+    },
+    {
+      "id": 10007,
+      "show_id": 1,
+      "play_order": 7,
+      "artist_name": "A\u015f\u0131q Altay",
+      "album_title": "Music from the Caucasus \u2013 The Archive of ORED Recordings, 2013\u20132023",
+      "track_title": "H\u00fcseyni",
+      "record_label": "TAL",
+      "request_flag": false,
+      "album_id": 9008
     }
   ],
   "searchResults": [
@@ -201,6 +285,7 @@
     "Aphex Twin",
     "Arthur Russell",
     "Autechre",
+    "A\u015f\u0131q Altay",
     "Beach House",
     "Big Thief",
     "Billie Holiday",
@@ -286,6 +371,7 @@
     "Rosie Thomas",
     "Sango",
     "Sessa",
+    "Sonido Due\u00f1ez",
     "Stereolab",
     "Sufjan Stevens",
     "Sun Ra",

--- a/src/test-utils/wxyc-example-data.ts
+++ b/src/test-utils/wxyc-example-data.ts
@@ -35,6 +35,12 @@ export const wxycExampleArtists = {
   jessicaPratt: artists[3]!,
   chuquimamaniCondori: artists[4]!,
   dukeEllingtonAndJohnColtrane: artists[5]!,
+  // Diacritic-bearing fixtures. Names from FLOWSHEET_ENTRY_PROD; library
+  // codes synthesized (these are streaming-only artists with no LIBRARY_CODE
+  // row) following the simplified 2-letter-genre convention used above.
+  niluferYanya: artists[6]!, // ü
+  sonidoDuenez: artists[7]!, // ñ (combining tilde)
+  asiqAltay: artists[8]!, // multi-diacritic (Turkish ş + ı)
 } as const;
 
 // ============================================================================
@@ -47,6 +53,9 @@ export const wxycExampleAlbums = {
   moonPix: albums[2]!,
   onYourOwnLoveAgain: albums[3]!,
   edits: albums[4]!,
+  painless: albums[5]!,
+  rebajadas2: albums[6]!,
+  musicFromTheCaucasus: albums[7]!,
 } as const;
 
 // ============================================================================
@@ -58,6 +67,9 @@ export const wxycExampleFlowsheetEntries = {
   jessicaPrattBackBaby: flowsheetEntries[1]!,
   chuquimamaniCondoriCallYourName: flowsheetEntries[2]!,
   dukeEllingtonSentimentalMood: flowsheetEntries[3]!,
+  niluferYanyaMidnightSun: flowsheetEntries[4]!,
+  sonidoDuenezMentirosoBoquisabroso: flowsheetEntries[5]!,
+  asiqAltayHuseyni: flowsheetEntries[6]!,
 } as const;
 
 // ============================================================================

--- a/tests/wxyc-example-data.test.ts
+++ b/tests/wxyc-example-data.test.ts
@@ -11,16 +11,23 @@ import {
 } from '../src/test-utils/wxyc-example-data.js';
 
 describe('WXYC Example Data', () => {
-  it('provides exactly 6 example artists', () => {
-    expect(wxycExampleArtistList).toHaveLength(6);
+  it('provides exactly 9 example artists', () => {
+    expect(wxycExampleArtistList).toHaveLength(9);
   });
 
-  it('provides exactly 5 example albums', () => {
-    expect(wxycExampleAlbumList).toHaveLength(5);
+  it('provides exactly 8 example albums', () => {
+    expect(wxycExampleAlbumList).toHaveLength(8);
   });
 
-  it('provides exactly 4 example flowsheet entries', () => {
-    expect(wxycExampleFlowsheetList).toHaveLength(4);
+  it('provides exactly 7 example flowsheet entries', () => {
+    expect(wxycExampleFlowsheetList).toHaveLength(7);
+  });
+
+  it('includes diacritic-bearing structured fixtures (ü, ñ, multi-diacritic Turkish ş+ı)', () => {
+    const names = new Set(wxycExampleArtistList.map(a => a.artist_name));
+    expect(names.has('Nilüfer Yanya')).toBe(true);
+    expect(names.has('Sonido Dueñez')).toBe(true);
+    expect(names.has('Aşıq Altay')).toBe(true);
   });
 
   it('artist IDs are in the 8000 range', () => {
@@ -117,8 +124,11 @@ describe('wxycCanonicalArtistNames', () => {
     const diacriticNames = wxycCanonicalArtistNames.filter(name =>
       [...name].some(c => c.charCodeAt(0) > 127)
     );
-    expect(diacriticNames.length).toBeGreaterThanOrEqual(3);
+    expect(diacriticNames.length).toBeGreaterThanOrEqual(5);
     expect(diacriticNames).toContain('Nilüfer Yanya');
     expect(diacriticNames).toContain('Csillagrablók');
+    expect(diacriticNames).toContain('Hermanos Gutiérrez');
+    expect(diacriticNames).toContain('Sonido Dueñez'); // ñ (combining tilde)
+    expect(diacriticNames).toContain('Aşıq Altay'); // multi-diacritic (Turkish ş + ı)
   });
 });


### PR DESCRIPTION
Closes #80.

## Summary

The structured fixtures in `@wxyc/shared/test-utils` had zero diacritic-bearing entries, forcing downstream tests that needed real `Artist`/`FlowsheetSongEntry` objects to fall back to non-canonical literal strings. Adds three real WXYC artists (from `FLOWSHEET_ENTRY_PROD`) chosen for their distinct Unicode normalization paths:

- **Nilüfer Yanya** — `ü` (precomposed Latin)
- **Sonido Dueñez** — `ñ` (combining-tilde decomp; previously zero coverage)
- **Aşıq Altay** — multi-diacritic Turkish (`ş` + `ı` twice; previously zero coverage)

Each gets a full Artist/Album/FlowsheetSongEntry triple. Names, albums, tracks, and labels are real. Library codes (`code_letters`/`code_artist_number`) are synthesized — no diacritic-bearing WXYC-aesthetic artist has a `LIBRARY_CODE` row in the staging clone (streaming-only).

Also adds **Sonido Dueñez** and **Aşıq Altay** to `wxycCanonicalArtistNames`, bringing it to 108.

## Test plan

- [x] `npm test` — 367 tests pass (17 in `wxyc-example-data.test.ts`, +5 new)
- [x] `npm run lint` — clean
- [x] `npm run generate:typescript` — codegen up to date
- [ ] CI passes