### PR TITLE
api.yaml: add /library/query endpoint for card catalog query builder (v1.4.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.3.0
+  version: 1.4.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -510,6 +510,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PlaylistSearchResult'
+        total:
+          type: integer
+        page:
+          type: integer
+        totalPages:
+          type: integer
+
+    LibraryQueryResponse:
+      type: object
+      required:
+        - results
+        - total
+        - page
+        - totalPages
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlbumSearchResult'
         total:
           type: integer
         page:
@@ -3906,6 +3925,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Album'
+
+  /library/query:
+    get:
+      summary: Query the card catalog with a parsed query string and filters
+      description: |
+        Search the library by a query-builder-style expression (the same grammar
+        as `/flowsheet/search`: `artist:foo AND album:"hello" NOT label:bar`,
+        with exact-match via double quotes). Combines parsed conditions with
+        optional catalog filters (`on_streaming`, `genre`, `format`) via `AND`.
+        Returns a paginated envelope.
+      security: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Search query (supports AND, OR, NOT, exact phrases). Empty/omitted returns recent additions.
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 100
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: [artist, album, plays, date]
+            default: album
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: asc
+        - name: on_streaming
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: When set, restricts results to releases with this streaming-availability state.
+        - name: genre
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by genre name (matches `library_artist_view.genre_name`).
+        - name: format
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by format name (matches `library_artist_view.format_name`).
+      responses:
+        '200':
+          description: Paginated catalog search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LibraryQueryResponse'
 
   /library/rotation:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -3947,15 +3947,20 @@ paths:
           in: query
           schema:
             type: integer
+            minimum: 0
             default: 0
         - name: limit
           in: query
           schema:
             type: integer
-            default: 50
+            minimum: 1
             maximum: 100
+            default: 50
         - name: sort
           in: query
+          description: |
+            Sort field. `date` means the catalog-addition date — when the album was
+            added to the WXYC library — not flowsheet play date.
           schema:
             type: string
             enum: [artist, album, plays, date]
@@ -3971,19 +3976,26 @@ paths:
           required: false
           schema:
             type: boolean
-          description: When set, restricts results to releases with this streaming-availability state.
+          description: |
+            When omitted, all releases are returned regardless of streaming state.
+            `on_streaming=true` returns only releases known to be on at least one
+            streaming service (`AlbumSearchResult.on_streaming = true`); releases
+            whose streaming state is unknown (`null`) are excluded.
+            `on_streaming=false` returns the complement — releases known to be
+            absent from streaming (`AlbumSearchResult.on_streaming = false`),
+            again excluding unknowns.
         - name: genre
           in: query
           required: false
           schema:
             type: string
-          description: Filter by genre name (matches `library_artist_view.genre_name`).
+          description: Filter by genre name (matches `AlbumSearchResult.genre_name`).
         - name: format
           in: query
           required: false
           schema:
             type: string
-          description: Filter by format name (matches `library_artist_view.format_name`).
+          description: Filter by format name (matches `AlbumSearchResult.format_name`).
       responses:
         '200':
           description: Paginated catalog search results

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Closes #125.

## Summary

- Adds \`GET /library/query\` path declaration in \`api.yaml\`, mirroring \`/flowsheet/search\`'s shape (\`q\`, \`page\`, \`limit\`, \`sort\`, \`order\`) plus catalog filter params (\`on_streaming\`, \`genre\`, \`format\`).
- Adds \`LibraryQueryResponse\` schema (\`{ results: AlbumSearchResult[], total, page, totalPages }\`); reuses existing \`AlbumSearchResult\` verbatim.
- Bumps \`@wxyc/shared\` from \`1.3.0\` to \`1.4.0\` (additive change → minor bump). Updates \`info.version\` in \`api.yaml\` to match.

This is **PR 1a** of the three-PR catalog-query-builder rollout (plan: [\`dj-site/plans/catalog-query-builder.md\`](https://github.com/WXYC/dj-site/blob/main/plans/catalog-query-builder.md)). Backend-Service handler (PR 1b) and dj-site UI (PR 2) follow after this is published.

## Why \`/library/query\` (not \`/library/search\`)

\`/library/search\` is already mounted to \`requestLineController.searchLibraryEndpoint\` for the request-line feature — different consumers, auth profile, and response shape. We pick \`/library/query\` to avoid the routing collision while keeping the symmetry with \`/flowsheet/search\` at the semantic level.

## Why \`LibraryQueryResponse\` (not \`LibrarySearchResponse\`)

\`LibrarySearchResponse\` already exists as the response for \`/library/search\` (uses \`LibrarySearchItem\`, no \`page\`/\`totalPages\`). The YAML parser caught the duplicate-key collision on the first regen attempt. \`LibraryQueryResponse\` matches the endpoint name and leaves the existing schema untouched.

## Verification

- [x] \`npm run generate:typescript\` regenerates \`src/generated/openapi-types.d.ts\` cleanly; both the path and schema appear
- [x] \`npm run lint\` passes
- [x] \`npm test\` — 408 / 408 tests pass
- [x] \`npm run check:breaking\` — no breaking changes detected

## Test plan

- [ ] CI green
- [ ] After merge, publish \`@wxyc/shared@1.4.0\` to GitHub Packages so Backend-Service (PR 1b) can pin