### PR TITLE
feat(api): extended-metadata fields for single-call iOS metadata

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2081,6 +2081,32 @@ components:
             is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets
             this to true on every call; other consumers (catalog search,
             dj-site proxy, iOS apps) leave it false.
+        extended:
+          type: boolean
+          default: false
+          description: >
+            When true, the top-1 result's `artwork` block is populated with
+            additional fields LML already fetches during enrichment but
+            normally discards: `discogs_artist_id`, `tracklist`, `genres`,
+            `styles`, `label`, `full_release_date`, `artist_image_url`, and
+            `bio_tokens` (cache-only deep parse of the artist's profile
+            markup). Lets a caller obtain a full playcut metadata payload in
+            a single `/lookup` call instead of following up with separate
+            `/discogs/release/{id}` and `/discogs/artist/{id}` requests.
+            When false (the default), the response shape is unchanged.
+        warm_cache:
+          type: boolean
+          default: false
+          description: >
+            When true, LML schedules a fire-and-forget background task after
+            the response is built that runs a *deep* async parse of the
+            top-1 artist's bio. The task resolves all `[a…]`/`[r…]`/`[m…]`
+            references against the Discogs API where the local cache misses,
+            warming the PG cache so subsequent reads of the same artist
+            render richer bio tokens. Intended for write-path callers (e.g.
+            Backend-Service's flowsheet-linkage service committing a new DJ
+            entry); read-path callers should leave this false to avoid
+            doubling the Discogs-API load per request.
 
     LibraryCatalogItem:
       type: object
@@ -2197,6 +2223,72 @@ components:
           type: string
           nullable: true
           description: SoundCloud search URL
+        discogs_artist_id:
+          type: integer
+          nullable: true
+          description: >
+            Discogs artist ID for this release. Populated only when the
+            originating `LookupRequest.extended` is true. Lets a caller key
+            an artist-metadata cache without a follow-up release fetch.
+        tracklist:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/DiscogsTrackItem'
+          description: >
+            Release tracklist with per-track artist credits where available.
+            Populated only when `extended` is true.
+        genres:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: >
+            Discogs genre tags (e.g. "Rock", "Electronic"). Populated only
+            when `extended` is true.
+        styles:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: >
+            Discogs style tags (finer-grained than genres; e.g. "Indie Rock",
+            "Ambient"). Populated only when `extended` is true.
+        label:
+          type: string
+          nullable: true
+          description: >
+            Primary record-label name from the Discogs release. Distinct
+            from `LibraryCatalogItem.label` (which comes from the WXYC
+            catalog's rotation-release join). Populated only when `extended`
+            is true.
+        full_release_date:
+          type: string
+          nullable: true
+          description: >
+            Release date as an ISO string (e.g. "1997-09-22"). May be
+            year-only ("1997") or year-month ("1997-09") if Discogs lacks
+            the full date. Populated only when `extended` is true.
+        artist_image_url:
+          type: string
+          nullable: true
+          description: >
+            Primary artist image URL from Discogs (the artist's profile
+            photo, not the release artwork). Populated only when `extended`
+            is true.
+        bio_tokens:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/DiscogsResolvedToken'
+          description: >
+            Pre-parsed structured tokens from the artist's `profile` markup,
+            using a cache-only resolver — references to entities not in the
+            local PG cache fall through as plain-text tokens (no inline
+            Discogs API calls on the read path). Populated only when
+            `extended` is true. Pair with `LookupRequest.warm_cache=true`
+            on write-path calls to progressively populate the cache so
+            subsequent reads render richer.
 
     LookupResultItem:
       type: object

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.4.0
+  version: 1.5.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -2083,20 +2083,18 @@ components:
             dj-site proxy, iOS apps) leave it false.
         extended:
           type: boolean
-          default: false
           description: >
             When true, the top-1 result's `artwork` block is populated with
             additional fields LML already fetches during enrichment but
             normally discards: `discogs_artist_id`, `tracklist`, `genres`,
             `styles`, `label`, `full_release_date`, `artist_image_url`, and
