### PR TITLE
corpus: NFC storage form + populate bidi_marks match form (v0.12.0)

### DIFF
--- a/.github/workflows/check-charset-corpus-drift.yml
+++ b/.github/workflows/check-charset-corpus-drift.yml
@@ -12,7 +12,7 @@ name: Charset Torture Corpus Drift Guard
 #     charset-corpus-drift:
 #       uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
 #       with:
-#         pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a
+#         pinned-sha256: 41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66
 #         # package-version: 'latest'  # optional; pins which @wxyc/shared release to fetch
 #       secrets:
 #         npm-token: ${{ secrets.GITHUB_TOKEN }}  # needs read:packages on WXYC org

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ jobs:
   drift:
     uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
     with:
-      pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a
+      pinned-sha256: 41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66
       # package-version: 'latest'  # optional; pin to a specific @wxyc/shared release if needed
     secrets:
       npm-token: ${{ secrets.GITHUB_TOKEN }}  # needs read:packages on the WXYC org

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/test-utils/charset-torture.json
+++ b/src/test-utils/charset-torture.json
@@ -4,8 +4,8 @@
     "version": 1,
     "schema": {
       "input": "Raw UTF-8 string the storage layer must round-trip losslessly.",
-      "expected_storage": "Canonical (mojibake-fixed) form. Equals input for non-mojibake categories.",
-      "expected_match_form": "Output of to_match_form(expected_storage). NFKD + strip combining marks + lowercase + Greek sigma fold + trim. Null when WX-2 has not formalized the rule for this script.",
+      "expected_storage": "Output of to_storage_form(input). ftfy-style mojibake repair, then NFC normalization, then ASCII whitespace trim. Equals input for clean NFC input; differs for mojibake (repaired) and NFD (re-NFC'd). Two byte forms of the same visual string canonicalize to one.",
+      "expected_match_form": "Output of to_match_form(expected_storage). NFKC + Unicode default-caseless casefold + strip combining marks + WXYC fold registry (sigma, ligatures) + strip Cf format chars except U+200D ZWJ + collapse internal whitespace + trim. Null when WX-2 has not formalized the rule for this script.",
       "expected_ascii_form": "Output of to_ascii_form(expected_storage). Lowercase ASCII transliteration. Null for scripts without a defined transliteration in v1.",
       "notes": "Why this entry exists; which encoding incident or hazard category it pins."
     },
