### PR TITLE
ci: add reusable charset-torture corpus drift-guard workflow (WX-1.3.1)

### DIFF
--- a/.github/workflows/check-charset-corpus-drift.yml
+++ b/.github/workflows/check-charset-corpus-drift.yml
@@ -1,0 +1,78 @@
+name: Charset Torture Corpus Drift Guard
+
+# Reusable workflow that fails CI when the published @wxyc/shared
+# charset-torture.json no longer matches the SHA-256 the consumer pinned.
+# Each consuming repo's per-repo round-trip tests are pinned to a specific
+# corpus version; this guard surfaces upstream changes as an actionable diff
+# rather than letting them present as opaque test failures later.
+#
+# Invoked from sister WXYC repos as:
+#
+#   jobs:
+#     charset-corpus-drift:
+#       uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
+#       with:
+#         pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a
+#         # package-version: 'latest'  # optional; pins which @wxyc/shared release to fetch
+#       secrets:
+#         npm-token: ${{ secrets.GITHUB_TOKEN }}  # needs read:packages on WXYC org
+#
+# When the pin and the published hash diverge, the job fails with the
+# bump procedure inline in the log so the consumer's response is mechanical.
+
+on:
+  workflow_call:
+    inputs:
+      pinned-sha256:
+        description: "SHA-256 the consumer expects for charset-torture.json"
+        required: true
+        type: string
+      package-version:
+        description: "Version of @wxyc/shared to fetch (e.g. '1.2.3', 'latest')"
+        required: false
+        type: string
+        default: "latest"
+      wxyc-shared-ref:
+        description: "Git ref of WXYC/wxyc-shared whose script to run"
+        required: false
+        type: string
+        default: "main"
+    secrets:
+      npm-token:
+        description: "GitHub token with read:packages on the WXYC org"
+        required: true
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout wxyc-shared (for the drift script)
+        uses: actions/checkout@v6
+        with:
+          repository: WXYC/wxyc-shared
+          ref: ${{ inputs.wxyc-shared-ref }}
+          path: wxyc-shared
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@wxyc"
+
+      - name: Pack @wxyc/shared and extract the corpus
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+        run: |
+          set -euo pipefail
+          mkdir -p extract
+          cd extract
+          npm pack "@wxyc/shared@${{ inputs.package-version }}" --silent
+          tar -xzf wxyc-shared-*.tgz package/src/test-utils/charset-torture.json
+          ls -la package/src/test-utils/
+
+      - name: Compare SHA-256 against the pinned hash
+        run: |
+          bash wxyc-shared/scripts/check-corpus-drift.sh \
+            extract/package/src/test-utils/charset-torture.json \
+            "${{ inputs.pinned-sha256 }}"

--- a/.github/workflows/check-charset-corpus-drift.yml
+++ b/.github/workflows/check-charset-corpus-drift.yml
@@ -42,6 +42,10 @@ on:
         description: "GitHub token with read:packages on the WXYC org"
         required: true
 
+concurrency:
+  group: charset-corpus-drift-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   drift-check:
     runs-on: ubuntu-latest
@@ -63,16 +67,18 @@ jobs:
       - name: Pack @wxyc/shared and extract the corpus
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+          PACKAGE_VERSION: ${{ inputs.package-version }}
         run: |
           set -euo pipefail
           mkdir -p extract
           cd extract
-          npm pack "@wxyc/shared@${{ inputs.package-version }}" --silent
+          npm pack "@wxyc/shared@${PACKAGE_VERSION}" --silent
           tar -xzf wxyc-shared-*.tgz package/src/test-utils/charset-torture.json
-          ls -la package/src/test-utils/
 
       - name: Compare SHA-256 against the pinned hash
+        env:
+          EXPECTED_SHA: ${{ inputs.pinned-sha256 }}
         run: |
           bash wxyc-shared/scripts/check-corpus-drift.sh \
             extract/package/src/test-utils/charset-torture.json \
-            "${{ inputs.pinned-sha256 }}"
+            "${EXPECTED_SHA}"

--- a/README.md
+++ b/README.md
@@ -497,6 +497,40 @@ sha256sum -c tests/fixtures/charset-torture.json.sha256
 
 This is the documented fallback only — the npm-pack recipe is the v1 happy path.
 
