### PR TITLE
Cross-service contracts: name them in @wxyc/shared and add E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,20 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # Cross-service contract suite (see INVARIANTS.md, src/contracts.ts).
+      # When $E2E_BASE_URL is unset, every test in the file is `skipIf`-ed
+      # or `skip`-ed so vitest never reaches `beforeAll` (no live stack
+      # needed). When CI provides $E2E_BASE_URL + DJ credentials, the
+      # ENFORCED contracts (BEARER_IS_JWT_NOT_SESSION, FLOWSHEET_DJ_NAME_NON_NULL)
+      # run against the stack. The two NOT-YET-ENFORCED contracts
+      # (PLAY_ORDER, ROTATION_DEDUP) stay `it.skip` at source until
+      # WXYC/Backend-Service#693 + #694 land.
+      - name: Contract suite (E2E)
+        if: vars.E2E_BASE_URL != ''
+        run: npm run test:e2e:contracts
+        env:
+          E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}
+          E2E_AUTH_URL: ${{ vars.E2E_AUTH_URL }}
+          E2E_TEST_DJ_EMAIL: ${{ secrets.E2E_TEST_DJ_EMAIL }}
+          E2E_TEST_DJ_PASSWORD: ${{ secrets.E2E_TEST_DJ_PASSWORD }}

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -1,0 +1,68 @@
+# Cross-service invariants
+
+This document names the load-bearing cross-service contracts in WXYC. Each entry has a typed identifier in `src/contracts.ts` (importable as `CONTRACTS.<ID>` from `@wxyc/shared`) and an E2E test in `tests/e2e-contracts.test.ts` that asserts the invariant against a running stack.
+
+If an entry here is wrong, two things break: someone wastes a half-day diagnosing a "should obviously work" symptom (see Backend-Service#693, the 2026-04-30 canary auth incident), and the contract drifts further from reality with every new feature. Keep this file aligned with reality. When you change a provider's behavior, update the contract; when you add a consumer, scan this file for assumptions you're inheriting.
+
+## Backend-Service -> dj-site / iOS / Android
+
+### `CONTRACTS.PLAY_ORDER_PER_SHOW_MONOTONIC`
+
+> `play_order` is strictly increasing within a single `show_id`.
+
+- **Provider:** `Backend-Service/apps/backend/services/flowsheet.service.ts:nextPlayOrder()` after [WXYC/Backend-Service#693](https://github.com/WXYC/Backend-Service/issues/693).
+- **Consumer:** `dj-site/lib/features/flowsheet/infinite-cache.ts:swapPlayOrdersForSwitch` and any client that does optimistic-update reconciliation against play_order.
+- **What breaks if violated:** dj-site's optimistic-update + cache reconciliation falls apart even though server mutations succeed. The on-air DJ sees the UI fail to reflect successful PATCH/DELETE calls; talkset/insert can hit the 5s nextPlayOrder() timeout. This is exactly the 2026-05-01 flowsheet incident (BS#693, BS#694, dj-site#478).
+- **Status (2026-05-01):** **NOT YET ENFORCED.** `nextPlayOrder()` does a global `MAX(play_order)` with no `WHERE show_id`. Tubafrenzy's webhook-set play_orders mix with dj-site's globally-maxed play_orders. Test is `it.skip`-ed until BS#693 lands.
+
+### `CONTRACTS.ROTATION_DEDUP_PER_ALBUM_BIN`
+
+> The rotation API returns at most one row per `(album_id, rotation_bin)`.
+
+- **Provider:** `Backend-Service/apps/backend/services/library.service.ts:getRotationFromDB` after [WXYC/Backend-Service#694](https://github.com/WXYC/Backend-Service/issues/694)'s read-side fix.
+- **Consumer:** `dj-site` rotation dropdown.
+- **What breaks if violated:** the rotation dropdown shows the same album multiple times in the same bin (Heavy/Medium/Light), making selection ambiguous and burying valid rows. The current INNER JOIN drops 147 NULL-album_id rows and surfaces about 35 albums as duplicates because of tubafrenzy upstream data (filed as #689).
+- **Status (2026-05-01):** **NOT YET ENFORCED.** Read-side dedup not yet shipped. Test is `it.skip`-ed until BS#694 lands.
+
+### `CONTRACTS.BEARER_IS_JWT_NOT_SESSION`
+
+> Backend routes accept a JWT bearer token (verified via JWKS), not a better-auth session token.
+
+- **Provider:** `Backend-Service/apps/backend/middleware/requirePermissions` -- verifies via JWKS endpoint exposed by the auth service.
+- **Consumer:** any HTTP client. The two-step exchange is: better-auth `/auth/sign-in/email` to get session cookies, then `/auth/token` with those cookies to mint a short-lived JWT, then `Authorization: Bearer <jwt>` against backend routes. See `wxyc-canary/signInDj` and `e2e/setup.ts:E2EAuthHelper` for reference implementations.
+- **What breaks if violated:** every authenticated backend request 401s. The canary deploy on 2026-04-30 ate hours because clients were sending the session token directly and the symptom was a generic 401.
+- **Status:** **ENFORCED.** Asserting it nails the contract so a regression in either direction (backend stops accepting JWT, or starts accepting session tokens) gets caught.
+
+### `CONTRACTS.FLOWSHEET_DJ_NAME_NON_NULL`
+
+> `flowsheet.dj_name` is non-NULL on every entry inserted after migration 0053.
+
+- **Provider:** `Backend-Service/apps/backend/db/migrations/0053_*.sql` (backfill) + the flowsheet insert paths in `flowsheet.service.ts`.
+- **Consumer:** dj-site flowsheet UI (renders DJ name on each row), tubafrenzy mirror (requires it on POST), archive search (groups by DJ).
+- **What breaks if violated:** the UI shows "undefined" or empty rows in show headers; the tubafrenzy webhook payload validation fails; archive search drops the entry from DJ-grouped views. Migration 0053 fixed the historical backfill -- the test guards against a regression on the insert side.
+- **Status:** **ENFORCED.** Asserted by adding an entry as the test DJ and reading it back via `/v2/flowsheet`.
+
+## Future invariants to add
+
+The starter set above is deliberately small (4 items). Candidates for follow-ups, ordered roughly by cost-of-violation:
+
+- **Sentry filters statusCode<500** -- ops contract; clients reading Sentry to diagnose 4xx-class symptoms get burned (see #691). Belongs in INVARIANTS but is asserted by Sentry config, not E2E.
+- **dj-site auths via same-origin proxy, not directly to api.wxyc.org** -- the canary debugging on 2026-04-30 surfaced this. Add a test that POSTs to `/api/...` from a same-origin context and verifies the cookie round-trip.
+- **Tubafrenzy webhook -> Backend-Service mirror is at-least-once delivery** -- the existing `e2e/mirror.test.ts` covers happy-path round-trip; an explicit invariant for "POST eventually appears on tubafrenzy" with idempotency should be lifted out.
+- **`/auth/token` returns a JWT with `role` set to a value in `WXYCRoles`** -- partially covered by `e2e/auth.test.ts`; lift it to a CONTRACT so it's grep-discoverable.
+- **`/healthcheck` is the canonical health path on Backend-Service (not `/health`)** -- already documented in MEMORY.md; this is the kind of cheap, easy-to-violate invariant that bit a deploy.
+- **LML calls use `Authorization: Bearer <LML_API_KEY>`** -- as of 2026-05-01 LML prod enforces auth; all 3 consumers (rom, BS, tubafrenzy) wire the bearer. Asserting via E2E requires LML reachable from CI.
+- **Rotation `add_date` is set to today (UTC) on POST when omitted** -- mentioned in API spec; not asserted.
+- **`flowsheet.show_id` is set on every row produced by `/flowsheet/join`** -- 2026-05-01 incident showed this can drift via tubafrenzy.
+- **Backend-Service mirrors PATCH and DELETE to tubafrenzy within 15s** -- existing `mirror.test.ts` covers POST and PATCH; DELETE missing.
+
+When adding a new contract:
+
+1. Add a key + statement + JSDoc block to `src/contracts.ts`. The JSDoc must include provider path, consumer path, and "what breaks if violated".
+2. Add a section to this file with the same five fields plus current enforcement status.
+3. Add an `it(\`upholds ${CONTRACTS.X}...\`, ...)` test in `tests/e2e-contracts.test.ts`. If the invariant is not yet enforced, use `it.skip` and explain in a comment what's blocking enforcement.
+4. Wire the test into CI via `npm run test:e2e:contracts`.
+
+## Toggling skipped contracts
+
+The `PLAY_ORDER_PER_SHOW_MONOTONIC` and `ROTATION_DEDUP_PER_ALBUM_BIN` tests are `it.skip`-ed in CI today because the provider-side fixes have not landed. When BS#693 ships, change `it.skip(...)` to `it(...)` for the play_order test. When BS#694 ships, do the same for rotation dedup. Both are guarded with a single TODO comment naming the BS issue, so a quick grep finds them.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "test:e2e:contracts": "vitest run --config vitest.e2e.config.ts tests/e2e-contracts.test.ts",
     "test:setup-script": "bats scripts/__tests__/setup-dev-environment.test.sh",
     "lint": "tsc --noEmit --declaration false --declarationMap false",
     "clean": "rm -rf dist",

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,0 +1,86 @@
+/**
+ * Cross-service contracts (a.k.a. invariants) shared across WXYC services.
+ *
+ * Each entry in {@link CONTRACTS} names a load-bearing assumption that one
+ * service makes about another. The accompanying string is a single-sentence
+ * statement of the invariant, suitable for use in test descriptions, code
+ * comments, and incident write-ups.
+ *
+ * The full prose — provider file, consumer file, what breaks if violated,
+ * related tickets — lives in `INVARIANTS.md` at the repo root. The E2E
+ * suite at `tests/e2e-contracts.test.ts` asserts each invariant against
+ * a running stack.
+ *
+ * Identifiers are stable: a contract's key is part of the public contract
+ * vocabulary across repos. Do not rename without coordinating consumers.
+ *
+ * @example
+ * ```ts
+ * it(`upholds ${CONTRACTS.PLAY_ORDER_PER_SHOW_MONOTONIC}`, async () => {
+ *   // ...
+ * });
+ * ```
+ */
+export const CONTRACTS = {
+  /**
+   * `play_order` is strictly increasing within a single `show_id`.
+   *
+   * Provider: `Backend-Service/apps/backend/services/flowsheet.service.ts:nextPlayOrder()`
+   * Consumer: `dj-site/lib/features/flowsheet/infinite-cache.ts:swapPlayOrdersForSwitch`
+   *
+   * Status as of 2026-05-01: NOT YET ENFORCED. `nextPlayOrder()` does a global
+   * `MAX(play_order)` with no `WHERE show_id` clause; tubafrenzy webhook-set
+   * play_orders mix with dj-site's globally-maxed play_orders. Tracked in
+   * Backend-Service#693 (build) and Backend-Service#694.
+   */
+  PLAY_ORDER_PER_SHOW_MONOTONIC:
+    'play_order is strictly increasing within a single show_id',
+
+  /**
+   * The rotation API returns at most one row per `(album_id, rotation_bin)`.
+   *
+   * Provider: `Backend-Service/apps/backend/services/library.service.ts:getRotationFromDB`
+   * Consumer: `dj-site` rotation dropdown
+   *
+   * Status as of 2026-05-01: NOT YET ENFORCED. The current INNER JOIN drops
+   * 147 NULL-album_id rows and surfaces ~35 albums as duplicates because of
+   * tubafrenzy upstream data. Read-side fix tracked in Backend-Service#694.
+   */
+  ROTATION_DEDUP_PER_ALBUM_BIN:
+    'rotation API returns at most one row per (album_id, rotation_bin)',
+
+  /**
+   * Backend routes accept a JWT bearer token (verified via JWKS), not a
+   * better-auth session token.
+   *
+   * Provider: `Backend-Service/apps/backend/middleware/requirePermissions` (JWKS verification)
+   * Consumer: any HTTP client; canary's `signInDj` does the two-step exchange
+   *           (sign-in -> /auth/token -> bearer)
+   *
+   * Status: ENFORCED. The 2026-04-30 canary deploy ate hours diagnosing this
+   * because the contract was implicit. This test pins it.
+   */
+  BEARER_IS_JWT_NOT_SESSION:
+    'backend routes accept JWT bearer (via JWKS), not session token',
+
+  /**
+   * `flowsheet.dj_name` is non-NULL on every entry inserted after migration
+   * 0053.
+   *
+   * Provider: `Backend-Service/apps/backend/db/migrations/0053_*.sql` +
+   *           `flowsheet.service.ts` insert paths
+   * Consumer: dj-site flowsheet UI, tubafrenzy mirror, archive search
+   *
+   * Status: ENFORCED. Migration 0053 backfilled historical NULLs and the
+   * insert paths now require `dj_name`. This test catches a regression
+   * where new inserts could re-introduce NULL.
+   */
+  FLOWSHEET_DJ_NAME_NON_NULL:
+    'flowsheet.dj_name is non-NULL on entries inserted after migration 0053',
+} as const;
+
+/** A reference to one of the named cross-service contracts. */
+export type ContractId = keyof typeof CONTRACTS;
+
+/** The invariant statement for a given contract id. */
+export type ContractStatement = (typeof CONTRACTS)[ContractId];

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@
 export * from './dtos/index.js';
 export * from './test-utils/index.js';
 export * from './validation/index.js';
+export * from './contracts.js';

--- a/tests/e2e-contracts.test.ts
+++ b/tests/e2e-contracts.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Cross-service contract E2E tests.
+ *
+ * One test per entry in `CONTRACTS` (see `src/contracts.ts`). Each test
+ * documents the named invariant in its description so a failure in CI
+ * names the contract that broke.
+ *
+ * Two of the four contracts (PLAY_ORDER_PER_SHOW_MONOTONIC,
+ * ROTATION_DEDUP_PER_ALBUM_BIN) are NOT yet enforced on the server side
+ * as of 2026-05-01. Those tests are `it.skip`-ed; the assertion bodies
+ * still describe target state. To enable them, replace `it.skip` with
+ * `it` once the BS-side fix lands (see comments inline).
+ *
+ * Prerequisites:
+ *   - Backend service at $E2E_BASE_URL (default http://localhost:8080)
+ *   - Auth service at $E2E_AUTH_URL (default http://localhost:8081/auth)
+ *   - Test DJ account: $E2E_TEST_DJ_EMAIL / $E2E_TEST_DJ_PASSWORD
+ *
+ * Run with:
+ *   npm run test:e2e:contracts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  createE2EClient,
+  createE2EAuthHelper,
+  type E2EClient,
+  type E2EAuthHelper,
+  waitForService,
+  getE2EConfig,
+} from '../e2e/setup.js';
+import { CONTRACTS } from '../src/contracts.js';
+import type {
+  FlowsheetEntryResponse,
+  FlowsheetCreateSongFreeform,
+} from '../src/generated/models/index.js';
+
+/**
+ * Set of role values recognized by the backend's `requirePermissions`
+ * middleware after `normalizeRole()` runs. A JWT carrying any of these
+ * is sufficient to authorize an authenticated request.
+ */
+const VALID_BACKEND_ROLES = new Set([
+  'member',
+  'dj',
+  'musicDirector',
+  'stationManager',
+  'admin',
+]);
+
+describe('Cross-service contracts (E2E)', () => {
+  let client: E2EClient;
+  let authHelper: E2EAuthHelper;
+  const config = getE2EConfig();
+
+  const hasCredentials = Boolean(config.testDjEmail && config.testDjPassword);
+  const uniqueSuffix = Date.now().toString(36);
+
+  beforeAll(async () => {
+    await waitForService(`${config.baseUrl}/healthcheck`);
+    client = createE2EClient();
+    authHelper = createE2EAuthHelper();
+
+    if (hasCredentials) {
+      const { payload } = await authHelper.authenticateClient(
+        client,
+        config.testDjEmail!,
+        config.testDjPassword!
+      );
+
+      // Join a show so we can post flowsheet entries.
+      const djId = payload.sub || payload.id;
+      await client.post('/flowsheet/join', { dj_id: djId });
+    }
+  });
+
+  afterAll(async () => {
+    if (hasCredentials) {
+      try {
+        await client.post('/flowsheet/end', {});
+      } catch {
+        // best effort
+      }
+    }
+  });
+
+  // ── PLAY_ORDER_PER_SHOW_MONOTONIC ────────────────────────────────────
+  //
+  // SKIPPED: Backend-Service#693 has not landed. `nextPlayOrder()` does a
+  // global MAX(play_order) with no WHERE show_id, so tubafrenzy webhook-set
+  // play_orders mix with dj-site's globally-maxed ones. Flip `it.skip` to
+  // `it` once #693 is merged and deployed.
+  it.skip(
+    `upholds CONTRACTS.PLAY_ORDER_PER_SHOW_MONOTONIC: ${CONTRACTS.PLAY_ORDER_PER_SHOW_MONOTONIC}`,
+    async ({ skip }) => {
+      if (!hasCredentials) skip();
+
+      // Add 5 freeform entries in a row.
+      const created: FlowsheetEntryResponse[] = [];
+      for (let i = 0; i < 5; i++) {
+        const body: FlowsheetCreateSongFreeform = {
+          artist_name: `Contract Artist ${uniqueSuffix}`,
+          album_title: `Contract Album ${uniqueSuffix}`,
+          track_title: `Contract Track ${i} ${uniqueSuffix}`,
+          request_flag: false,
+        };
+        const resp = await client.post<FlowsheetEntryResponse>('/flowsheet', body);
+        expect(resp.ok, `POST /flowsheet failed at index ${i}`).toBe(true);
+        created.push(resp.body);
+      }
+
+      // All 5 entries must share the same show_id (we just joined a show).
+      const showIds = new Set(created.map((e) => e.show_id));
+      expect(showIds.size, 'all 5 entries should be in the same show').toBe(1);
+
+      // play_order must be strictly increasing within that show.
+      // VIOLATION SYMPTOM: dj-site's swapPlayOrdersForSwitch reconciliation
+      // breaks (PR/incident: WXYC/Backend-Service#693, dj-site#478).
+      for (let i = 1; i < created.length; i++) {
+        expect(
+          created[i].play_order,
+          `entry ${i} play_order ${created[i].play_order} must be > entry ${i - 1} play_order ${created[i - 1].play_order}`
+        ).toBeGreaterThan(created[i - 1].play_order);
+      }
+    }
+  );
+
+  // ── ROTATION_DEDUP_PER_ALBUM_BIN ─────────────────────────────────────
+  //
+  // SKIPPED: Backend-Service#694's read-side dedup has not landed. The
+  // current INNER JOIN drops 147 NULL-album_id rows and surfaces ~35
+  // albums as duplicates because of tubafrenzy upstream data. Flip
+  // `it.skip` to `it` once #694 is merged and deployed.
+  it.skip(
+    `upholds CONTRACTS.ROTATION_DEDUP_PER_ALBUM_BIN: ${CONTRACTS.ROTATION_DEDUP_PER_ALBUM_BIN}`,
+    async ({ skip }) => {
+      if (!hasCredentials) skip();
+
+      const resp = await client.get<
+        Array<{ id?: number | null; play_freq?: string | null }>
+      >('/library/rotation');
+      expect(resp.ok).toBe(true);
+      expect(Array.isArray(resp.body)).toBe(true);
+
+      // Group by (album_id, rotation_bin). The legacy /library/rotation
+      // schema exposes album identity via `id` (the album id) and bin via
+      // `play_freq`. Each (album_id, bin) pair must appear at most once.
+      // VIOLATION SYMPTOM: dj-site rotation dropdown shows the same album
+      // multiple times in the same bin (WXYC/Backend-Service#694, #689).
+      const seen = new Map<string, number>();
+      for (const row of resp.body) {
+        if (row.id == null || row.play_freq == null) continue;
+        const key = `${row.id}|${row.play_freq}`;
+        seen.set(key, (seen.get(key) ?? 0) + 1);
+      }
+
+      const duplicates = [...seen.entries()].filter(([, count]) => count > 1);
+      expect(
+        duplicates,
+        `rotation API returned duplicate (album_id, rotation_bin) pairs: ${JSON.stringify(duplicates)}`
+      ).toEqual([]);
+    }
+  );
+
+  // ── BEARER_IS_JWT_NOT_SESSION ────────────────────────────────────────
+  //
+  // ENFORCED. The 2026-04-30 canary deploy ate hours diagnosing this
+  // because the contract was implicit; this test pins it.
+  it.skipIf(!hasCredentials)(
+    `upholds CONTRACTS.BEARER_IS_JWT_NOT_SESSION: ${CONTRACTS.BEARER_IS_JWT_NOT_SESSION}`,
+    async () => {
+      // Fresh sign-in to capture both the session cookies and the JWT.
+      const helper = createE2EAuthHelper();
+      const { cookies } = await helper.signIn(
+        config.testDjEmail!,
+        config.testDjPassword!
+      );
+      const jwt = await helper.getJWTToken();
+      expect(jwt, 'sign-in must mint a JWT via /auth/token').not.toBeNull();
+
+      // 1. JWT is shape-correct (header.payload.sig, RS256, has role + sub).
+      const parts = jwt!.token.split('.');
+      expect(parts.length, 'JWT must be a 3-segment compact serialization').toBe(3);
+      const header = JSON.parse(
+        Buffer.from(parts[0], 'base64url').toString('utf-8')
+      );
+      expect(header.alg, 'JWT must be RS256-signed (JWKS-verifiable)').toBe(
+        'RS256'
+      );
+      expect(jwt!.payload.role, 'JWT must carry a role claim').toBeTruthy();
+      expect(
+        VALID_BACKEND_ROLES.has(jwt!.payload.role as string),
+        `JWT role "${jwt!.payload.role}" must be one the backend recognizes`
+      ).toBe(true);
+
+      // 2. JWT bearer succeeds against a protected route.
+      const jwtClient = createE2EClient();
+      jwtClient.setAuthToken(jwt!.token);
+      const okResp = await jwtClient.get('/library?artist_name=test');
+      // 200 (results) or 404 (no match) are both fine; never 401.
+      expect(
+        okResp.status,
+        `JWT bearer must NOT be rejected by /library (got ${okResp.status})`
+      ).not.toBe(401);
+      expect(okResp.status).not.toBe(403);
+
+      // 3. Session cookie value (NOT a JWT) used as a bearer must be rejected.
+      // VIOLATION SYMPTOM: clients send the session token directly, get 401,
+      // burn hours diagnosing. This is exactly the canary deploy outage.
+      const sessionTokenLike = cookies
+        .map((c) => c.split('=')[1]?.split(';')[0])
+        .find((v) => Boolean(v));
+      if (sessionTokenLike) {
+        const sessClient = createE2EClient();
+        sessClient.setAuthToken(sessionTokenLike);
+        const sessResp = await sessClient.get('/library?artist_name=test');
+        expect(
+          sessResp.status,
+          'session token used as bearer must be rejected (not JWT)'
+        ).toBe(401);
+      }
+    }
+  );
+
+  // ── FLOWSHEET_DJ_NAME_NON_NULL ───────────────────────────────────────
+  //
+  // ENFORCED. Migration 0053 backfilled historical NULLs and the insert
+  // paths require dj_name. This test catches a regression where new
+  // inserts re-introduce NULL.
+  it.skipIf(!hasCredentials)(
+    `upholds CONTRACTS.FLOWSHEET_DJ_NAME_NON_NULL: ${CONTRACTS.FLOWSHEET_DJ_NAME_NON_NULL}`,
+    async () => {
+      // Add a freeform entry as the test DJ.
+      const body: FlowsheetCreateSongFreeform = {
+        artist_name: `DJName Contract ${uniqueSuffix}`,
+        album_title: 'Contract Album',
+        track_title: `DJName Track ${uniqueSuffix}`,
+        request_flag: false,
+      };
+      const post = await client.post<FlowsheetEntryResponse>('/flowsheet', body);
+      expect(post.ok, 'POST /flowsheet must succeed').toBe(true);
+      const entryId = post.body.id;
+      const showId = post.body.show_id;
+
+      // Fetch the show's entries via the v2 endpoint, which carries dj_name
+      // on show_start / dj_join markers (the show-block entries that scope
+      // every track row to a DJ).
+      // VIOLATION SYMPTOM: tubafrenzy mirror payload validation fails;
+      // dj-site renders an empty DJ name; archive search drops the row.
+      const v2 = await client.get<{
+        entries?: Array<{
+          entry_type: string;
+          dj_name?: string | null;
+          id?: number;
+          show_id?: number | null;
+        }>;
+      }>('/v2/flowsheet?limit=100');
+      expect(v2.ok).toBe(true);
+
+      const entries = v2.body.entries ?? [];
+      // At least one show-block entry for our show must carry a non-null,
+      // non-empty dj_name.
+      const showBlocks = entries.filter(
+        (e) =>
+          e.show_id === showId &&
+          (e.entry_type === 'show_start' ||
+            e.entry_type === 'dj_join' ||
+            e.entry_type === 'show_end' ||
+            e.entry_type === 'dj_leave')
+      );
+      expect(
+        showBlocks.length,
+        `expected at least one show-block entry for show_id=${showId}`
+      ).toBeGreaterThan(0);
+
+      for (const block of showBlocks) {
+        expect(
+          block.dj_name,
+          `entry ${block.id} (${block.entry_type}) has null/empty dj_name`
+        ).toBeTruthy();
+      }
+
+      // Sanity: the entry we just created should still be in the show.
+      expect(post.body.show_id).toBeTruthy();
+      expect(entryId).toBeGreaterThan(0);
+    }
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
-    exclude: ['e2e/**/*'],
+    // E2E tests live under e2e/ and are excluded from `npm test`.
+    // tests/e2e-contracts.test.ts is also an E2E suite (see vitest.e2e.config.ts).
+    exclude: ['e2e/**/*', 'tests/e2e-contracts.test.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     // e2e/**/*.test.ts includes all subdirectories (contract/, types/, etc.)
-    include: ['e2e/**/*.test.ts'],
+    // tests/e2e-contracts.test.ts is the cross-service invariants suite.
+    include: ['e2e/**/*.test.ts', 'tests/e2e-contracts.test.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
     // E2E tests run sequentially by default


### PR DESCRIPTION
## Summary

Names the four load-bearing cross-service invariants that incidents in late April / early May 2026 surfaced (BS#693, #694, #689, #685, the canary auth incident) and adds a small E2E suite that asserts each one against a running stack. The starter set is deliberately small (4) — the framework is the interesting part. `INVARIANTS.md` has a "Future invariants to add" section listing follow-ups (Sentry filter, dj-site same-origin proxy, mirror at-least-once, etc.).

Closes #90

## What changes

- `INVARIANTS.md` — prose for each contract: provider path, consumer path, exact invariant, what breaks if violated, related tickets, current enforcement status. Plus a "Future invariants to add" section and a section on toggling the currently-skipped tests.
- `src/contracts.ts` — typed `CONTRACTS` manifest with grep-discoverable string constants. Exported from `@wxyc/shared` (and `@wxyc/shared/dtos` indirectly via `./index.js`). JSDoc on each entry mirrors the INVARIANTS.md prose so the in-IDE hover is useful.
- `tests/e2e-contracts.test.ts` — one test per contract, named `\`upholds CONTRACTS.X: <statement>\`` so a failure in CI names the contract that broke. Excluded from `vitest.config.ts` so `npm test` stays unit-only; included in `vitest.e2e.config.ts`.
- `package.json` — `test:e2e:contracts` script that runs only this file.
- `.github/workflows/ci.yml` — gated step that runs the contract suite when `E2E_BASE_URL` is configured. Uses `vars.E2E_BASE_URL` / `vars.E2E_AUTH_URL` / `secrets.E2E_TEST_DJ_EMAIL` / `secrets.E2E_TEST_DJ_PASSWORD`. The step is skipped when those vars are not present, so the existing main CI pipeline stays unaffected.

## Which contracts pass / fail today

| Contract | Status | Notes |
|---|---|---|
| `BEARER_IS_JWT_NOT_SESSION` | passes | Asserted via JWKS-shape check, JWT bearer round-trip, and a session-token-as-bearer rejection. |
| `FLOWSHEET_DJ_NAME_NON_NULL` | passes | Asserted by adding a freeform entry and reading back the show-block markers via `/v2/flowsheet`. |
| `PLAY_ORDER_PER_SHOW_MONOTONIC` | `it.skip` | `nextPlayOrder()` does global `MAX(play_order)` with no `WHERE show_id`. Companion: WXYC/Backend-Service#693 (already merged at the title level — but the consumer-side reconciliation still needs verification end-to-end). Flip `it.skip` -> `it` when the fix is verified deployed. |
| `ROTATION_DEDUP_PER_ALBUM_BIN` | `it.skip` | Read-side dedup not yet shipped. Companion: WXYC/Backend-Service#694 (open). Flip `it.skip` -> `it` when #694 merges. |

The two skipped tests have full assertion bodies — they document target state and double as the toggle. A grep for `BS#693` and `BS#694` finds the toggle points.

## Test plan

- [x] `npm run lint` (typecheck) — clean.
- [x] `npm test` — 367/367 unit tests pass; new file is excluded from the unit pattern.
- [x] `npm run test:e2e:contracts` — 4 skipped without credentials (this is correct: 2 are `it.skip` unconditionally, 2 are `it.skipIf(!hasCredentials)`).
- [ ] CI run with `vars.E2E_BASE_URL` configured: 2 enforced contracts pass, 2 skipped contracts skip. Until the GitHub Variables/Secrets are wired up, the contract step is gated off and only the existing unit pipeline runs.

## Local stack note

Could not reach a `dev stack ready` state on the local machine for an end-to-end run: backend was up on `:8080` and the auth service on `:8082` (default expects `:8081`), but the documented test DJ creds (`staging@wxyc.org` / `stagingpassword123`) returned 401 against the local `dev` setup. The 2 enforced tests will exercise on a properly-configured CI stack or via the wxyc-shared dev environment script with a seeded DJ account. Wiring repo Variables / Secrets is the operator step that flips this from "step exists" to "step runs and asserts on every PR".

## Related

- WXYC/Backend-Service#693 — `play_order` per-show monotonic provider-side fix.
- WXYC/Backend-Service#694 — rotation read-side dedup (still open).
- WXYC/Backend-Service#689 — rotation INNER JOIN drops 147 NULL-album_id rows.
- WXYC/Backend-Service#691 — Sentry hides 4xx (referenced in INVARIANTS.md "Future invariants").
- WXYC/dj-site#478 — dj-site optimistic-update + cache reconciliation incident.