### PR TITLE
Add GIDEÖN to canonical pool for capital-diacritic Unicode coverage

### DIFF
--- a/src/test-utils/wxyc-example-data.json
+++ b/src/test-utils/wxyc-example-data.json
@@ -320,6 +320,7 @@
     "Flying Lotus",
     "For Tracy Hyde",
     "Four Tet",
+    "GIDE\u00d6N",
     "Gil Scott-Heron",
     "Gregory Alan Isakov",
     "Group Doueh",

--- a/tests/wxyc-example-data.test.ts
+++ b/tests/wxyc-example-data.test.ts
@@ -124,11 +124,12 @@ describe('wxycCanonicalArtistNames', () => {
     const diacriticNames = wxycCanonicalArtistNames.filter(name =>
       [...name].some(c => c.charCodeAt(0) > 127)
     );
-    expect(diacriticNames.length).toBeGreaterThanOrEqual(5);
+    expect(diacriticNames.length).toBeGreaterThanOrEqual(6);
     expect(diacriticNames).toContain('Nilüfer Yanya');
     expect(diacriticNames).toContain('Csillagrablók');
     expect(diacriticNames).toContain('Hermanos Gutiérrez');
     expect(diacriticNames).toContain('Sonido Dueñez'); // ñ (combining tilde)
     expect(diacriticNames).toContain('Aşıq Altay'); // multi-diacritic (Turkish ş + ı)
+    expect(diacriticNames).toContain('GIDEÖN'); // capital diacritic mid-word (Ö)
   });
 });


### PR DESCRIPTION
Closes #83.

## Summary

Adds **GIDEÖN** (capital Ö mid-word; 82 all-time WXYC plays) to `wxycCanonicalArtistNames`. Closes the last Unicode gap in the canonical pool by covering the capital-diacritic-mid-word shape (the Ólafur Arnalds case). Pool: 108 → 109.

## Test plan

- [x] `npm test` — 367 tests pass
- [x] `npm run lint` — clean
- [ ] CI passes