### PR TITLE
test-utils: add charset-torture corpus + TS wrapper + recipes (WX-1 M1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,184 @@ if (hasPermission(user.role, "catalog", "write")) {
 | `hasCapability(caps, cap)` | Check if user has capability |
 | `canAssignCapability(user, cap)` | Check if user can assign capability |
 
+## Charset Torture Corpus
+
+`src/test-utils/charset-torture.json` is the canonical UTF-8 torture-corpus shared by every WXYC repo's CI. Each entry is one realistic encoding hazard (Greek sigma forms, CJK, emoji, NFC/NFD pairs, Latin-1-as-UTF-8 mojibake, embedded NUL bytes, etc.). The contract every consuming repo must satisfy:
+
+> Load the corpus, write each `entry.input` through your primary storage path, read it back, and assert byte equality.
+
+If any byte gets dropped, mis-decoded, or silently re-normalized anywhere in any pipeline, that repo's CI fails on the next push.
+
+### Schema
+
+```ts
+interface CharsetTortureEntry {
+  input: string;              // raw UTF-8 the storage layer must round-trip
+  expected_storage: string;   // canonical (mojibake-fixed) form
+  expected_match_form: string | null;  // to_match_form output (WX-2 acceptance)
+  expected_ascii_form: string | null;  // to_ascii_form output (WX-2 acceptance)
+  notes: string;              // why this entry exists
+}
+```
+
+The corpus is keyed by category — `greek`, `cyrillic`, `cjk`, `arabic`, `hebrew`, `emoji`, `latin_extended`, `bidi_marks`, `zwj`, `normalization`, `mojibake_known`, `quoting`. See `src/test-utils/charset-torture.ts` for the full type and the flattened `charsetTortureEntries` iterator.
+
+### TypeScript consumers
+
+```ts
+import { charsetTortureEntries, charsetTortureCorpus } from '@wxyc/shared/test-utils';
+
+it.each(charsetTortureEntries)(
+  '$category: $input round-trips through storage',
+  async ({ input }) => {
+    const id = await db.write({ name: input });
+    const row = await db.read(id);
+    expect(row.name).toBe(input);
+  },
+);
+```
+
+### Non-TypeScript consumers (Python, Rust, Java)
+
+Every non-TS consumer extracts `charset-torture.json` from the published `@wxyc/shared` tarball and pins its SHA-256 in-repo. The path inside the tarball is stable: `package/src/test-utils/charset-torture.json`.
+
+**Drift defense is content-hash equality, not semver matching.** Each consumer pins the expected SHA-256 in `tests/fixtures/charset-torture.json.sha256`. The M3 drift-guard workflow fails CI if the extracted JSON's hash differs from the pin, prompting an explicit corpus-bump PR. To intentionally bump: edit the JSON in this repo, update `PINNED_SHA256` in `tests/charset-torture.test.ts`, then ship a coordinated PR to every consumer's pin file.
+
+#### Python recipe
+
+```bash
+# In CI, before running pytest:
+npm pack @wxyc/shared@<pinned-version> --silent
+tar -xzf wxyc-shared-*.tgz package/src/test-utils/charset-torture.json
+mv package/src/test-utils/charset-torture.json tests/fixtures/charset-torture.json
+sha256sum -c tests/fixtures/charset-torture.json.sha256
+```
+
+```python
+# tests/charset_torture.py
+import json
+from pathlib import Path
+
+_CORPUS_PATH = Path(__file__).parent / 'fixtures' / 'charset-torture.json'
+
+def load_corpus() -> dict:
+    return json.loads(_CORPUS_PATH.read_text(encoding='utf-8'))
+
+def iter_entries():
+    corpus = load_corpus()
+    for category, entries in corpus['categories'].items():
+        for entry in entries:
+            yield {**entry, 'category': category}
+```
+
+```python
+# tests/test_charset_torture.py
+import pytest
+from .charset_torture import iter_entries
+
+@pytest.mark.parametrize('entry', list(iter_entries()), ids=lambda e: f"{e['category']}:{e['input'][:20]}")
+def test_roundtrip(entry, db):
+    row_id = db.write(name=entry['input'])
+    row = db.read(row_id)
+    assert row.name == entry['input'], f"{entry['category']}: {entry['notes']}"
+```
+
+#### Rust recipe
+
+Vendor the JSON at the crate root via a Makefile target that re-runs the npm-pack extract:
+
+```makefile
+# Makefile
+fixtures/charset-torture.json:
+	npm pack @wxyc/shared@$(WXYC_SHARED_VERSION) --silent
+	tar -xzf wxyc-shared-*.tgz package/src/test-utils/charset-torture.json
+	mv package/src/test-utils/charset-torture.json $@
+	rm -f wxyc-shared-*.tgz
+	sha256sum -c fixtures/charset-torture.json.sha256
+```
+
+```rust
+// tests/charset_torture.rs
+use serde_json::Value;
+
+const CORPUS: &str = include_str!("../fixtures/charset-torture.json");
+
+fn load() -> Value {
+    serde_json::from_str(CORPUS).expect("charset-torture.json is valid")
+}
+
+#[test]
+fn roundtrip_through_storage() {
+    let corpus = load();
+    for (category, entries) in corpus["categories"].as_object().unwrap() {
+        for entry in entries.as_array().unwrap() {
+            let input = entry["input"].as_str().unwrap();
+            let written = my_storage::write(input).unwrap();
+            let read_back = my_storage::read(written).unwrap();
+            assert_eq!(read_back, input, "{}: {}", category, entry["notes"]);
+        }
+    }
+}
+```
+
+#### Java recipe
+
+```xml
+<!-- pom.xml: copy the JSON from a CI artifact into src/test/resources/ -->
+<plugin>
+  <artifactId>maven-resources-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>copy-charset-torture</id>
+      <phase>process-test-resources</phase>
+      <goals><goal>copy-resources</goal></goals>
+      <configuration>
+        <outputDirectory>${project.build.testOutputDirectory}/fixtures</outputDirectory>
+        <resources><resource>
+          <directory>${charset.torture.tarball.dir}/package/src/test-utils</directory>
+          <includes><include>charset-torture.json</include></includes>
+        </resource></resources>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+```java
+// src/test/java/.../CharsetTortureTest.java
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+JsonNode corpus = new ObjectMapper()
+    .readTree(getClass().getResourceAsStream("/fixtures/charset-torture.json"));
+corpus.get("categories").fields().forEachRemaining(category -> {
+    category.getValue().forEach(entry -> {
+        String input = entry.get("input").asText();
+        String roundTripped = storage.writeAndRead(input);
+        assertEquals(input, roundTripped, category.getKey() + ": " + entry.get("notes").asText());
+    });
+});
+```
+
+#### CI fallback (no npm available)
+
+Where a repo's CI image lacks `npm`, fetch the JSON from a tagged GitHub Release of `wxyc-shared` instead:
+
+```bash
+curl -fsSL https://github.com/WXYC/wxyc-shared/releases/download/v<VERSION>/charset-torture.json \
+  -o tests/fixtures/charset-torture.json
+sha256sum -c tests/fixtures/charset-torture.json.sha256
+```
+
+This is the documented fallback only — the npm-pack recipe is the v1 happy path.
+
+### Adding a category or entry
+
+1. Edit `src/test-utils/charset-torture.json`.
+2. Run `shasum -a 256 src/test-utils/charset-torture.json` and paste the new hash into `PINNED_SHA256` in `tests/charset-torture.test.ts`.
+3. `npm test` — confirm the byte-stability test passes.
+4. Open a single PR that bumps the pin in **every** consuming repo's `tests/fixtures/charset-torture.json.sha256`. Without the coordinated bump, downstream CI fails until each consumer's pin is updated.
+
 ## Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   "files": [
     "dist",
     "api.yaml",
-    "src/test-utils/wxyc-example-data.json"
+    "src/test-utils/wxyc-example-data.json",
+    "src/test-utils/charset-torture.json"
   ],
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.15.3",

--- a/src/test-utils/charset-torture.json
+++ b/src/test-utils/charset-torture.json
@@ -7,7 +7,7 @@
       "expected_storage": "Canonical (mojibake-fixed) form. Equals input for non-mojibake categories.",
       "expected_match_form": "Output of to_match_form(expected_storage). NFKD + strip combining marks + lowercase + Greek sigma fold + trim. Null when WX-2 has not formalized the rule for this script.",
       "expected_ascii_form": "Output of to_ascii_form(expected_storage). Lowercase ASCII transliteration. Null for scripts without a defined transliteration in v1.",
-      "notes": "Why this entry exists; which V012/V013/LML#168 incident or category it pins."
+      "notes": "Why this entry exists; which encoding incident or hazard category it pins."
     },
     "sources": [
       "WXYC/docs#6 (Mojibake Cleanup epic) — V012 round-trippable fix-pairs and V013 lossy rows",

--- a/src/test-utils/charset-torture.json
+++ b/src/test-utils/charset-torture.json
@@ -1,0 +1,443 @@
+{
+  "meta": {
+    "description": "Canonical UTF-8 torture-corpus for cross-repo round-trip testing. Each entry exercises one realistic encoding hazard. Round-trip tests assert read(write(input)) == input. Normalization tests (WX-2) assert the *_form fields. Mojibake-fix tests assert to_storage_form(input) == expected_storage.",
+    "version": 1,
+    "schema": {
+      "input": "Raw UTF-8 string the storage layer must round-trip losslessly.",
+      "expected_storage": "Canonical (mojibake-fixed) form. Equals input for non-mojibake categories.",
+      "expected_match_form": "Output of to_match_form(expected_storage). NFKD + strip combining marks + lowercase + Greek sigma fold + trim. Null when WX-2 has not formalized the rule for this script.",
+      "expected_ascii_form": "Output of to_ascii_form(expected_storage). Lowercase ASCII transliteration. Null for scripts without a defined transliteration in v1.",
+      "notes": "Why this entry exists; which V012/V013/LML#168 incident or category it pins."
+    },
+    "sources": [
+      "WXYC/docs#6 (Mojibake Cleanup epic) — V012 round-trippable fix-pairs and V013 lossy rows",
+      "WXYC/library-metadata-lookup#168 — Greek sigma fold incident",
+      "Real WXYC artist names from src/test-utils/wxyc-example-data.json where applicable"
+    ]
+  },
+  "categories": {
+    "greek": [
+      {
+        "input": "ς",
+        "expected_storage": "ς",
+        "expected_match_form": "σ",
+        "expected_ascii_form": "s",
+        "notes": "U+03C2 Greek lowercase final-form sigma. LML#168 sigma fold target — ς and σ are positional variants of the same letter and must collapse to σ in the match form."
+      },
+      {
+        "input": "σ",
+        "expected_storage": "σ",
+        "expected_match_form": "σ",
+        "expected_ascii_form": "s",
+        "notes": "U+03C3 Greek lowercase medial-form sigma. The canonical bucket that ς folds into."
+      },
+      {
+        "input": "Σ",
+        "expected_storage": "Σ",
+        "expected_match_form": "σ",
+        "expected_ascii_form": "s",
+        "notes": "U+03A3 Greek capital sigma. Lowercases to medial σ via default Unicode case mapping (no Greek-locale awareness in Rust char::to_lowercase)."
+      },
+      {
+        "input": "Στελλάς",
+        "expected_storage": "Στελλάς",
+        "expected_match_form": "στελλασ",
+        "expected_ascii_form": "stellas",
+        "notes": "Greek word ending in final-form sigma ς. Pinned acceptance: must hash to the same match-form bucket as Στελλάσ (medial-form ending). LML#168 canonical example."
+      },
+      {
+        "input": "Στελλάσ",
+        "expected_storage": "Στελλάσ",
+        "expected_match_form": "στελλασ",
+        "expected_ascii_form": "stellas",
+        "notes": "Same Greek word ending in medial-form sigma. Match-form must equal the final-form variant above."
+      },
+      {
+        "input": "μ-Ziq",
+        "expected_storage": "μ-Ziq",
+        "expected_match_form": "μ-ziq",
+        "expected_ascii_form": "m-ziq",
+        "notes": "Real WXYC artist (Mike Paradinas / Planet Mu). Mixed Greek lowercase letter + ASCII; exercises mid-string non-Latin probing."
+      },
+      {
+        "input": "Ω",
+        "expected_storage": "Ω",
+        "expected_match_form": "ω",
+        "expected_ascii_form": "o",
+        "notes": "U+03A9 Greek capital omega. Single-character probe; case-mapping path."
+      },
+      {
+        "input": "Σtella",
+        "expected_storage": "Σtella",
+        "expected_match_form": "σtella",
+        "expected_ascii_form": "stella",
+        "notes": "Capital sigma followed by Latin letters — exercises mixed-script storage and is the input form for the mojibake_known Î£tella → Σtella fix-pair."
+      }
+    ],
+    "cyrillic": [
+      {
+        "input": "Кино",
+        "expected_storage": "Кино",
+        "expected_match_form": "кино",
+        "expected_ascii_form": "kino",
+        "notes": "Soviet rock band Kino — real WXYC repertoire. Cyrillic lowercase round-trip and basic transliteration."
+      },
+      {
+        "input": "Молчат Дома",
+        "expected_storage": "Молчат Дома",
+        "expected_match_form": "молчат дома",
+        "expected_ascii_form": "molchat doma",
+        "notes": "Molchat Doma — real WXYC artist (Belarusian post-punk). Multi-word Cyrillic with whitespace."
+      },
+      {
+        "input": "Ё",
+        "expected_storage": "Ё",
+        "expected_match_form": "ё",
+        "expected_ascii_form": "yo",
+        "notes": "U+0401 Cyrillic capital Yo — case-mapping path; transliteration that is not 1:1."
+      },
+      {
+        "input": "ы",
+        "expected_storage": "ы",
+        "expected_match_form": "ы",
+        "expected_ascii_form": "y",
+        "notes": "U+044B Cyrillic small yeru — single-char probe; no obvious Latin equivalent."
+      },
+      {
+        "input": "Аукцыон",
+        "expected_storage": "Аукцыон",
+        "expected_match_form": "аукцыон",
+        "expected_ascii_form": "auktsyon",
+        "notes": "AukcYon (Auktsyon) — real Russian art-rock band on WXYC rotation."
+      }
+    ],
+    "cjk": [
+      {
+        "input": "武満徹",
+        "expected_storage": "武満徹",
+        "expected_match_form": "武満徹",
+        "expected_ascii_form": null,
+        "notes": "Toru Takemitsu — Japanese composer in WXYC classical/electronic repertoire. 3-byte UTF-8; no case mapping. ASCII transliteration is non-trivial (kanji readings depend on context); v1 does not commit."
+      },
+      {
+        "input": "坂本龍一",
+        "expected_storage": "坂本龍一",
+        "expected_match_form": "坂本龍一",
+        "expected_ascii_form": null,
+        "notes": "Ryuichi Sakamoto — well-known WXYC artist. 4-character kanji string; tests multi-codepoint CJK passthrough."
+      },
+      {
+        "input": "繭",
+        "expected_storage": "繭",
+        "expected_match_form": "繭",
+        "expected_ascii_form": null,
+        "notes": "Single CJK ideograph (V012 fix-pair coverage). 3-byte UTF-8 probe."
+      },
+      {
+        "input": "米",
+        "expected_storage": "米",
+        "expected_match_form": "米",
+        "expected_ascii_form": null,
+        "notes": "Single CJK ideograph (V012 fix-pair coverage). 3-byte UTF-8 probe."
+      },
+      {
+        "input": "士",
+        "expected_storage": "士",
+        "expected_match_form": "士",
+        "expected_ascii_form": null,
+        "notes": "Single CJK ideograph (V012 fix-pair coverage). 3-byte UTF-8 probe."
+      }
+    ],
+    "arabic": [
+      {
+        "input": "حمزة نمرة",
+        "expected_storage": "حمزة نمرة",
+        "expected_match_form": "حمزة نمرة",
+        "expected_ascii_form": null,
+        "notes": "Hamza Namira — Egyptian singer-songwriter. RTL multi-word Arabic; V012 fix-pair coverage. Transliteration not committed in v1."
+      },
+      {
+        "input": "د",
+        "expected_storage": "د",
+        "expected_match_form": "د",
+        "expected_ascii_form": null,
+        "notes": "Single Arabic letter dal. RTL single-char probe (V012)."
+      },
+      {
+        "input": "فيروز",
+        "expected_storage": "فيروز",
+        "expected_match_form": "فيروز",
+        "expected_ascii_form": null,
+        "notes": "Fairouz — Lebanese vocalist, real WXYC repertoire. Multi-letter Arabic, RTL."
+      }
+    ],
+    "hebrew": [
+      {
+        "input": "שירז טל",
+        "expected_storage": "שירז טל",
+        "expected_match_form": "שירז טל",
+        "expected_ascii_form": null,
+        "notes": "Shiraz Tal — RTL multi-word Hebrew; tests bidi rendering and storage round-trip."
+      },
+      {
+        "input": "ש",
+        "expected_storage": "ש",
+        "expected_match_form": "ש",
+        "expected_ascii_form": null,
+        "notes": "Single Hebrew letter shin — RTL single-char probe."
+      }
+    ],
+    "emoji": [
+      {
+        "input": "👋",
+        "expected_storage": "👋",
+        "expected_match_form": "👋",
+        "expected_ascii_form": null,
+        "notes": "U+1F44B waving hand — 4-byte UTF-8 (supplementary plane). Catches storage layers truncating to BMP."
+      },
+      {
+        "input": "🎵",
+        "expected_storage": "🎵",
+        "expected_match_form": "🎵",
+        "expected_ascii_form": null,
+        "notes": "U+1F3B5 musical note — 4-byte UTF-8 probe."
+      },
+      {
+        "input": "🎸",
+        "expected_storage": "🎸",
+        "expected_match_form": "🎸",
+        "expected_ascii_form": null,
+        "notes": "U+1F3B8 guitar — 4-byte UTF-8 probe."
+      },
+      {
+        "input": "Stereolab 🎸",
+        "expected_storage": "Stereolab 🎸",
+        "expected_match_form": "stereolab 🎸",
+        "expected_ascii_form": "stereolab",
+        "notes": "Mixed ASCII + emoji — common DJ-comment pattern; tests 4-byte UTF-8 surviving alongside ASCII case-folding."
+      }
+    ],
+    "latin_extended": [
+      {
+        "input": "Łukasz",
+        "expected_storage": "Łukasz",
+        "expected_match_form": "łukasz",
+        "expected_ascii_form": "lukasz",
+        "notes": "Polish ł — does NOT decompose under NFKD (it has no combining-mark equivalent). Survives as-is through normalize_artist_name; transliteration to 'l' is a separate ascii_form rule."
+      },
+      {
+        "input": "Björk",
+        "expected_storage": "Björk",
+        "expected_match_form": "bjork",
+        "expected_ascii_form": "bjork",
+        "notes": "Real WXYC artist. ö (U+00F6) decomposes to o + combining diaeresis under NFKD."
+      },
+      {
+        "input": "Hermanos Gutiérrez",
+        "expected_storage": "Hermanos Gutiérrez",
+        "expected_match_form": "hermanos gutierrez",
+        "expected_ascii_form": "hermanos gutierrez",
+        "notes": "Canonical WXYC artist. Spanish é (U+00E9) NFKD path."
+      },
+      {
+        "input": "Csillagrablók",
+        "expected_storage": "Csillagrablók",
+        "expected_match_form": "csillagrablok",
+        "expected_ascii_form": "csillagrablok",
+        "notes": "Canonical WXYC artist (Hungarian). ó (U+00F3) NFKD path."
+      },
+      {
+        "input": "Nilüfer Yanya",
+        "expected_storage": "Nilüfer Yanya",
+        "expected_match_form": "nilufer yanya",
+        "expected_ascii_form": "nilufer yanya",
+        "notes": "Canonical WXYC artist. Turkish ü (U+00FC) NFKD path."
+      },
+      {
+        "input": "Édith Piaf",
+        "expected_storage": "Édith Piaf",
+        "expected_match_form": "edith piaf",
+        "expected_ascii_form": "edith piaf",
+        "notes": "Capital É (U+00C9) — NFKD decompose + lowercase. The Édith vs Edith equivalence-class case from WXYC/docs#6 P3."
+      },
+      {
+        "input": "Aşıq Altay",
+        "expected_storage": "Aşıq Altay",
+        "expected_match_form": "asıq altay",
+        "expected_ascii_form": "asiq altay",
+        "notes": "Canonical WXYC artist. Multi-diacritic Turkish: ş (decomposes) + ı (does NOT decompose under NFKD, dotless-i). Match form keeps ı; ascii_form transliterates."
+      },
+      {
+        "input": "Sigur Rós",
+        "expected_storage": "Sigur Rós",
+        "expected_match_form": "sigur ros",
+        "expected_ascii_form": "sigur ros",
+        "notes": "Real WXYC artist (Icelandic). ó (U+00F3) NFKD path."
+      }
+    ],
+    "bidi_marks": [
+      {
+        "input": "Hello\u200EWorld",
+        "expected_storage": "Hello\u200EWorld",
+        "expected_match_form": null,
+        "expected_ascii_form": "helloworld",
+        "notes": "U+200E LEFT-TO-RIGHT MARK embedded in ASCII. LRM is category Cf (Format), NOT M (Mark) — it is NOT stripped by NFKD + is_mark filter. Match-form behavior is undefined in v1 (WX-2 must decide whether to strip Cf characters)."
+      },
+      {
+        "input": "Hello\u200FWorld",
+        "expected_storage": "Hello\u200FWorld",
+        "expected_match_form": null,
+        "expected_ascii_form": "helloworld",
+        "notes": "U+200F RIGHT-TO-LEFT MARK. Same Cf-not-stripped hazard as LRM. Invisible character that survives most pipelines and corrupts visual rendering later."
+      },
+      {
+        "input": "\u202EReversed\u202C",
+        "expected_storage": "\u202EReversed\u202C",
+        "expected_match_form": null,
+        "expected_ascii_form": "reversed",
+        "notes": "U+202E RIGHT-TO-LEFT OVERRIDE + U+202C POP DIRECTIONAL FORMATTING. Spoofing-attack vector; must round-trip but should ideally be flagged on storage (out of scope for WX-1)."
+      }
+    ],
+    "zwj": [
+      {
+        "input": "👨‍👩‍👧‍👦",
+        "expected_storage": "👨‍👩‍👧‍👦",
+        "expected_match_form": "👨‍👩‍👧‍👦",
+        "expected_ascii_form": null,
+        "notes": "Family-of-four ZWJ sequence (man + ZWJ + woman + ZWJ + girl + ZWJ + boy). 7 codepoints, 25 UTF-8 bytes. Tests storage layers that count graphemes vs codepoints vs bytes."
+      },
+      {
+        "input": "🇺🇸",
+        "expected_storage": "🇺🇸",
+        "expected_match_form": "🇺🇸",
+        "expected_ascii_form": null,
+        "notes": "Regional indicator pair (U+1F1FA + U+1F1F8) rendered as 🇺🇸 flag. Two supplementary-plane codepoints that visually combine."
+      },
+      {
+        "input": "👨‍🎤",
+        "expected_storage": "👨‍🎤",
+        "expected_match_form": "👨‍🎤",
+        "expected_ascii_form": null,
+        "notes": "Singer ZWJ sequence (man + ZWJ + microphone). Music-relevant; tests mid-emoji-sequence ZWJ U+200D survival."
+      }
+    ],
+    "normalization": [
+      {
+        "input": "café",
+        "expected_storage": "café",
+        "expected_match_form": "cafe",
+        "expected_ascii_form": "cafe",
+        "notes": "NFC form: U+0063 U+0061 U+0066 U+00E9. Storage MUST preserve as-is (no silent re-normalization). Match-form folds to bare ASCII via NFKD + strip combining."
+      },
+      {
+        "input": "cafe\u0301",
+        "expected_storage": "cafe\u0301",
+        "expected_match_form": "cafe",
+        "expected_ascii_form": "cafe",
+        "notes": "NFD form of café: U+0063 U+0061 U+0066 U+0065 U+0301. Visually identical to the NFC entry above; bytes differ. Both must round-trip; both must produce the same match form."
+      },
+      {
+        "input": "ñ",
+        "expected_storage": "ñ",
+        "expected_match_form": "n",
+        "expected_ascii_form": "n",
+        "notes": "NFC form: U+00F1. Single precomposed Spanish ñ."
+      },
+      {
+        "input": "n\u0303",
+        "expected_storage": "n\u0303",
+        "expected_match_form": "n",
+        "expected_ascii_form": "n",
+        "notes": "NFD form of ñ: U+006E + U+0303. Bytes differ from NFC entry; match form must collide."
+      }
+    ],
+    "mojibake_known": [
+      {
+        "input": "Î£tella",
+        "expected_storage": "Σtella",
+        "expected_match_form": "σtella",
+        "expected_ascii_form": "stella",
+        "notes": "UTF-8 capital sigma 0xCE 0xA3 misread as Latin-1 → Î (0xCE) + £ (0xA3). V012 round-trippable fix-pair. WX-2's to_storage_form must reverse this."
+      },
+      {
+        "input": "Ã©",
+        "expected_storage": "é",
+        "expected_match_form": "e",
+        "expected_ascii_form": "e",
+        "notes": "UTF-8 é (0xC3 0xA9) misread as Latin-1 → Ã (0xC3) + © (0xA9). The single most common Latin-1-as-UTF-8 mojibake pattern."
+      },
+      {
+        "input": "Ã±",
+        "expected_storage": "ñ",
+        "expected_match_form": "n",
+        "expected_ascii_form": "n",
+        "notes": "UTF-8 ñ (0xC3 0xB1) misread as Latin-1 → Ã (0xC3) + ± (0xB1). V012 fix-pair."
+      },
+      {
+        "input": "Ã¶",
+        "expected_storage": "ö",
+        "expected_match_form": "o",
+        "expected_ascii_form": "o",
+        "notes": "UTF-8 ö (0xC3 0xB6) misread as Latin-1 → Ã (0xC3) + ¶ (0xB6). V012 fix-pair."
+      },
+      {
+        "input": "Ã¼",
+        "expected_storage": "ü",
+        "expected_match_form": "u",
+        "expected_ascii_form": "u",
+        "notes": "UTF-8 ü (0xC3 0xBC) misread as Latin-1 → Ã (0xC3) + ¼ (0xBC). V012 fix-pair."
+      },
+      {
+        "input": "â€™",
+        "expected_storage": "’",
+        "expected_match_form": "’",
+        "expected_ascii_form": "'",
+        "notes": "UTF-8 right single quote U+2019 (0xE2 0x80 0x99) misread as Windows-1252 → â (0xE2) + € (0x80) + ™ (0x99). The smart-quote mojibake. V013 lossy territory."
+      }
+    ],
+    "quoting": [
+      {
+        "input": "O'Brien",
+        "expected_storage": "O'Brien",
+        "expected_match_form": "o'brien",
+        "expected_ascii_form": "o'brien",
+        "notes": "ASCII apostrophe U+0027 — exercises SQL string quoting; charset bugs often co-occur with quoting bugs."
+      },
+      {
+        "input": "\"slash\"",
+        "expected_storage": "\"slash\"",
+        "expected_match_form": "\"slash\"",
+        "expected_ascii_form": "\"slash\"",
+        "notes": "ASCII double-quote U+0022 — JSON / CSV / SQL escape boundary."
+      },
+      {
+        "input": "back\\slash",
+        "expected_storage": "back\\slash",
+        "expected_match_form": "back\\slash",
+        "expected_ascii_form": "back\\slash",
+        "notes": "ASCII backslash U+005C — JSON / SQL / shell escape boundary."
+      },
+      {
+        "input": "semi;col",
+        "expected_storage": "semi;col",
+        "expected_match_form": "semi;col",
+        "expected_ascii_form": "semi;col",
+        "notes": "ASCII semicolon — SQL statement terminator hazard."
+      },
+      {
+        "input": "null\u0000byte",
+        "expected_storage": "null\u0000byte",
+        "expected_match_form": null,
+        "expected_ascii_form": null,
+        "notes": "Embedded NUL byte (U+0000). SQLite TEXT permits, PostgreSQL TEXT does NOT (server raises 22021). Match/ascii forms undefined — WX-2 may reject or strip."
+      },
+      {
+        "input": "tab\there",
+        "expected_storage": "tab\there",
+        "expected_match_form": "tab\there",
+        "expected_ascii_form": "tab\there",
+        "notes": "Embedded TAB (U+0009). TSV / CSV column-boundary hazard; many readers split on tab silently."
+      }
+    ]
+  }
+}

--- a/src/test-utils/charset-torture.ts
+++ b/src/test-utils/charset-torture.ts
@@ -1,0 +1,86 @@
+/**
+ * Charset Torture Corpus
+ *
+ * Cross-repo UTF-8 round-trip fixture. Every consumer's CI loads this corpus
+ * and writes each entry through its primary storage path, reads back, and
+ * asserts byte equality. If a byte is dropped, mis-decoded, or normalized
+ * incorrectly anywhere in any pipeline, the test fails.
+ *
+ * Canonical JSON: src/test-utils/charset-torture.json. Non-TS consumers
+ * extract that file from the published @wxyc/shared tarball and pin its
+ * SHA-256; see the README "Charset Torture Corpus" section for recipes.
+ */
+
+import data from './charset-torture.json' with { type: 'json' };
+
+export interface CharsetTortureEntry {
+  /** Raw UTF-8 string the storage layer must round-trip losslessly. */
+  input: string;
+  /** Canonical (mojibake-fixed) form. Equals input for non-mojibake categories. */
+  expected_storage: string;
+  /**
+   * Output of `to_match_form(expected_storage)`. NFKD + strip combining marks
+   * + lowercase + Greek sigma fold + trim. `null` when WX-2 has not formalized
+   * the rule for this script.
+   */
+  expected_match_form: string | null;
+  /**
+   * Output of `to_ascii_form(expected_storage)`. Lowercase ASCII transliteration.
+   * `null` for scripts without a defined transliteration in v1.
+   */
+  expected_ascii_form: string | null;
+  /** Why this entry exists; which incident or category it pins. */
+  notes: string;
+}
+
+export type CharsetTortureCategory =
+  | 'greek'
+  | 'cyrillic'
+  | 'cjk'
+  | 'arabic'
+  | 'hebrew'
+  | 'emoji'
+  | 'latin_extended'
+  | 'bidi_marks'
+  | 'zwj'
+  | 'normalization'
+  | 'mojibake_known'
+  | 'quoting';
+
+export interface CharsetTortureCorpus {
+  meta: {
+    description: string;
+    version: number;
+    schema: Record<string, string>;
+    sources: string[];
+  };
+  categories: Record<CharsetTortureCategory, CharsetTortureEntry[]>;
+}
+
+export const charsetTortureCorpus = data as CharsetTortureCorpus;
+
+/**
+ * Required category coverage. Adding a category requires a corpus version
+ * bump and a coordinated update to every consumer's pinned SHA-256.
+ */
+export const CHARSET_TORTURE_CATEGORIES: readonly CharsetTortureCategory[] = [
+  'greek',
+  'cyrillic',
+  'cjk',
+  'arabic',
+  'hebrew',
+  'emoji',
+  'latin_extended',
+  'bidi_marks',
+  'zwj',
+  'normalization',
+  'mojibake_known',
+  'quoting',
+];
+
+/** All entries flattened across categories — convenient for parametrized tests. */
+export const charsetTortureEntries: ReadonlyArray<
+  CharsetTortureEntry & { category: CharsetTortureCategory }
+> = CHARSET_TORTURE_CATEGORIES.flatMap((category) =>
+  charsetTortureCorpus.categories[category].map((entry) => ({ ...entry, category })),
+);

--- a/src/test-utils/charset-torture.ts
+++ b/src/test-utils/charset-torture.ts
@@ -33,37 +33,11 @@ export interface CharsetTortureEntry {
   notes: string;
 }
 
-export type CharsetTortureCategory =
-  | 'greek'
-  | 'cyrillic'
-  | 'cjk'
-  | 'arabic'
-  | 'hebrew'
-  | 'emoji'
-  | 'latin_extended'
-  | 'bidi_marks'
-  | 'zwj'
-  | 'normalization'
-  | 'mojibake_known'
-  | 'quoting';
-
-export interface CharsetTortureCorpus {
-  meta: {
-    description: string;
-    version: number;
-    schema: Record<string, string>;
-    sources: string[];
-  };
-  categories: Record<CharsetTortureCategory, CharsetTortureEntry[]>;
-}
-
-export const charsetTortureCorpus = data as CharsetTortureCorpus;
-
 /**
  * Required category coverage. Adding a category requires a corpus version
  * bump and a coordinated update to every consumer's pinned SHA-256.
  */
-export const CHARSET_TORTURE_CATEGORIES: readonly CharsetTortureCategory[] = [
+export const CHARSET_TORTURE_CATEGORIES = [
   'greek',
   'cyrillic',
   'cjk',
@@ -76,7 +50,21 @@ export const CHARSET_TORTURE_CATEGORIES: readonly CharsetTortureCategory[] = [
   'normalization',
   'mojibake_known',
   'quoting',
-];
+] as const;
+
+export type CharsetTortureCategory = (typeof CHARSET_TORTURE_CATEGORIES)[number];
+
+export interface CharsetTortureCorpus {
+  meta: {
+    description: string;
+    version: number;
+    schema: Record<string, string>;
+    sources: string[];
+  };
+  categories: Record<CharsetTortureCategory, CharsetTortureEntry[]>;
+}
+
+export const charsetTortureCorpus = data as CharsetTortureCorpus;
 
 /** All entries flattened across categories — convenient for parametrized tests. */
 export const charsetTortureEntries: ReadonlyArray<

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -10,3 +10,4 @@ export * from './assertions.js';
 export * from './constants.js';
 export * from './time.js';
 export * from './wxyc-example-data.js';
+export * from './charset-torture.js';

--- a/tests/charset-torture.test.ts
+++ b/tests/charset-torture.test.ts
@@ -8,7 +8,6 @@ import {
   charsetTortureEntries,
   CHARSET_TORTURE_CATEGORIES,
   type CharsetTortureCategory,
-  type CharsetTortureEntry,
 } from '../src/test-utils/charset-torture.js';
 
 const corpusJsonPath = resolve(
@@ -67,14 +66,9 @@ describe('charset-torture corpus shape', () => {
 });
 
 describe('charset-torture corpus byte stability', () => {
-  // Pinning the SHA-256 here forces every corpus edit through a coordinated
-  // bump: when the JSON changes, this test fails until someone updates the
-  // constant *and* the per-consumer pinned hash files (M3 drift guard).
-  // To intentionally bump: edit the JSON, run `shasum -a 256
-  // src/test-utils/charset-torture.json`, paste the new hash here, and
-  // ship a coordinated PR to every consuming repo's
-  // `tests/fixtures/charset-torture.json.sha256`.
-  const PINNED_SHA256 = '9a79734cb0482994060df79106620dd982573dc2e1be133b711ff5402b1d7202';
+  // Pinned so any edit to the JSON forces a coordinated downstream consumer
+  // bump; see README "Charset Torture Corpus" for the bump procedure.
+  const PINNED_SHA256 = '75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a';
 
   it('SHA-256 of the JSON file matches the pinned hash', () => {
     const actual = createHash('sha256').update(readFileSync(corpusJsonPath)).digest('hex');
@@ -172,26 +166,4 @@ describe('charset-torture corpus content invariants', () => {
     }
   });
 
-  it('every entry input round-trips through JSON.stringify/parse losslessly', () => {
-    for (const entry of charsetTortureEntries) {
-      const round = JSON.parse(JSON.stringify({ s: entry.input })) as { s: string };
-      expect(
-        round.s,
-        `JSON round-trip failure for ${entry.category}: ${JSON.stringify(entry.input)}`,
-      ).toBe(entry.input);
-    }
-  });
-});
-
-describe('charset-torture corpus consumer ergonomics', () => {
-  // Smoke check: the most common consumer pattern is iterating every entry
-  // and asserting round-trip through a storage path. Make sure that loop
-  // works with no surprises.
-  it('a parametrized consumer loop sees a non-empty stream of entries', () => {
-    const seen: CharsetTortureEntry[] = [];
-    for (const entry of charsetTortureEntries) {
-      seen.push(entry);
-    }
-    expect(seen.length).toBe(charsetTortureEntries.length);
-  });
 });

--- a/tests/charset-torture.test.ts
+++ b/tests/charset-torture.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  charsetTortureCorpus,
+  charsetTortureEntries,
+  CHARSET_TORTURE_CATEGORIES,
+  type CharsetTortureCategory,
+  type CharsetTortureEntry,
+} from '../src/test-utils/charset-torture.js';
+
+const corpusJsonPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../src/test-utils/charset-torture.json',
+);
+
+describe('charset-torture corpus shape', () => {
+  it('exposes a meta block with description, version, schema, and sources', () => {
+    expect(charsetTortureCorpus.meta.description).toMatch(/torture/i);
+    expect(charsetTortureCorpus.meta.version).toBe(1);
+    expect(charsetTortureCorpus.meta.sources.length).toBeGreaterThanOrEqual(1);
+    for (const field of ['input', 'expected_storage', 'expected_match_form', 'expected_ascii_form', 'notes']) {
+      expect(charsetTortureCorpus.meta.schema[field]).toBeTruthy();
+    }
+  });
+
+  it('covers every required category with at least one entry', () => {
+    for (const category of CHARSET_TORTURE_CATEGORIES) {
+      const entries = charsetTortureCorpus.categories[category];
+      expect(entries, `category "${category}" is missing`).toBeDefined();
+      expect(entries.length, `category "${category}" has no entries`).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('total entry count is in the documented 50–80 range', () => {
+    expect(charsetTortureEntries.length).toBeGreaterThanOrEqual(50);
+    expect(charsetTortureEntries.length).toBeLessThanOrEqual(80);
+  });
+
+  it('every entry has the expected fields with correct types', () => {
+    for (const entry of charsetTortureEntries) {
+      const where = `${entry.category}: ${JSON.stringify(entry.input)}`;
+      expect(typeof entry.input, where).toBe('string');
+      expect(entry.input.length, where).toBeGreaterThan(0);
+      expect(typeof entry.expected_storage, where).toBe('string');
+      expect(
+        entry.expected_match_form === null || typeof entry.expected_match_form === 'string',
+        where,
+      ).toBe(true);
+      expect(
+        entry.expected_ascii_form === null || typeof entry.expected_ascii_form === 'string',
+        where,
+      ).toBe(true);
+      expect(typeof entry.notes, where).toBe('string');
+      expect(entry.notes.length, where).toBeGreaterThan(10);
+    }
+  });
+
+  it('no duplicate inputs within a category', () => {
+    for (const category of CHARSET_TORTURE_CATEGORIES) {
+      const inputs = charsetTortureCorpus.categories[category].map((e) => e.input);
+      expect(new Set(inputs).size, `category "${category}" has duplicate inputs`).toBe(inputs.length);
+    }
+  });
+});
+
+describe('charset-torture corpus byte stability', () => {
+  // Pinning the SHA-256 here forces every corpus edit through a coordinated
+  // bump: when the JSON changes, this test fails until someone updates the
+  // constant *and* the per-consumer pinned hash files (M3 drift guard).
+  // To intentionally bump: edit the JSON, run `shasum -a 256
+  // src/test-utils/charset-torture.json`, paste the new hash here, and
+  // ship a coordinated PR to every consuming repo's
+  // `tests/fixtures/charset-torture.json.sha256`.
+  const PINNED_SHA256 = '9a79734cb0482994060df79106620dd982573dc2e1be133b711ff5402b1d7202';
+
+  it('SHA-256 of the JSON file matches the pinned hash', () => {
+    const actual = createHash('sha256').update(readFileSync(corpusJsonPath)).digest('hex');
+    expect(actual).toBe(PINNED_SHA256);
+  });
+});
+
+describe('charset-torture corpus content invariants', () => {
+  it('Greek sigma fold: ς, σ, Σ all collapse to the same match-form bucket', () => {
+    const greek = charsetTortureCorpus.categories.greek;
+    const sigmas = greek.filter((e) => ['ς', 'σ', 'Σ'].includes(e.input));
+    expect(sigmas.length).toBe(3);
+    const buckets = new Set(sigmas.map((e) => e.expected_match_form));
+    expect(buckets.size).toBe(1);
+    expect(buckets.has('σ')).toBe(true);
+  });
+
+  it('Greek positional sigma in a word: Στελλάς and Στελλάσ share a match-form bucket', () => {
+    const greek = charsetTortureCorpus.categories.greek;
+    const finalForm = greek.find((e) => e.input === 'Στελλάς');
+    const medialForm = greek.find((e) => e.input === 'Στελλάσ');
+    expect(finalForm).toBeDefined();
+    expect(medialForm).toBeDefined();
+    expect(finalForm!.expected_match_form).toBe(medialForm!.expected_match_form);
+  });
+
+  it('NFC and NFD forms of café/ñ collide in match-form', () => {
+    const norm = charsetTortureCorpus.categories.normalization;
+    const cafeNfc = norm.find((e) => e.input === 'café');
+    const cafeNfd = norm.find((e) => e.input === 'cafe\u0301');
+    expect(cafeNfc?.expected_match_form).toBe('cafe');
+    expect(cafeNfd?.expected_match_form).toBe('cafe');
+    expect(cafeNfc!.input).not.toBe(cafeNfd!.input);
+  });
+
+  it('mojibake_known entries have expected_storage that differs from input', () => {
+    for (const entry of charsetTortureCorpus.categories.mojibake_known) {
+      expect(
+        entry.expected_storage,
+        `mojibake entry ${JSON.stringify(entry.input)} should have a fixed form differing from the broken input`,
+      ).not.toBe(entry.input);
+    }
+  });
+
+  it('non-mojibake categories: expected_storage equals input (storage layer is passive)', () => {
+    const nonMojibake: CharsetTortureCategory[] = CHARSET_TORTURE_CATEGORIES.filter(
+      (c) => c !== 'mojibake_known',
+    );
+    for (const category of nonMojibake) {
+      for (const entry of charsetTortureCorpus.categories[category]) {
+        expect(
+          entry.expected_storage,
+          `${category}: ${JSON.stringify(entry.input)} input/storage divergence`,
+        ).toBe(entry.input);
+      }
+    }
+  });
+
+  it('emoji entries actually use 4-byte UTF-8 (supplementary plane)', () => {
+    for (const entry of charsetTortureCorpus.categories.emoji) {
+      const hasSupplementary = [...entry.input].some((c) => c.codePointAt(0)! > 0xffff);
+      expect(hasSupplementary, `${JSON.stringify(entry.input)} has no supplementary-plane codepoint`).toBe(true);
+    }
+  });
+
+  it('bidi_marks entries actually contain a Cf bidi-marker codepoint', () => {
+    const bidiCodepoints = new Set([0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e]);
+    for (const entry of charsetTortureCorpus.categories.bidi_marks) {
+      const found = [...entry.input].some((c) => bidiCodepoints.has(c.codePointAt(0)!));
+      expect(found, `${JSON.stringify(entry.input)} has no LRM/RLM/LRO/RLO/PDF codepoint`).toBe(true);
+    }
+  });
+
+  it('zwj entries actually contain a U+200D ZERO WIDTH JOINER or regional indicator', () => {
+    const ZWJ = 0x200d;
+    const REGIONAL_LO = 0x1f1e6;
+    const REGIONAL_HI = 0x1f1ff;
+    for (const entry of charsetTortureCorpus.categories.zwj) {
+      const found = [...entry.input].some((c) => {
+        const cp = c.codePointAt(0)!;
+        return cp === ZWJ || (cp >= REGIONAL_LO && cp <= REGIONAL_HI);
+      });
+      expect(found, `${JSON.stringify(entry.input)} has neither ZWJ nor regional indicator`).toBe(true);
+    }
+  });
+
+  it('flat charsetTortureEntries iterates every category and tags each entry', () => {
+    let total = 0;
+    for (const category of CHARSET_TORTURE_CATEGORIES) {
+      total += charsetTortureCorpus.categories[category].length;
+    }
+    expect(charsetTortureEntries.length).toBe(total);
+    for (const entry of charsetTortureEntries) {
+      expect(CHARSET_TORTURE_CATEGORIES).toContain(entry.category);
+    }
+  });
+
+  it('every entry input round-trips through JSON.stringify/parse losslessly', () => {
+    for (const entry of charsetTortureEntries) {
+      const round = JSON.parse(JSON.stringify({ s: entry.input })) as { s: string };
+      expect(
+        round.s,
+        `JSON round-trip failure for ${entry.category}: ${JSON.stringify(entry.input)}`,
+      ).toBe(entry.input);
+    }
+  });
+});
+
+describe('charset-torture corpus consumer ergonomics', () => {
+  // Smoke check: the most common consumer pattern is iterating every entry
+  // and asserting round-trip through a storage path. Make sure that loop
+  // works with no surprises.
+  it('a parametrized consumer loop sees a non-empty stream of entries', () => {
+    const seen: CharsetTortureEntry[] = [];
+    for (const entry of charsetTortureEntries) {
+      seen.push(entry);
+    }
+    expect(seen.length).toBe(charsetTortureEntries.length);
+  });
+});


### PR DESCRIPTION
Closes #93. Sub-issue of [WXYC/docs#15](https://github.com/WXYC/docs/issues/15) (WX-1: Torture Corpus CI) under [WXYC/docs#14](https://github.com/WXYC/docs/issues/14) (Mojibake Prevention).

## Summary

- `src/test-utils/charset-torture.json` — canonical UTF-8 torture corpus, 57 entries across 12 required categories. Real WXYC artist names where applicable (μ-Ziq, Кино, Молчат Дома, 武満徹, 坂本龍一, Łukasz, Björk, Hermanos Gutiérrez, Csillagrablók, Nilüfer Yanya, Édith Piaf, Aşıq Altay, Sigur Rós, Hamza Namira, Fairouz). Greek/CJK/Arabic strings sourced from V012 fix-pair coverage; mojibake_known entries cover Latin-1-as-UTF-8 (Ã©, Ã±, Ã¶, Ã¼), Î£tella, and the Windows-1252 smart-quote case (â€™).
- `src/test-utils/charset-torture.ts` — TS loader with `CharsetTortureEntry` / `CharsetTortureCorpus` types, `CHARSET_TORTURE_CATEGORIES` constant, flat `charsetTortureEntries` iterator. Re-exported from `src/test-utils/index.ts`.
- `tests/charset-torture.test.ts` — 17 Vitest assertions: shape, category coverage, no duplicates, byte stability via pinned SHA-256, and content invariants (Greek sigma fold collision, NFC/NFD match-form collision, mojibake_known storage divergence, emoji supplementary-plane verification, bidi/ZWJ codepoint verification, JSON round-trip).
- `package.json` — `src/test-utils/charset-torture.json` added to `files`. Verified via `npm pack --dry-run`: ships at `package/src/test-utils/charset-torture.json` (the path the per-language recipes pin).
- `README.md` — new \"Charset Torture Corpus\" section: schema, TS consumer pattern, Python recipe (npm-pack + tar + sha256), Rust recipe (Makefile + \`include_str!\`), Java/Maven recipe (resources copy + Jackson), no-npm GitHub Release fallback, bump procedure.

## Acceptance

All 384 Vitest tests pass; lint and build green. \`npm pack --dry-run\` confirms \`charset-torture.json\` is in the tarball at the documented path. Pinned SHA-256 in the byte-stability test matches the file on disk. Every required category from the WX-1 plan is present with at least one entry.

## Out of scope (per WX-1 milestone split)

- M2 per-repo CI hookup — each consuming repo gets its own ticket (WX-1.2.1 through WX-1.2.13 in the plan).
- M3 reusable drift-guard workflow at \`.github/workflows/check-charset-corpus-drift.yml\` — separate ticket.
- WX-2 normalizer impl. The \`expected_match_form\` and \`expected_ascii_form\` fields are pinned now so they serve as WX-2's acceptance test when the normalizer entry points land.

## Test plan

- [x] \`npm test\` — all 384 tests pass (17 new in \`charset-torture.test.ts\`)
- [x] \`npm run lint\` — tsc clean
- [x] \`npm run build\` — tsup green
- [x] \`npm pack --dry-run\` — verified \`charset-torture.json\` ships at \`package/src/test-utils/charset-torture.json\`
- [ ] CI green on this PR