+#### Drift guard CI
+
+Every consuming repo should add a one-job CI workflow that calls the reusable drift-guard at `WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml`. The job extracts `charset-torture.json` from the published `@wxyc/shared` tarball, hashes it, and compares against the consumer's pinned SHA-256 — failing CI loudly if the upstream corpus has moved.
+
+```yaml
+# .github/workflows/charset-corpus-drift.yml in the consuming repo
+name: Charset Corpus Drift
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 8 * * 1"  # Monday morning catches upstream bumps merged over the weekend
+
+jobs:
+  drift:
+    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
+    with:
+      pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a
+      # package-version: 'latest'  # optional; pin to a specific @wxyc/shared release if needed
+    secrets:
+      npm-token: ${{ secrets.GITHUB_TOKEN }}  # needs read:packages on the WXYC org
+```
+
+When the guard fails, the consumer's response is one of:
+
+1. **Bump the pin.** Read the diff in `WXYC/wxyc-shared`, copy the new SHA into `tests/fixtures/charset-torture.json.sha256`, re-run the local round-trip suite to confirm the new fixture still passes, and open a PR.
+2. **Freeze the pin for one release.** Add a comment in `tests/fixtures/charset-torture.json.sha256`:
+   ```
+   # corpus-pin-frozen reason: <why this consumer can't bump yet>
+   ```
+   The freeze is enforced by reviewers, not the workflow — keep the reason specific and link the follow-up issue.
+
 ### Adding a category or entry
 
 1. Edit `src/test-utils/charset-torture.json`.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:e2e:contracts": "vitest run --config vitest.e2e.config.ts tests/e2e-contracts.test.ts",
     "test:setup-script": "bats scripts/__tests__/setup-dev-environment.test.sh",
+    "test:drift-guard": "bats scripts/__tests__/check-corpus-drift.test.sh",
     "lint": "tsc --noEmit --declaration false --declarationMap false",
     "clean": "rm -rf dist",
     "generate": "npm run generate:typescript && npm run generate:python && npm run generate:swift && npm run generate:kotlin",

--- a/scripts/__tests__/check-corpus-drift.test.sh
+++ b/scripts/__tests__/check-corpus-drift.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+#
+# BATS tests for check-corpus-drift.sh.
+#
+# Run with: npm run test:drift-guard
+# Or directly: npx bats scripts/__tests__/check-corpus-drift.test.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/check-corpus-drift.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CORPUS_PATH="$REPO_ROOT/src/test-utils/charset-torture.json"
+
+# Pinned hash of the in-tree corpus. Bumped in lockstep with the test in
+# tests/charset-torture.test.ts.
+PINNED_SHA256='75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a'
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "exits 2 when called with no arguments" {
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "exits 2 when called with one argument" {
+    run "$SCRIPT_PATH" /tmp/whatever
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "exits 2 when the JSON path does not exist" {
+    run "$SCRIPT_PATH" "$TEST_TEMP_DIR/missing.json" "$PINNED_SHA256"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "exits 0 and prints OK when SHA matches" {
+    run "$SCRIPT_PATH" "$CORPUS_PATH" "$PINNED_SHA256"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+    [[ "$output" == *"$PINNED_SHA256"* ]]
+}
+
+@test "exits 1 and prints both SHAs when SHA does not match" {
+    local wrong='0000000000000000000000000000000000000000000000000000000000000000'
+    run "$SCRIPT_PATH" "$CORPUS_PATH" "$wrong"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"drift"* ]]
+    [[ "$output" == *"$wrong"* ]]
+    [[ "$output" == *"$PINNED_SHA256"* ]]
+}
+
+@test "drift output enumerates current categories with entry counts" {
+    local wrong='0000000000000000000000000000000000000000000000000000000000000000'
+    run "$SCRIPT_PATH" "$CORPUS_PATH" "$wrong"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"greek"* ]]
+    [[ "$output" == *"cyrillic"* ]]
+    [[ "$output" == *"mojibake_known"* ]]
+    [[ "$output" == *"entries"* ]]
+}
+
+@test "drift output names the bump procedure" {
+    local wrong='0000000000000000000000000000000000000000000000000000000000000000'
+    run "$SCRIPT_PATH" "$CORPUS_PATH" "$wrong"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"charset-torture.json.sha256"* ]]
+}