-            `bio_tokens` (cache-only deep parse of the artist's profile
+            `profile_tokens` (cache-only deep parse of the artist's profile
             markup). Lets a caller obtain a full playcut metadata payload in
             a single `/lookup` call instead of following up with separate
             `/discogs/release/{id}` and `/discogs/artist/{id}` requests.
-            When false (the default), the response shape is unchanged.
+            Absent or false leaves the response shape unchanged.
         warm_cache:
           type: boolean
-          default: false
           description: >
             When true, LML schedules a fire-and-forget background task after
             the response is built that runs a *deep* async parse of the
@@ -2105,8 +2103,8 @@ components:
             warming the PG cache so subsequent reads of the same artist
             render richer bio tokens. Intended for write-path callers (e.g.
             Backend-Service's flowsheet-linkage service committing a new DJ
-            entry); read-path callers should leave this false to avoid
-            doubling the Discogs-API load per request.
+            entry); read-path callers should leave this absent/false to
+            avoid doubling the Discogs-API load per request.
 
     LibraryCatalogItem:
       type: object
@@ -2276,7 +2274,7 @@ components:
             Primary artist image URL from Discogs (the artist's profile
             photo, not the release artwork). Populated only when `extended`
             is true.
-        bio_tokens:
+        profile_tokens:
           type: array
           nullable: true
           items:
@@ -2286,9 +2284,11 @@ components:
             using a cache-only resolver — references to entities not in the
             local PG cache fall through as plain-text tokens (no inline
             Discogs API calls on the read path). Populated only when
