### PR TITLE
api.yaml: add TrackMatchHint + matched_via + track_position (catalog-track-search E7-1)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -268,6 +268,14 @@ components:
             artist_wikipedia_url:
               type: string
               nullable: true
+            track_position:
+              type: string
+              nullable: true
+              description: >
+                Track position on the release (e.g., "A1", "B2", "5"). Populated when the
+                flowsheet entry was created via the dj-site picker after release selection
+                (catalog-track-search plan §5.3 / Track 3). String-typed to match Discogs's
+                `release_track.position`. Null for free-text entries and legacy rows.
 
     FlowsheetSongEntry:
       description: Song entry in the flowsheet
@@ -301,6 +309,15 @@ components:
               type: integer
             rotation_bin:
               $ref: '#/components/schemas/RotationBin'
+            track_position:
+              type: string
+              nullable: true
+              description: >
+                Track position on the release (e.g., "A1", "B2", "5"). Optional;
+                populated by the dj-site picker when a release with a resolvable
+                tracklist is chosen (catalog-track-search plan §5.3 / Track 3).
+                Free-text `track_title` remains the source of truth; this field is
+                additive metadata for future enrichment + analytics.
 
     FlowsheetShowBlockEntry:
       description: Show block entry (start or end of a DJ's show)
@@ -1006,6 +1023,15 @@ components:
           type: string
           nullable: true
           description: Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.
+        matched_via:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackMatchHint'
+          description: >
+            Populated by Backend's catalog `/library/` search when a track-title match
+            (CTA or LML proxy fallback) drove this release into the results, per
+            catalog-track-search plan §5.1. Empty or absent on normal artist/album hits.
+            Backward-compatible — existing consumers ignore the field.
 
     AddAlbumRequest:
       type: object
@@ -2165,6 +2191,15 @@ components:
           $ref: '#/components/schemas/DiscogsMatchResult'
         reconciled_identity:
           $ref: '#/components/schemas/ReconciledIdentity'
+        matched_via:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackMatchHint'
+          description: >
+            Populated when a track-title match (LML's new SONG_AS_TRACK strategy)
+            drove this release into the results, per catalog-track-search plan §5.1.
+            Empty or absent when the release matched via artist/album strategies.
+            Backward-compatible — existing consumers ignore the field.
 
     CacheStats:
       type: object
@@ -2972,6 +3007,64 @@ components:
     # Library Search Types
     # ============================
 
+    TrackMatchHint:
+      type: object
+      description: >
+        Populated on library search / lookup result items when a track-title match drove
+        the inclusion of this release. Per the catalog-track-search plan §5.2
+        (`https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#52-trackmatchhint-schema`),
+        the `source` field distinguishes the underlying match pathway so consumers can
+        render appropriate UX (e.g., qualitative "matched via Discogs (verified)" tooltips)
+        and downstream audits can break coverage down by source.
+      required:
+        - title
+        - source
+      properties:
+        title:
+          type: string
+          description: The track title as stored in the source.
+        artist_credit:
+          type: string
+          nullable: true
+          description: >
+            Per-track artist credit (for compilations, where each track may credit a
+            distinct artist). Null for non-comp tracks where the release-level artist
+            applies.
+        position:
+          type: string
+          nullable: true
+          description: >
+            Track position on the release as stored in the source (e.g., "A1", "B2", "5").
+            String-typed to match Discogs's `release_track.position` shape, which uses
+            vinyl-side notation for LP releases. Null when position is unknown or
+            inapplicable (e.g., CTA-derived matches that don't track position).
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+          nullable: true
+          description: >
+            Confidence score for the underlying identity match (sourced from
+            `library_identity.confidence` post-`#25`, from `canonical_entity_confidence`
+            pre-`#25`, or 1.0 for curated CTA matches). Used by the UI to render
+            qualitative tooltips on the matched-via chip per plan §13 Q7.
+        source:
+          type: string
+          enum:
+            - cta
+            - discogs_release
+            - discogs_master
+            - library_identity
+          description: >
+            Provenance of the match.
+            - `cta`: BS `compilation_track_artist` lookup (Track 1; BS-local).
+            - `discogs_release`: LML matched via Discogs release_id (Track 2; pre-`#25`
+              direct CEI release hit OR post-`#25` `library_identity.discogs_release_id`).
+            - `discogs_master`: LML matched via Discogs master_id (Track 2; the more
+              common pre-`#25` path, since 90% of CEI rows are master-format).
+            - `library_identity`: explicit substrate match (Track 2 post-`#25` when LML's
+              pipeline exposes this distinction in its response).
+
     LibrarySearchItem:
       type: object
       description: A single item from LML's library catalog search.
@@ -3016,6 +3109,15 @@ components:
         library_url:
           type: string
           description: URL to the release on wxyc.info
+        matched_via:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackMatchHint'
+          description: >
+            Populated when a track-title match drove this release into the results
+            (catalog-track-search plan §5.1). Empty or absent when the release matched
+            on artist / title normally. Backward-compatible — existing consumers ignore
+            the field.
 
     LibrarySearchResponse:
       type: object

--- a/api.yaml
+++ b/api.yaml
@@ -3007,15 +3007,32 @@ components:
     # Library Search Types
     # ============================
 
+    TrackMatchSource:
+      type: string
+      enum:
+        - cta
+        - discogs_release
+        - discogs_master
+        - library_identity
+      description: >
+        Provenance of a TrackMatchHint. `cta` indicates Backend's local
+        `compilation_track_artist` lookup (Track 1, BS-local). `discogs_release` indicates
+        LML matched via a Discogs release_id (Track 2; pre-cross-cache-identity, this is a
+        direct CEI release-format hit; post-cross-cache-identity, it's a
+        `library_identity.discogs_release_id` hit). `discogs_master` indicates LML matched
+        via a Discogs master_id (Track 2; the more common pre-cross-cache-identity path,
+        since ~90% of CEI rows are master-format). `library_identity` indicates an
+        explicit substrate match — emitted post-cross-cache-identity when LML's pipeline
+        exposes the distinction in its response.
+
     TrackMatchHint:
       type: object
       description: >
         Populated on library search / lookup result items when a track-title match drove
-        the inclusion of this release. Per the catalog-track-search plan §5.2
-        (`https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#52-trackmatchhint-schema`),
-        the `source` field distinguishes the underlying match pathway so consumers can
-        render appropriate UX (e.g., qualitative "matched via Discogs (verified)" tooltips)
-        and downstream audits can break coverage down by source.
+        the inclusion of this release into the results. The `source` field distinguishes
+        the underlying match pathway so consumers can render appropriate UX (e.g.,
+        qualitative "matched via Discogs (verified)" tooltips) and downstream audits can
+        break coverage down by source.
       required:
         - title
         - source
@@ -3037,33 +3054,22 @@ components:
             Track position on the release as stored in the source (e.g., "A1", "B2", "5").
             String-typed to match Discogs's `release_track.position` shape, which uses
             vinyl-side notation for LP releases. Null when position is unknown or
-            inapplicable (e.g., CTA-derived matches that don't track position).
+            inapplicable (e.g., CTA-derived matches, since `compilation_track_artist` has
+            no position column).
         confidence:
           type: number
           minimum: 0
           maximum: 1
           nullable: true
           description: >
-            Confidence score for the underlying identity match (sourced from
-            `library_identity.confidence` post-`#25`, from `canonical_entity_confidence`
-            pre-`#25`, or 1.0 for curated CTA matches). Used by the UI to render
-            qualitative tooltips on the matched-via chip per plan §13 Q7.
+            Confidence score for the underlying identity match. Sourced from
+            `library_identity.confidence` post-cross-cache-identity, from
+            `canonical_entity_confidence` pre-cross-cache-identity, or fixed at 1.0 for
+            `cta`-source hits (the curated VA-disambiguation data is treated as
+            authoritative). Used by the UI to render qualitative tooltips on the chip;
+            consumers should not assume null for `cta` source.
         source:
-          type: string
-          enum:
-            - cta
-            - discogs_release
-            - discogs_master
-            - library_identity
-          description: >
-            Provenance of the match.
-            - `cta`: BS `compilation_track_artist` lookup (Track 1; BS-local).
-            - `discogs_release`: LML matched via Discogs release_id (Track 2; pre-`#25`
-              direct CEI release hit OR post-`#25` `library_identity.discogs_release_id`).
-            - `discogs_master`: LML matched via Discogs master_id (Track 2; the more
-              common pre-`#25` path, since 90% of CEI rows are master-format).
-            - `library_identity`: explicit substrate match (Track 2 post-`#25` when LML's
-              pipeline exposes this distinction in its response).
+          $ref: '#/components/schemas/TrackMatchSource'
 
     LibrarySearchItem:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "vitest": "^2.0.0",
         "yaml": "^2.6.0"
       },
+      "engines": {
+        "node": ">=24"
+      },
       "peerDependencies": {
         "better-auth": "^1.5.0",
         "typescript": "^5.0.0 || ^6.0.0"

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -8,7 +8,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   type FlowsheetEntryResponse,
+  type FlowsheetSongEntry,
   type Album,
+  type AlbumSearchResult,
   type Label,
   type DJ,
   type ScheduleShift,
@@ -19,12 +21,16 @@ import {
   type ReconciledIdentity,
   type HealthCheckResponse,
   type ReadinessResponse,
+  type LibrarySearchItem,
+  type LookupResultItem,
+  type TrackMatchHint,
   RotationBin,
   DayOfWeek,
   Genre,
   Format,
   RequestStatus,
   MetadataSource,
+  TrackMatchSource,
 } from '../src/generated/models/index.js';
 
 describe('Generated TypeScript Types', () => {
@@ -405,6 +411,174 @@ describe('Generated TypeScript Types', () => {
       expect(MetadataSource.spotify).toBe('spotify');
       expect(MetadataSource.cache).toBe('cache');
       expect(MetadataSource.none).toBe('none');
+    });
+
+    it('should define TrackMatchSource values', () => {
+      expect(TrackMatchSource.cta).toBe('cta');
+      expect(TrackMatchSource.discogs_release).toBe('discogs_release');
+      expect(TrackMatchSource.discogs_master).toBe('discogs_master');
+      expect(TrackMatchSource.library_identity).toBe('library_identity');
+    });
+  });
+
+  describe('TrackMatchHint (catalog-track-search §5.2)', () => {
+    it('should accept a minimal object with only required fields', () => {
+      const hint: TrackMatchHint = {
+        title: 'VI Scose Poise',
+        source: TrackMatchSource.discogs_master,
+      };
+
+      expect(hint.title).toBe('VI Scose Poise');
+      expect(hint.source).toBe('discogs_master');
+    });
+
+    it('should accept all optional fields', () => {
+      const hint: TrackMatchHint = {
+        title: 'In a Sentimental Mood',
+        artist_credit: 'Duke Ellington & John Coltrane',
+        position: 'A1',
+        confidence: 0.95,
+        source: TrackMatchSource.cta,
+      };
+
+      expect(hint.position).toBe('A1');
+      expect(hint.confidence).toBe(0.95);
+      expect(hint.artist_credit).toBe('Duke Ellington & John Coltrane');
+    });
+
+    it('should accept null for nullable optional fields', () => {
+      const hint: TrackMatchHint = {
+        title: 'la paradoja',
+        artist_credit: null,
+        position: null,
+        confidence: null,
+        source: TrackMatchSource.discogs_release,
+      };
+
+      expect(hint.artist_credit).toBeNull();
+      expect(hint.position).toBeNull();
+      expect(hint.confidence).toBeNull();
+    });
+  });
+
+  describe('matched_via on result schemas (catalog-track-search §5.1)', () => {
+    it('AlbumSearchResult.matched_via is optional and typed as TrackMatchHint[]', () => {
+      const withoutHint: AlbumSearchResult = {
+        id: 60359,
+        add_date: '2026-05-12T00:00:00Z',
+        album_title: 'Confield',
+        artist_name: 'Autechre',
+        code_letters: 'AU',
+        code_number: 8,
+        code_artist_number: 3,
+        format_name: 'CD',
+        genre_name: 'Electronic',
+        label: 'Warp Records',
+      };
+
+      const withHint: AlbumSearchResult = {
+        ...withoutHint,
+        matched_via: [
+          { title: 'VI Scose Poise', source: TrackMatchSource.discogs_master },
+        ],
+      };
+
+      expect(withoutHint.matched_via).toBeUndefined();
+      expect(withHint.matched_via?.[0].title).toBe('VI Scose Poise');
+    });
+
+    it('LibrarySearchItem.matched_via is optional and typed as TrackMatchHint[]', () => {
+      const item: LibrarySearchItem = {
+        id: 65880,
+        title: 'Confield',
+        artist: 'Autechre',
+        matched_via: [
+          { title: 'VI Scose Poise', source: TrackMatchSource.discogs_master, confidence: 0.85 },
+        ],
+      };
+
+      expect(item.matched_via?.[0].source).toBe('discogs_master');
+    });
+
+    it('LookupResultItem.matched_via is optional and typed as TrackMatchHint[]', () => {
+      const result: LookupResultItem = {
+        library_item: {
+          id: 60359,
+          title: 'Confield',
+          artist: 'Autechre',
+        },
+        matched_via: [
+          { title: 'VI Scose Poise', source: TrackMatchSource.library_identity, confidence: 0.92 },
+        ],
+      };
+
+      expect(result.matched_via?.[0].source).toBe('library_identity');
+    });
+
+    it('matched_via supports multiple hints per release (e.g., comps with two matching tracks)', () => {
+      const item: LibrarySearchItem = {
+        id: 6468,
+        title: "Jazz: The 50's, Volume I",
+        artist: 'Various Artists',
+        matched_via: [
+          { title: 'In a Sentimental Mood', artist_credit: 'Duke Ellington', source: TrackMatchSource.cta, confidence: 1.0 },
+          { title: 'Whistling Away The Dark', artist_credit: 'Abbey Lincoln', source: TrackMatchSource.cta, confidence: 1.0 },
+        ],
+      };
+
+      expect(item.matched_via?.length).toBe(2);
+    });
+  });
+
+  describe('track_position on flowsheet schemas (catalog-track-search §5.3)', () => {
+    it('FlowsheetSongEntry accepts optional track_position', () => {
+      const withoutPosition: FlowsheetSongEntry = {
+        id: 12345,
+        play_order: 100,
+        show_id: 42,
+        track_title: 'VI Scose Poise',
+        artist_name: 'Autechre',
+        album_title: 'Confield',
+        record_label: 'Warp Records',
+        request_flag: false,
+      };
+
+      const withPosition: FlowsheetSongEntry = {
+        ...withoutPosition,
+        track_position: '2',
+      };
+
+      expect(withoutPosition.track_position).toBeUndefined();
+      expect(withPosition.track_position).toBe('2');
+    });
+
+    it('FlowsheetSongEntry accepts null track_position', () => {
+      const entry: FlowsheetSongEntry = {
+        id: 12345,
+        play_order: 100,
+        show_id: 42,
+        track_title: 'VI Scose Poise',
+        artist_name: 'Autechre',
+        album_title: 'Confield',
+        record_label: 'Warp Records',
+        request_flag: false,
+        track_position: null,
+      };
+
+      expect(entry.track_position).toBeNull();
+    });
+
+    it('FlowsheetEntryResponse accepts vinyl-style track_position strings', () => {
+      const entry: FlowsheetEntryResponse = {
+        id: 12345,
+        play_order: 100,
+        show_id: 42,
+        request_flag: false,
+        track_title: 'In a Sentimental Mood',
+        track_position: 'A1',
+      };
+
+      expect(entry.track_position).toBe('A1');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds three additive schema changes to `api.yaml` to unblock the rest of catalog-track-search:

- New **`TrackMatchHint`** schema — `(title, artist_credit, position, confidence, source)` where `source` is one of `cta | discogs_release | discogs_master | library_identity`.
- Optional **`matched_via: TrackMatchHint[]`** on three result schemas: `AlbumSearchResult` (Backend's `/library/` catalog response), `LibrarySearchItem` (LML's `/library/search` + Backend's `/proxy/library/search`), and `LookupResultItem` (LML's `/lookup` pipeline). Populated when a track-title match drove the inclusion; empty / absent on normal artist+album hits.
- Optional **`track_position: string`** on `FlowsheetEntryResponse` + `FlowsheetSongEntry` — written by the dj-site flowsheet picker (Track 3) when the DJ selects a track from the post-release-pick tracklist. String-typed to match Discogs's `release_track.position` shape ("A1", "B2", "5") — same typing already used by `BulkResolveTrackIdentity`.

All additions are optional / nullable. No version bump (api.yaml already at 1.3.0).

## Plan reference

[catalog-track-search §5](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#5-api-contract-changes). Note: plan §5.1 refers to `AlbumSearchResultJSON`; the actual schema is `AlbumSearchResult` (the JSON suffix was dropped at some point in api.yaml's evolution). Small plan-doc fixup is worth filing as a followup but not load-bearing.

## Test plan

- [x] `npm run check:breaking` — no breaking changes detected.
- [x] `npm run generate:typescript` — regen clean; `TrackMatchHint`, `matched_via`, `track_position` all present in `src/generated/openapi-types.d.ts`.
- [x] `npm test` — 397 / 397 tests pass.
- [x] `npm run lint` — `tsc` clean.

## Related

Closes WXYC/wxyc-shared#112. Unblocks the rest of Epic E7:

- WXYC/wxyc-shared#113 (E7-2) — publish v1.3.0 release tag (or whatever the next npm version cut is) once this merges.
- WXYC/Backend-Service#837 (E7-3) — bump `@wxyc/shared` consumer side.
- WXYC/dj-site#503 (E7-4) — same.
- WXYC/library-metadata-lookup#298 (E7-5) — regenerate `generated/api_models.py`.

And transitively the LML strategy work in [E2-1](https://github.com/WXYC/library-metadata-lookup/issues/301), which needs `matched_via` on `LookupResponse` to emit results.