### PR TITLE
test-utils: cover segue, on_streaming, and rotation_bin variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/test-utils/wxyc-example-data.json
+++ b/src/test-utils/wxyc-example-data.json
@@ -181,7 +181,8 @@
       "track_title": "la paradoja",
       "record_label": "Sonamos",
       "request_flag": false,
-      "album_id": 9001
+      "album_id": 9001,
+      "rotation_bin": "H"
     },
     {
       "id": 10002,
@@ -192,7 +193,8 @@
       "track_title": "Back, Baby",
       "record_label": "Drag City",
       "request_flag": false,
-      "album_id": 9004
+      "album_id": 9004,
+      "rotation_bin": "M"
     },
     {
       "id": 10003,
@@ -203,7 +205,8 @@
       "track_title": "Call Your Name",
       "record_label": "self-released",
       "request_flag": false,
-      "album_id": 9005
+      "album_id": 9005,
+      "rotation_bin": "L"
     },
     {
       "id": 10004,
@@ -224,7 +227,8 @@
       "track_title": "Midnight Sun",
       "record_label": "ATO Records",
       "request_flag": false,
-      "album_id": 9006
+      "album_id": 9006,
+      "rotation_bin": "S"
     },
     {
       "id": 10006,
@@ -247,6 +251,18 @@
       "record_label": "TAL",
       "request_flag": false,
       "album_id": 9008
+    },
+    {
+      "id": 10008,
+      "show_id": 1,
+      "play_order": 8,
+      "artist_name": "A\u015f\u0131q Altay",
+      "album_title": "Music from the Caucasus \u2013 The Archive of ORED Recordings, 2013\u20132023",
+      "track_title": "Bayat\u0131-\u015eiraz",
+      "record_label": "TAL",
+      "request_flag": false,
+      "album_id": 9008,
+      "segue": true
     }
   ],
   "searchResults": [
@@ -273,6 +289,48 @@
       "format_name": "CD",
       "genre_name": "Rock",
       "label": "Matador Records"
+    },
+    {
+      "id": 9002,
+      "add_date": "1998-09-01T00:00:00.000Z",
+      "album_title": "Aluminum Tunes",
+      "artist_name": "Stereolab",
+      "code_letters": "RO",
+      "code_number": 5,
+      "code_artist_number": 87,
+      "format_name": "CD",
+      "genre_name": "Rock",
+      "label": "Duophonic",
+      "on_streaming": false
+    },
+    {
+      "id": 9006,
+      "add_date": "2022-03-04T00:00:00.000Z",
+      "album_title": "PAINLESS",
+      "artist_name": "Nilüfer Yanya",
+      "code_letters": "RO",
+      "code_number": 1,
+      "code_artist_number": 158,
+      "format_name": "Vinyl LP",
+      "genre_name": "Rock",
+      "label": "ATO Records",
+      "on_streaming": true,
+      "rotation_bin": "S",
+      "rotation_id": 7001
+    },
+    {
+      "id": 9009,
+      "add_date": "2024-02-15T00:00:00.000Z",
+      "album_title": "Various: A WXYC Local Compilation Vol. 1",
+      "artist_name": "Various Artists",
+      "code_letters": "ZA",
+      "code_number": 1,
+      "code_artist_number": 1,
+      "format_name": "Vinyl LP",
+      "genre_name": "Rock",
+      "label": "WXYC Recordings",
+      "on_streaming": true,
+      "album_artist": "Various Artists"
     }
   ],
   "canonicalArtistNames": [

--- a/src/test-utils/wxyc-example-data.json
+++ b/src/test-utils/wxyc-example-data.json
@@ -320,15 +320,15 @@
     },
     {
       "id": 9009,
-      "add_date": "2024-02-15T00:00:00.000Z",
-      "album_title": "Various: A WXYC Local Compilation Vol. 1",
+      "add_date": "1989-09-26T00:00:00.000Z",
+      "album_title": "Brazil Classics 1: Beleza Tropical",
       "artist_name": "Various Artists",
-      "code_letters": "ZA",
+      "code_letters": "ZL",
       "code_number": 1,
       "code_artist_number": 1,
-      "format_name": "Vinyl LP",
-      "genre_name": "Rock",
-      "label": "WXYC Recordings",
+      "format_name": "CD",
+      "genre_name": "Latin",
+      "label": "Luaka Bop",
       "on_streaming": true,
       "album_artist": "Various Artists"
     }

