### PR TITLE
chore: bump @wxyc/shared to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Cuts the first release containing the charset-torture corpus + TS wrapper ([#94](https://github.com/WXYC/wxyc-shared/pull/94)) and the reusable drift-guard workflow ([#97](https://github.com/WXYC/wxyc-shared/pull/97)).

## Why now

`npm pack @wxyc/shared@latest` currently returns the pre-corpus v0.9.0 tarball. This blocks every WX-1 M2 / M3.2 per-repo wiring (13 consumer repos), since the M3.2 drift-guard's first step is to extract `package/src/test-utils/charset-torture.json` from the latest published tarball.

## After merge

1. Push tag `v0.10.0` from this commit
2. `publish.yml` runs `npm publish` → @wxyc/shared@0.10.0 lands in GitHub Packages
3. M2 + M3.2 work can begin in `library-metadata-lookup` (then fan out)

## Test plan

- [x] No code changes; existing CI must stay green