### PR TITLE
api.yaml: add HealthCheckResponse + ReadinessResponse (Phase C)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.2.0
+  version: 1.3.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -92,6 +92,59 @@ components:
         time:
           type: string
           description: Time string (e.g., "14:00")
+
+    HealthCheckResponse:
+      type: object
+      description: |
+        Liveness response shape for `GET /health` (and equivalent) endpoints.
+        Cross-language contract owned by `wxyc-fastapi` (Python) and adopted
+        by Backend-Service (Node) via generated TS types.
+
+        `additionalProperties: true` lets services attach extra fields without
+        breaking consumers; semantic-index, for example, returns `artist_count`
+        alongside `status`.
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - healthy
+            - degraded
+            - unhealthy
+          description: |
+            Service-reported health. `healthy` = fully operational; `degraded`
+            = serving but with reduced capability; `unhealthy` = should not
+            receive traffic.
+      additionalProperties: true
+
+    ReadinessResponse:
+      description: |
+        Readiness response shape for `GET /ready` (and equivalent) endpoints.
+        Extends `HealthCheckResponse` with a per-dependency status map.
+        Each entry in `services` reports the live state of one external
+        dependency (database, upstream HTTP service, queue, etc.).
+
+        Status values:
+          - `ok`          — dependency reachable and responsive
+          - `unavailable` — dependency reachable but reporting an error,
+                            or the connection itself failed
+          - `timeout`     — dependency exceeded the readiness probe deadline
+      allOf:
+        - $ref: '#/components/schemas/HealthCheckResponse'
+        - type: object
+          required:
+            - services
+          properties:
+            services:
+              type: object
+              description: Per-dependency readiness map keyed by dependency name.
+              additionalProperties:
+                type: string
+                enum:
+                  - ok
+                  - unavailable
+                  - timeout
 
     Genre:
       type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -433,4 +433,52 @@ describe('OpenAPI Specification', () => {
       expect(spec.components.securitySchemes?.BearerAuth).toBeDefined();
     });
   });