--- a/src/test-utils/wxyc-example-data.ts
+++ b/src/test-utils/wxyc-example-data.ts
@@ -62,6 +62,14 @@ export const wxycExampleAlbums = {
 // Flowsheet Entries (FlowsheetSongEntry -- narrower type, all required fields)
 // ============================================================================
 
+// Flowsheet entries carry rotation_bin/segue/request_flag variants to exercise
+// Classic-mode capsule and segue rendering:
+//   - juanaMolinaLaParadoja        → rotation_bin: 'H'  (heavy)
+//   - jessicaPrattBackBaby         → rotation_bin: 'M'  (medium)
+//   - chuquimamaniCondoriCallYourName → rotation_bin: 'L'  (light)
+//   - dukeEllingtonSentimentalMood → request_flag: true
+//   - niluferYanyaMidnightSun      → rotation_bin: 'S'  (singles)
+//   - asiqAltayBayatiShiraz        → segue: true (follows asiqAltayHuseyni, same album)
 export const wxycExampleFlowsheetEntries = {
   juanaMolinaLaParadoja: flowsheetEntries[0]!,
   jessicaPrattBackBaby: flowsheetEntries[1]!,
@@ -70,15 +78,25 @@ export const wxycExampleFlowsheetEntries = {
   niluferYanyaMidnightSun: flowsheetEntries[4]!,
   sonidoDuenezMentirosoBoquisabroso: flowsheetEntries[5]!,
   asiqAltayHuseyni: flowsheetEntries[6]!,
+  asiqAltayBayatiShiraz: flowsheetEntries[7]!,
 } as const;
 
 // ============================================================================
 // Album Search Results
 // ============================================================================
 
+// Search results cover the visible variants exercised by Classic catalog rows:
+//   - doga                  → plain (no rotation, no on_streaming flag)
+//   - moonPix               → plain
+//   - aluminumTunesExclusive → on_streaming: false (EXCLUSIVE capsule)
+//   - painlessRotationS     → rotation_bin: 'S', on_streaming: true (ROTATION capsule)
+//   - variousArtistsComp    → album_artist: 'Various Artists' (V/A credited)
 export const wxycExampleSearchResults = {
   doga: searchResults[0]!,
   moonPix: searchResults[1]!,
+  aluminumTunesExclusive: searchResults[2]!,
+  painlessRotationS: searchResults[3]!,
+  variousArtistsComp: searchResults[4]!,
 } as const;
 
 // ============================================================================

--- a/tests/wxyc-example-data.test.ts
+++ b/tests/wxyc-example-data.test.ts
@@ -73,6 +73,19 @@ describe('WXYC Example Data', () => {
     expect(Object.values(wxycExampleFlowsheetEntries)).toEqual(wxycExampleFlowsheetList);
   });
 
+  // Bind named exports to expected IDs so a future reorder of the JSON array
+  // can't silently rebind a name to the wrong row. Without this, e.g. swapping
+  // searchResults[2] and searchResults[3] would still satisfy the variant
+  // coverage tests above but break every downstream consumer that uses the
+  // named export.
+  it('named search results bind to the expected fixture IDs', () => {
+    expect(wxycExampleSearchResults.doga.id).toBe(9001);
+    expect(wxycExampleSearchResults.moonPix.id).toBe(9003);
+    expect(wxycExampleSearchResults.aluminumTunesExclusive.id).toBe(9002);
+    expect(wxycExampleSearchResults.painlessRotationS.id).toBe(9006);
+    expect(wxycExampleSearchResults.variousArtistsComp.id).toBe(9009);
+  });
+
   it('search results reference valid artist names (or the V/A sentinel)', () => {
     const artistNames = new Set(wxycExampleArtistList.map(a => a.artist_name));
     for (const result of Object.values(wxycExampleSearchResults)) {
@@ -99,7 +112,7 @@ describe('WXYC Example Data', () => {
     expect(wxycExampleFlowsheetList.some(e => e.request_flag === true)).toBe(true);
   });
 
-  it('segue rows reference the same album as the preceding entry', () => {
+  it('segue rows reference the same album and artist as the preceding entry', () => {
     for (let i = 0; i < wxycExampleFlowsheetList.length; i++) {
       const entry = wxycExampleFlowsheetList[i]!;
       if (entry.segue !== true) continue;
@@ -107,6 +120,7 @@ describe('WXYC Example Data', () => {
       const prev = wxycExampleFlowsheetList[i - 1]!;
       expect(entry.album_id).toBeDefined();
       expect(entry.album_id).toBe(prev.album_id);
+      expect(entry.artist_name).toBe(prev.artist_name);
     }
   });
 

--- a/tests/wxyc-example-data.test.ts
+++ b/tests/wxyc-example-data.test.ts
@@ -19,8 +19,8 @@ describe('WXYC Example Data', () => {
     expect(wxycExampleAlbumList).toHaveLength(8);
   });
 
-  it('provides exactly 7 example flowsheet entries', () => {
-    expect(wxycExampleFlowsheetList).toHaveLength(7);
+  it('provides exactly 8 example flowsheet entries', () => {
+    expect(wxycExampleFlowsheetList).toHaveLength(8);
   });
 
   it('includes diacritic-bearing structured fixtures (ü, ñ, multi-diacritic Turkish ş+ı)', () => {
@@ -73,11 +73,62 @@ describe('WXYC Example Data', () => {
     expect(Object.values(wxycExampleFlowsheetEntries)).toEqual(wxycExampleFlowsheetList);
   });
 
-  it('search results reference valid artist names', () => {
+  it('search results reference valid artist names (or the V/A sentinel)', () => {
     const artistNames = new Set(wxycExampleArtistList.map(a => a.artist_name));
     for (const result of Object.values(wxycExampleSearchResults)) {
-      expect(artistNames.has(result.artist_name)).toBe(true);
+      const isVariousArtists = result.artist_name === 'Various Artists';
+      expect(isVariousArtists || artistNames.has(result.artist_name)).toBe(true);
     }
+  });
+
+  // Variant coverage for Classic-mode capsule and segue rendering.
+  // Consumers (dj-site, tubafrenzy parity tests, BS API tests) need at least
+  // one fixture row per visible variant so they can exercise the rendering
+  // paths without inventing ad-hoc data.
+
+  it('covers each rotation_bin value (H/M/L/S) in at least one flowsheet entry', () => {
+    const bins = new Set(wxycExampleFlowsheetList.map(e => e.rotation_bin));
+    expect(bins.has('H')).toBe(true);
+    expect(bins.has('M')).toBe(true);
+    expect(bins.has('L')).toBe(true);
+    expect(bins.has('S')).toBe(true);
+  });
+
+  it('covers segue=true and request_flag=true in flowsheet entries', () => {
+    expect(wxycExampleFlowsheetList.some(e => e.segue === true)).toBe(true);
+    expect(wxycExampleFlowsheetList.some(e => e.request_flag === true)).toBe(true);
+  });
+
+  it('segue rows reference the same album as the preceding entry', () => {
+    for (let i = 0; i < wxycExampleFlowsheetList.length; i++) {
+      const entry = wxycExampleFlowsheetList[i]!;
+      if (entry.segue !== true) continue;
+      expect(i).toBeGreaterThan(0); // segue can't be on the first row
+      const prev = wxycExampleFlowsheetList[i - 1]!;
+      expect(entry.album_id).toBeDefined();
+      expect(entry.album_id).toBe(prev.album_id);
+    }
+  });
+
+  it('covers on_streaming=false in at least one search result (EXCLUSIVE capsule fixture)', () => {
+    const exclusives = Object.values(wxycExampleSearchResults).filter(
+      r => r.on_streaming === false
+    );
+    expect(exclusives.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('covers rotation_bin in at least one search result (ROTATION capsule fixture)', () => {
+    const rotated = Object.values(wxycExampleSearchResults).filter(
+      r => r.rotation_bin !== undefined
+    );
+    expect(rotated.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('covers album_artist (Various Artists credit) in at least one search result', () => {
+    const compilations = Object.values(wxycExampleSearchResults).filter(
+      r => r.album_artist !== undefined
+    );
+    expect(compilations.length).toBeGreaterThanOrEqual(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- Overlay `rotation_bin` H/M/L/S on four existing flowsheet entries and add a same-album segue pair so consumers can exercise capsule and segue rendering paths.
- Add three search-result rows covering `on_streaming=false`, `rotation_bin`, and `album_artist` for V/A.
- Bump `@wxyc/shared` 1.3.0 → 1.4.0.

All existing fixture semantics are preserved — every change is additive. Downstream consumer is WXYC/dj-site#511 (Classic-mode tubafrenzy sync); PR 1 of that effort uses these variants directly.

Closes #128

## Test plan

- [x] `npm test` (414 → 419 tests pass)
- [x] `npm run lint`
- [x] `npm run build`