@@ -279,23 +279,23 @@
       {
         "input": "Hello\u200EWorld",
         "expected_storage": "Hello\u200EWorld",
-        "expected_match_form": null,
+        "expected_match_form": "helloworld",
         "expected_ascii_form": "helloworld",
-        "notes": "U+200E LEFT-TO-RIGHT MARK embedded in ASCII. LRM is category Cf (Format), NOT M (Mark) — it is NOT stripped by NFKD + is_mark filter. Match-form behavior is undefined in v1 (WX-2 must decide whether to strip Cf characters)."
+        "notes": "U+200E LEFT-TO-RIGHT MARK embedded in ASCII. LRM is category Cf (Format), NOT M (Mark) — survives NFKD + is_mark filter. Match-form strips it (WX-2 charter: strip all Cf except U+200D ZWJ); storage preserves it for round-trip fidelity."
       },
       {
         "input": "Hello\u200FWorld",
         "expected_storage": "Hello\u200FWorld",
-        "expected_match_form": null,
+        "expected_match_form": "helloworld",
         "expected_ascii_form": "helloworld",
-        "notes": "U+200F RIGHT-TO-LEFT MARK. Same Cf-not-stripped hazard as LRM. Invisible character that survives most pipelines and corrupts visual rendering later."
+        "notes": "U+200F RIGHT-TO-LEFT MARK. Same Cf-not-stripped hazard as LRM; same charter resolution — match-form strips, storage preserves."
       },
       {
         "input": "\u202EReversed\u202C",
         "expected_storage": "\u202EReversed\u202C",
-        "expected_match_form": null,
+        "expected_match_form": "reversed",
         "expected_ascii_form": "reversed",
-        "notes": "U+202E RIGHT-TO-LEFT OVERRIDE + U+202C POP DIRECTIONAL FORMATTING. Spoofing-attack vector; must round-trip but should ideally be flagged on storage (out of scope for WX-1)."
+        "notes": "U+202E RIGHT-TO-LEFT OVERRIDE + U+202C POP DIRECTIONAL FORMATTING. Spoofing-attack vector — both are Cf, both stripped from match-form; storage preserves the bytes (write-boundary defense is WX-3 scope, not WX-1 corpus scope)."
       }
     ],
     "zwj": [
@@ -327,28 +327,28 @@
         "expected_storage": "café",
         "expected_match_form": "cafe",
         "expected_ascii_form": "cafe",
-        "notes": "NFC form: U+0063 U+0061 U+0066 U+00E9. Storage MUST preserve as-is (no silent re-normalization). Match-form folds to bare ASCII via NFKD + strip combining."
+        "notes": "NFC form: U+0063 U+0061 U+0066 U+00E9. Already canonical; storage form is a no-op. Match-form folds to bare ASCII via NFKC + casefold + strip combining."
       },
       {
         "input": "cafe\u0301",
-        "expected_storage": "cafe\u0301",
+        "expected_storage": "café",
         "expected_match_form": "cafe",
         "expected_ascii_form": "cafe",
-        "notes": "NFD form of café: U+0063 U+0061 U+0066 U+0065 U+0301. Visually identical to the NFC entry above; bytes differ. Both must round-trip; both must produce the same match form."
+        "notes": "NFD form of café (U+0063 U+0061 U+0066 U+0065 U+0301) — three codepoints, four bytes after NFC. Storage form NFC-normalizes to the precomposed form so two byte-distinct submissions of the same visual string canonicalize to one row at the catalog. Match form collides with the NFC entry above."
       },
       {
         "input": "ñ",
         "expected_storage": "ñ",
         "expected_match_form": "n",
         "expected_ascii_form": "n",
-        "notes": "NFC form: U+00F1. Single precomposed Spanish ñ."
+        "notes": "NFC form: U+00F1. Single precomposed Spanish ñ; storage form is a no-op."
       },
       {
         "input": "n\u0303",
-        "expected_storage": "n\u0303",
+        "expected_storage": "ñ",
         "expected_match_form": "n",
         "expected_ascii_form": "n",
-        "notes": "NFD form of ñ: U+006E + U+0303. Bytes differ from NFC entry; match form must collide."
+        "notes": "NFD form of ñ (U+006E + U+0303). Storage form NFC-normalizes to the precomposed U+00F1 — same canonicalization rule as café-NFD above. Match form collides with both NFC and NFD ñ entries."
       }
     ],
     "mojibake_known": [

--- a/tests/charset-torture.test.ts
+++ b/tests/charset-torture.test.ts
@@ -68,7 +68,7 @@ describe('charset-torture corpus shape', () => {
 describe('charset-torture corpus byte stability', () => {
   // Pinned so any edit to the JSON forces a coordinated downstream consumer
   // bump; see README "Charset Torture Corpus" for the bump procedure.
-  const PINNED_SHA256 = '75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a';
+  const PINNED_SHA256 = '41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66';
 
   it('SHA-256 of the JSON file matches the pinned hash', () => {
     const actual = createHash('sha256').update(readFileSync(corpusJsonPath)).digest('hex');
@@ -113,17 +113,31 @@ describe('charset-torture corpus content invariants', () => {
     }
   });
 
-  it('non-mojibake categories: expected_storage equals input (storage layer is passive)', () => {
-    const nonMojibake: CharsetTortureCategory[] = CHARSET_TORTURE_CATEGORIES.filter(
-      (c) => c !== 'mojibake_known',
+  it('storage form is a passthrough except for mojibake repair and NFD-to-NFC', () => {
+    // to_storage_form per WX-2 charter: ftfy-style mojibake repair + NFC + trim.
+    // The mojibake_known category exercises the repair leg; the normalization
+    // category exercises the NFC leg (NFD inputs canonicalize to NFC). All
+    // other categories are pure passthrough.
+    const passthrough: CharsetTortureCategory[] = CHARSET_TORTURE_CATEGORIES.filter(
+      (c) => c !== 'mojibake_known' && c !== 'normalization',
     );
-    for (const category of nonMojibake) {
+    for (const category of passthrough) {
       for (const entry of charsetTortureCorpus.categories[category]) {
         expect(
           entry.expected_storage,
           `${category}: ${JSON.stringify(entry.input)} input/storage divergence`,
         ).toBe(entry.input);
       }
+    }
+  });
+
+  it('normalization category: NFC inputs are passthrough; NFD inputs canonicalize to NFC', () => {
+    for (const entry of charsetTortureCorpus.categories.normalization) {
+      const nfc = entry.input.normalize('NFC');
+      expect(
+        entry.expected_storage,
+        `normalization: ${JSON.stringify(entry.input)} expected_storage must equal NFC(input)`,
+      ).toBe(nfc);
     }
   });
 


### PR DESCRIPTION
WX-2 normalizer charter implementation has moved from M1 design into M2 implementation (`wxyc-etl#82` — the first M2 PR — depends on this corpus update). Two changes follow.

## (1) NFC storage form — normalization category

NFD inputs in the `normalization` category now expect NFC bytes from `to_storage_form`. The storage form is the canonicalization point per the WX-2 charter; the earlier corpus copy (\"storage MUST preserve as-is\") was the conservative reading. The active reading wins because `to_match_form`'s NFKC step does not paper over duplicate rows at the catalog level — by then it's too late.

Behavior change for two entries:
| Input bytes | Old `expected_storage` | New `expected_storage` |
|---|---|---|
| NFD `café` | NFD `café` (unchanged) | NFC `café` |
| NFD `ñ` | NFD `ñ` (unchanged) | NFC `ñ` |

The `input` fields stay NFD — that's the load-bearing property under test.

## (2) bidi_marks match-form — populate \"undefined\" placeholders

The 3 `bidi_marks` entries had `expected_match_form: null` pending the WX-2.1.2 fold-registry decision (\"strip all Cf format chars except U+200D ZWJ\" — preserves ZWJ for emoji ZWJ sequences). Now populated:

| Input | New `expected_match_form` |
|---|---|
| `Hello‎World` (LRM) | `helloworld` |
| `Hello‏World` (RLM) | `helloworld` |
| `‮Reversed‬` (RLO+PDF) | `reversed` |

## Cross-cutting

Schema descriptions for `expected_storage` and `expected_match_form` refreshed to spell out the contract.

`tests/charset-torture.test.ts`:
- `PINNED_SHA256` updated to `41a18c5c…` (was `75a3395b…`).
- The \"non-mojibake = passthrough\" invariant split into two — passthrough categories excluding `normalization`, plus a new `normalization` invariant asserting `expected_storage == NFC(input)`.

## Versioning

Bumped to 0.12.0 so this corpus update ships separately from the still-pending v0.11.0 identity-block release (1a27f52). Tag v0.11.0 first, then v0.12.0.

## Cascade

Once 0.12.0 publishes, 14 consumer repos need PRs:
- Bump `pinned-sha256` and `package-version` in `.github/workflows/charset-corpus-drift.yml`.
- Re-vendor `tests/fixtures/charset-torture.json` and update the `.sha256` file.
- Add 3 `bidi_marks` `[<consumer>:no-match-form]` xfail entries (none of them strip Cf chars in their normalizers today; M3 of the WX-2 plan migrates each consumer to `to_match_form`, removing the xfails).

Consumer repos: wxyc-etl, library-metadata-lookup, dj-site, archive, request-o-matic, semantic-index, discogs-etl, musicbrainz-cache, wikidata-json-filter, catalog-audits, tubafrenzy, Backend-Service, wxyc-archive-search, discogs-xml-converter.

## Test plan

- [x] `npm test` — all 391 tests pass locally
- [ ] After tag v0.12.0 publishes, verify a consumer's drift-guard CI fails on the old pin and passes after the bump