### PR TITLE
Tighten cache_stats schema in api.yaml to a typed CacheStats object

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2100,6 +2100,13 @@ components:
         LML's `core/telemetry.py:get_cache_stats()` and forwarded onto Sentry
         trace data by both the LML transaction (LML#213) and the BS-side
         client span wrapping `lookupMetadata` (BS#646).
+      required:
+        - memory_hits
+        - pg_hits
+        - pg_misses
+        - api_calls
+        - pg_time_ms
+        - api_time_ms
       properties:
         memory_hits:
           type: integer

--- a/api.yaml
+++ b/api.yaml
@@ -2093,6 +2093,39 @@ components:
         reconciled_identity:
           $ref: '#/components/schemas/ReconciledIdentity'
 
+    CacheStats:
+      type: object
+      description: >
+        Cache hit/miss statistics for a single lookup operation. Populated by
+        LML's `core/telemetry.py:get_cache_stats()` and forwarded onto Sentry
+        trace data by both the LML transaction (LML#213) and the BS-side
+        client span wrapping `lookupMetadata` (BS#646).
+      properties:
+        memory_hits:
+          type: integer
+          minimum: 0
+          description: Hits in LML's per-process in-memory TTL cache
+        pg_hits:
+          type: integer
+          minimum: 0
+          description: Hits in the discogs-cache PostgreSQL cache
+        pg_misses:
+          type: integer
+          minimum: 0
+          description: Misses in the discogs-cache PostgreSQL cache (forced an API call or fallback)
+        api_calls:
+          type: integer
+          minimum: 0
+          description: Number of Discogs API calls made during the lookup
+        pg_time_ms:
+          type: number
+          minimum: 0
+          description: Total milliseconds spent in PostgreSQL cache lookups
+        api_time_ms:
+          type: number
+          minimum: 0
+          description: Total milliseconds spent in Discogs API calls
+
     LookupResponse:
       type: object
       description: Response from the lookup service containing library search results and metadata
@@ -2130,9 +2163,7 @@ components:
           type: string
           description: Fuzzy-corrected artist name if different from the original
         cache_stats:
-          type: object
-          additionalProperties: true
-          description: Cache hit/miss statistics from the lookup
+          $ref: '#/components/schemas/CacheStats'
 
     # ====================================
     # LML Discogs & Metadata Service Types


### PR DESCRIPTION
Closes #86.

## Summary

Replace the freeform `LookupResponse.cache_stats` schema (`additionalProperties: true`) with a `\$ref` to a new `CacheStats` component:

```yaml
CacheStats:
  type: object
  properties:
    memory_hits:  { type: integer, minimum: 0 }
    pg_hits:      { type: integer, minimum: 0 }
    pg_misses:    { type: integer, minimum: 0 }
    api_calls:    { type: integer, minimum: 0 }
    pg_time_ms:   { type: number,  minimum: 0 }
    api_time_ms:  { type: number,  minimum: 0 }
```

This matches the actual shape LML populates (`core/telemetry.py:get_cache_stats`).

## Effect on consumers

- **LML (Python)**: re-run `scripts/generate_api_models.sh` → `generated/api_models.py` gains typed `CacheStats` model. Producer in `core/telemetry.py:get_cache_stats` already returns the right shape; no behavior change.
- **Backend-Service (TypeScript)**: re-run `npm run generate:typescript`. The `cache_stats` field becomes `components["schemas"]["CacheStats"]` instead of `Record<string, unknown>`. The inline cast in `apps/backend/services/lml/lml.client.ts:lookupMetadata` (added in WXYC/Backend-Service#646 against the freeform schema) drops in a follow-up cleanup once BS bumps the @wxyc/shared dependency.
- **iOS / Android**: regenerated types only. No consumers today, so no callsite change.

## Test plan

- [x] `npm run generate:typescript` produces a typed `CacheStats` interface (verified locally).
- [x] `npm run check:breaking` reports no breaking changes (additive `CacheStats` schema; the field's wire-level optionality is unchanged).
- [x] Full unit suite green (367 tests).

## Sequencing notes

Wire payload is unchanged, so this can land in any order. The natural sequence is: ship + cut a release, BS bumps the dependency, BS drops the inline cast — all small. If we want the lockstep, hold this PR until BS#646 (#669) merges, then ship together; either works.

## Sibling work

- WXYC/library-metadata-lookup#213 / #229 — server-side cache_stats projection onto LML's Sentry transaction
- WXYC/Backend-Service#646 / #669 — client-side wrap of `lookupMetadata` in a Sentry span + cache_stats projection