--- a/scripts/check-corpus-drift.sh
+++ b/scripts/check-corpus-drift.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Charset Torture Corpus Drift Guard
+#
+# Compares the SHA-256 of a charset-torture.json file against a pinned hash.
+# Used by the WX-1 reusable workflow at
+# .github/workflows/check-charset-corpus-drift.yml so consuming repos detect
+# upstream corpus changes before their per-repo round-trip tests start failing
+# for unexplained reasons.
+#
+# Usage:
+#   bash scripts/check-corpus-drift.sh <path-to-json> <expected-sha256>
+#
+# Exit codes:
+#   0 - hash matches the pin
+#   1 - hash does not match (drift)
+#   2 - error (missing arg, missing file)
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: check-corpus-drift.sh <path-to-charset-torture.json> <expected-sha256>
+
+Verifies that the file at <path> has the given SHA-256 hash. Use this from CI
+to detect upstream charset-torture corpus changes that would invalidate
+pinned per-repo round-trip fixtures.
+EOF
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+    exit 2
+fi
+
+JSON_PATH="$1"
+EXPECTED_SHA="$2"
+
+if [ ! -f "$JSON_PATH" ]; then
+    echo "error: corpus JSON not found at $JSON_PATH" >&2
+    exit 2
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA=$(sha256sum "$JSON_PATH" | awk '{print $1}')
+else
+    ACTUAL_SHA=$(shasum -a 256 "$JSON_PATH" | awk '{print $1}')
+fi
+
+if [ "$ACTUAL_SHA" = "$EXPECTED_SHA" ]; then
+    echo "OK: charset-torture.json SHA-256 matches the pinned hash ($EXPECTED_SHA)"
+    exit 0
+fi
+
+cat <<EOF
+::error::charset-torture corpus drift detected
+
+  Pinned SHA-256:    $EXPECTED_SHA
+  Published SHA-256: $ACTUAL_SHA
+
+Categories in the published corpus:
+EOF
+
+if command -v jq >/dev/null 2>&1; then
+    jq -r '.categories | to_entries[] | "  \(.key): \(.value | length) entries"' "$JSON_PATH"
+else
+    echo "  (jq not available; install jq for a per-category breakdown)"
+fi
+
+cat <<EOF
+
+Bump procedure:
+  1. Inspect the change at https://github.com/WXYC/wxyc-shared/blob/main/src/test-utils/charset-torture.json
+  2. Update tests/fixtures/charset-torture.json.sha256 in this repo to:
+       $ACTUAL_SHA
+  3. Re-run your repo's charset-torture round-trip suite against the new fixture
+  4. Open a PR; reviewers verify expected vs. surprise category changes
+
+To freeze the pin for one release with reviewer sign-off, add a comment in
+tests/fixtures/charset-torture.json.sha256:
+  # corpus-pin-frozen reason: <text>
+EOF
+
+exit 1

--- a/scripts/check-corpus-drift.sh
+++ b/scripts/check-corpus-drift.sh
@@ -19,7 +19,7 @@
 set -euo pipefail
 
 usage() {
-    cat <<'EOF'
+    cat >&2 <<'EOF'
 Usage: check-corpus-drift.sh <path-to-charset-torture.json> <expected-sha256>
 
 Verifies that the file at <path> has the given SHA-256 hash. Use this from CI


### PR DESCRIPTION
Closes #96. WX-1 M3.1 — Mojibake Prevention drift-guard milestone.

Builds on the M1 corpus shipped in #94 / [#93](https://github.com/WXYC/wxyc-shared/issues/93). Unblocks WX-1.3.2 (per-repo wiring across the 13 M2 consumer repos) and complements the open M2 per-repo CI hookup tickets.

## Summary

- Reusable workflow `.github/workflows/check-charset-corpus-drift.yml` (`workflow_call`) — consuming repos invoke with a `pinned-sha256` input. The job checks out this repo for the comparison script, runs `npm pack @wxyc/shared@<package-version>` (default `latest`), extracts `package/src/test-utils/charset-torture.json` from the tarball, hashes it, and fails CI on mismatch.
- `scripts/check-corpus-drift.sh` — comparison logic in a unit-testable shell script. Exit 0 on match, 1 on drift, 2 on usage / missing-file errors. The drift output names both SHAs, the per-category entry counts of the published corpus, and the bump-or-freeze procedure inline so the consumer's response is mechanical.
- `scripts/__tests__/check-corpus-drift.test.sh` — BATS suite (7 tests) covering happy-path, drift, missing-file, and missing-arg cases. Wired as `npm run test:drift-guard`.
- README — new "Drift guard CI" subsection under the Charset Torture Corpus section, with the consumer `uses:` snippet, the `secrets: npm-token` requirement (needs `read:packages` on the WXYC org), and the `# corpus-pin-frozen reason: <text>` freeze format.

## Test plan

- [x] `npm run test:drift-guard` — 7/7 BATS tests pass
- [x] `npm test` — 382/382 Vitest tests pass (no regressions)
- [x] `npm run lint` — clean
- [x] Reusable workflow YAML parses
- [ ] WX-1.3.2 will validate the workflow end-to-end by wiring it into the first consumer repo

## Notes

The workflow checks out this repo (`WXYC/wxyc-shared`) at the consumer-supplied `wxyc-shared-ref` (default `main`) so the comparison script and the published tarball stay decoupled — the script can evolve (e.g., richer diff output) without forcing a corpus republish.

The publish workflow does not currently upload `charset-torture.json` as a standalone GitHub Release asset, so the no-npm `curl` fallback documented in M1 still relies on a manual upload. If that becomes load-bearing for any consumer, that's its own follow-up.