### PR TITLE
ci: pin oasdiff-action to v0.0.47 SHA

### DIFF
--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check for breaking changes
         if: steps.base.outputs.skip != 'true'
         id: diff
-        uses: oasdiff/oasdiff-action/breaking@main
+        uses: oasdiff/oasdiff-action/breaking@6147a58e5d1249a12f42fc864ab791d571a30015 # v0.0.47
         with:
           base: api-base.yaml
           revision: api.yaml


### PR DESCRIPTION
## Summary

- Replaces `oasdiff/oasdiff-action/breaking@main` with the SHA of `v0.0.47`, with a trailing version comment for review legibility
- One-line change to `.github/workflows/breaking-changes.yml`

Phase 5 of the WXYC org-wide GitHub Actions hardening project.

Closes #120.

## Test plan

The `breaking-changes.yml` workflow only runs on PRs that touch `api.yaml`, so this PR will not exercise it. Verified by diff inspection:

- [x] Diff is one line, replacing `@main` with `@<sha> # v0.0.47`
- [x] SHA matches `v0.0.47` ref on oasdiff/oasdiff-action (`6147a58e5d1249a12f42fc864ab791d571a30015`)