-            `extended` is true. Pair with `LookupRequest.warm_cache=true`
-            on write-path calls to progressively populate the cache so
-            subsequent reads render richer.
+            `extended` is true. Field name matches `DiscogsArtistDetails.profile_tokens`
+            so callers can share rendering code across the two payloads.
+            Pair with `LookupRequest.warm_cache=true` on write-path calls
+            to progressively populate the cache so subsequent reads render
+            richer.
 
     LookupResultItem:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -382,27 +382,31 @@ describe('OpenAPI Specification', () => {
       $ref?: string;
     };
 
-    it('should define LookupRequest.extended as optional boolean defaulting to false', () => {
+    it('should define LookupRequest.extended as an optional boolean with no default', () => {
       const schema = spec.components.schemas.LookupRequest as {
         properties: Record<string, SchemaProp>;
         required?: string[];
       };
       expect(schema.properties.extended).toBeDefined();
       expect(schema.properties.extended.type).toBe('boolean');
-      expect(schema.properties.extended.default).toBe(false);
+      // Intentionally omit `default:` so openapi-typescript emits the field
+      // as optional (`extended?: boolean`) rather than required. Existing
+      // consumers (LML/BS/iOS/dj-site) keep compiling without passing it.
+      expect(schema.properties.extended.default).toBeUndefined();
       // Not required — non-iOS consumers continue to omit it.
       expect(schema.required ?? []).not.toContain('extended');
     });
 
-    it('should define LookupRequest.warm_cache as optional boolean defaulting to false', () => {
+    it('should define LookupRequest.warm_cache as an optional boolean with no default', () => {
       const schema = spec.components.schemas.LookupRequest as {
         properties: Record<string, SchemaProp>;
         required?: string[];
       };
       expect(schema.properties.warm_cache).toBeDefined();
       expect(schema.properties.warm_cache.type).toBe('boolean');
-      expect(schema.properties.warm_cache.default).toBe(false);
-      // Read-path callers leave this false to avoid doubling Discogs-API load.
+      // Same rationale as `extended` — see comment above.
+      expect(schema.properties.warm_cache.default).toBeUndefined();
+      // Read-path callers leave this absent to avoid doubling Discogs-API load.
       expect(schema.required ?? []).not.toContain('warm_cache');
     });
 
@@ -446,9 +450,11 @@ describe('OpenAPI Specification', () => {
       optional('artist_image_url');
       expect(schema.properties.artist_image_url.type).toBe('string');
 
-      optional('bio_tokens');
-      expect(schema.properties.bio_tokens.type).toBe('array');
-      expect(schema.properties.bio_tokens.items?.$ref).toBe(
+      // Field name matches DiscogsArtistDetails.profile_tokens so iOS / dj-site
+      // can share rendering code across the two payloads.
+      optional('profile_tokens');
+      expect(schema.properties.profile_tokens.type).toBe('array');
+      expect(schema.properties.profile_tokens.items?.$ref).toBe(
         '#/components/schemas/DiscogsResolvedToken',
       );
     });

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -373,6 +373,87 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  describe('Lookup Extended Metadata (subsecond iOS metadata path)', () => {
+    type SchemaProp = {
+      type?: string;
+      default?: unknown;
+      nullable?: boolean;
+      items?: { $ref?: string; type?: string };
+      $ref?: string;
+    };
+
+    it('should define LookupRequest.extended as optional boolean defaulting to false', () => {
+      const schema = spec.components.schemas.LookupRequest as {
+        properties: Record<string, SchemaProp>;
+        required?: string[];
+      };
+      expect(schema.properties.extended).toBeDefined();
+      expect(schema.properties.extended.type).toBe('boolean');
+      expect(schema.properties.extended.default).toBe(false);
+      // Not required — non-iOS consumers continue to omit it.
+      expect(schema.required ?? []).not.toContain('extended');
+    });
+
+    it('should define LookupRequest.warm_cache as optional boolean defaulting to false', () => {
+      const schema = spec.components.schemas.LookupRequest as {
+        properties: Record<string, SchemaProp>;
+        required?: string[];
+      };
+      expect(schema.properties.warm_cache).toBeDefined();
+      expect(schema.properties.warm_cache.type).toBe('boolean');
+      expect(schema.properties.warm_cache.default).toBe(false);
+      // Read-path callers leave this false to avoid doubling Discogs-API load.
+      expect(schema.required ?? []).not.toContain('warm_cache');
+    });
+
+    it('should attach the extended-metadata fields to DiscogsMatchResult', () => {
+      const schema = spec.components.schemas.DiscogsMatchResult as {
+        properties: Record<string, SchemaProp>;
+        required?: string[];
+      };
+
+      // Each new field is optional + nullable so the additive contract
+      // doesn't break the LML/BS/iOS consumers that omit `extended`.
+      const optional = (name: string) => {
+        expect(schema.properties[name]).toBeDefined();
+        expect(schema.required ?? []).not.toContain(name);
+        expect(schema.properties[name].nullable).toBe(true);
+      };
+
+      optional('discogs_artist_id');
+      expect(schema.properties.discogs_artist_id.type).toBe('integer');
+
+      optional('tracklist');
+      expect(schema.properties.tracklist.type).toBe('array');
+      expect(schema.properties.tracklist.items?.$ref).toBe(
+        '#/components/schemas/DiscogsTrackItem',
+      );
+
+      optional('genres');
+      expect(schema.properties.genres.type).toBe('array');
+      expect(schema.properties.genres.items?.type).toBe('string');
+
+      optional('styles');
+      expect(schema.properties.styles.type).toBe('array');
+      expect(schema.properties.styles.items?.type).toBe('string');
+
+      optional('label');
+      expect(schema.properties.label.type).toBe('string');
+
+      optional('full_release_date');
+      expect(schema.properties.full_release_date.type).toBe('string');
+
+      optional('artist_image_url');
+      expect(schema.properties.artist_image_url.type).toBe('string');
+
+      optional('bio_tokens');
+      expect(schema.properties.bio_tokens.type).toBe('array');
+      expect(schema.properties.bio_tokens.items?.$ref).toBe(
+        '#/components/schemas/DiscogsResolvedToken',
+      );
+    });
+  });
+
   describe('Proxy Response Schemas', () => {
     it('should define AlbumMetadataResponse with enriched fields', () => {
       const schema = spec.components.schemas.AlbumMetadataResponse as {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -23,6 +23,8 @@ import {
   type ReadinessResponse,
   type LibrarySearchItem,
   type LookupResultItem,
+  type LookupRequest,
+  type DiscogsMatchResult,
   type TrackMatchHint,
   RotationBin,
   DayOfWeek,
@@ -579,6 +581,95 @@ describe('Generated TypeScript Types', () => {
       };
 
       expect(entry.track_position).toBe('A1');
+    });
+  });
+
+  describe('LookupRequest extended-metadata flags (PR #133)', () => {
+    // These tests pin the *generated TypeScript* contract for `extended` and
+    // `warm_cache`. If a future api.yaml edit accidentally adds `default: false`
+    // back to either field, openapi-typescript will promote them to required
+    // (`extended: boolean` instead of `extended?: boolean`) and every existing
+    // LML/BS/iOS/dj-site caller stops typechecking — these tests fail-fast
+    // before that lands.
+    it('treats `extended` and `warm_cache` as optional (callers can omit both)', () => {
+      const minimal: LookupRequest = {
+        artist: 'Stereolab',
+        album: 'Aluminum Tunes',
+      };
+
+      expect(minimal.artist).toBe('Stereolab');
+      // Compile-time assertion: omitting `extended`/`warm_cache` must be legal.
+      expect(minimal.extended).toBeUndefined();
+      expect(minimal.warm_cache).toBeUndefined();
+    });
+
+    it('accepts `extended` and `warm_cache` when callers opt in', () => {
+      const opted: LookupRequest = {
+        artist: 'Jessica Pratt',
+        album: 'On Your Own Love Again',
+        extended: true,
+        warm_cache: true,
+      };
+
+      expect(opted.extended).toBe(true);
+      expect(opted.warm_cache).toBe(true);
+    });
+  });
+
+  describe('DiscogsMatchResult extended-metadata fields (PR #133)', () => {
+    // Same pattern as above: pin the consumer-facing contract that the
+    // new extended-metadata fields are optional + nullable.
+    it('accepts a result with none of the extended fields set', () => {
+      const baseline: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+      };
+
+      expect(baseline.discogs_artist_id).toBeUndefined();
+      expect(baseline.tracklist).toBeUndefined();
+      expect(baseline.genres).toBeUndefined();
+      expect(baseline.styles).toBeUndefined();
+      expect(baseline.label).toBeUndefined();
+      expect(baseline.full_release_date).toBeUndefined();
+      expect(baseline.artist_image_url).toBeUndefined();
+      expect(baseline.profile_tokens).toBeUndefined();
+    });
+
+    it('accepts a result with all extended fields populated', () => {
+      const full: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        discogs_artist_id: 999,
+        tracklist: [{ position: 'A1', title: 'In a Sentimental Mood' }],
+        genres: ['Jazz'],
+        styles: ['Modal'],
+        label: 'Impulse Records',
+        full_release_date: '1963-02-07',
+        artist_image_url: 'https://img.discogs.com/foo.jpg',
+        profile_tokens: [{ type: 'plainText', text: 'American jazz pianist.' }],
+      };
+
+      expect(full.discogs_artist_id).toBe(999);
+      expect(full.label).toBe('Impulse Records');
+      expect(full.profile_tokens?.[0].type).toBe('plainText');
+    });
+
+    it('accepts null for every nullable extended field', () => {
+      const nulled: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        discogs_artist_id: null,
+        tracklist: null,
+        genres: null,
+        styles: null,
+        label: null,
+        full_release_date: null,
+        artist_image_url: null,
+        profile_tokens: null,
+      };
+
+      expect(nulled.label).toBeNull();
+      expect(nulled.profile_tokens).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds optional/nullable fields to `DiscogsMatchResult` (`discogs_artist_id`, `tracklist`, `genres`, `styles`, `label`, `full_release_date`, `artist_image_url`, `bio_tokens`) so LML can surface metadata it already fetches during `/lookup` enrichment.
- Adds two opt-in flags to `LookupRequest`: `extended` (return the new fields) and `warm_cache` (fire-and-forget deep-async bio parse to warm the PG cache, write-path only).
- Bumps to `1.5.0`. Strictly additive; `npm run check:breaking` passes; existing consumers (LML, BS, iOS, dj-site) unaffected.

This is the schema-side foundation for collapsing the iOS playcut-metadata fetch from 2 client + 4 LML round-trips to 1 client + 1 LML round-trip. Subsequent PRs in `library-metadata-lookup`, `Backend-Service`, and `wxyc-ios-64` consume these new fields.

Closes #132

## Test plan

- [x] `npm test` — 418 passed (3 new in `api-spec.test.ts`)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run check:breaking` — no breaking changes
- [x] `npm run generate:typescript` and verify new fields appear in `src/generated/openapi-types.d.ts`
- [ ] CI green