+
+  describe('Healthcheck Schemas (wxyc-fastapi Phase C)', () => {
+    it('should define HealthCheckResponse with required status enum and additionalProperties', () => {
+      const schema = spec.components.schemas.HealthCheckResponse as {
+        type: string;
+        required: string[];
+        properties: Record<string, { type?: string; enum?: string[] }>;
+        additionalProperties?: boolean;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+      expect(schema.required).toEqual(['status']);
+      expect(schema.properties.status.type).toBe('string');
+      expect(schema.properties.status.enum).toEqual(['healthy', 'degraded', 'unhealthy']);
+      // Consumers may extend (e.g., semantic-index includes artist_count)
+      expect(schema.additionalProperties).toBe(true);
+    });
+
+    it('should define ReadinessResponse extending HealthCheckResponse with required services map', () => {
+      const schema = spec.components.schemas.ReadinessResponse as {
+        allOf: Array<{
+          $ref?: string;
+          type?: string;
+          required?: string[];
+          properties?: Record<
+            string,
+            {
+              type?: string;
+              additionalProperties?: { type?: string; enum?: string[] };
+            }
+          >;
+        }>;
+      };
+      expect(schema).toBeDefined();
+      expect(Array.isArray(schema.allOf)).toBe(true);
+      expect(schema.allOf).toHaveLength(2);
+
+      const [base, extension] = schema.allOf;
+      expect(base.$ref).toBe('#/components/schemas/HealthCheckResponse');
+
+      expect(extension.type).toBe('object');
+      expect(extension.required).toEqual(['services']);
+      const services = extension.properties?.services;
+      expect(services?.type).toBe('object');
+      expect(services?.additionalProperties?.type).toBe('string');
+      expect(services?.additionalProperties?.enum).toEqual(['ok', 'unavailable', 'timeout']);
+    });
+  });
 });

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -17,6 +17,8 @@ import {
   type ArtistMetadataResponse,
   type TrackListItem,
   type ReconciledIdentity,
+  type HealthCheckResponse,
+  type ReadinessResponse,
   RotationBin,
   DayOfWeek,
   Genre,
@@ -312,6 +314,58 @@ describe('Generated TypeScript Types', () => {
 
       expect(identity.discogs_artist_id).toBe(7894);
       expect(identity.musicbrainz_artist_id).toBeNull();
+    });
+  });
+
+  describe('HealthCheckResponse', () => {
+    it('should accept the three documented status values', () => {
+      const healthy: HealthCheckResponse = { status: 'healthy' };
+      const degraded: HealthCheckResponse = { status: 'degraded' };
+      const unhealthy: HealthCheckResponse = { status: 'unhealthy' };
+
+      expect(healthy.status).toBe('healthy');
+      expect(degraded.status).toBe('degraded');
+      expect(unhealthy.status).toBe('unhealthy');
+    });
+
+    it('should accept arbitrary extension properties (additionalProperties: true)', () => {
+      // semantic-index extends the base shape with `artist_count`; the type
+      // must accept that without type errors.
+      const extended: HealthCheckResponse = {
+        status: 'healthy',
+        artist_count: 12345,
+        version: 'abc123',
+      };
+
+      expect(extended.status).toBe('healthy');
+      expect(extended.artist_count).toBe(12345);
+    });
+  });
+
+  describe('ReadinessResponse', () => {
+    it('should require status and a services map', () => {
+      const ready: ReadinessResponse = {
+        status: 'healthy',
+        services: {
+          postgres: 'ok',
+          discogs: 'unavailable',
+          spotify: 'timeout',
+        },
+      };
+
+      expect(ready.status).toBe('healthy');
+      expect(ready.services.postgres).toBe('ok');
+      expect(ready.services.discogs).toBe('unavailable');
+      expect(ready.services.spotify).toBe('timeout');
+    });
+
+    it('should allow an empty services map', () => {
+      const ready: ReadinessResponse = {
+        status: 'degraded',
+        services: {},
+      };
+
+      expect(ready.services).toEqual({});
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `HealthCheckResponse` and `ReadinessResponse` to `api.yaml` so the cross-language health/readiness shape lives in one place. Consumers in any language inherit it via `@wxyc/shared` codegen.
- `HealthCheckResponse`: `{ status: healthy | degraded | unhealthy }` with `additionalProperties: true` (semantic-index already returns `artist_count` alongside `status`; future services may extend similarly).
- `ReadinessResponse`: `allOf` extends `HealthCheckResponse` with a required `services` map keyed by dependency name; values are constrained to `ok | unavailable | timeout` per the wxyc-fastapi probe contract.
- Bumps `api.yaml` 1.2.0 -> 1.3.0 and `package.json` 0.12.0 -> 0.13.0 (both additive minors).

## Test plan

- [x] Red: api-spec.test.ts assertions for both schemas fail before edit
- [x] Green: api-spec.test.ts + generated-types.test.ts pass after schemas added and types regenerated
- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] `npm run build` clean; `dist/dtos/index.d.ts` re-exports `HealthCheckResponse` and `ReadinessResponse`
- [x] `npm run check:breaking` reports no breaking changes
- [ ] CI green on push (workflow runs codegen + build + lint + test)

## Context

Phase C of the wxyc-fastapi consolidation: the shared FastAPI package has the Python healthcheck routers; this PR defines the response contract so non-Python services can adopt the same shape via generated types.

Closes https://github.com/WXYC/wxyc-shared/issues/108

## Related

- Epic: https://github.com/WXYC/wxyc-fastapi/issues/1
- Phase C epic: https://github.com/WXYC/wxyc-fastapi/issues/13
- Backend-Service adoption (downstream, separate PR): https://github.com/WXYC/Backend-Service/issues/804
- In-flight release-tag enforcement (referenced in #108): https://github.com/WXYC/wxyc-shared/issues/105