### PR TITLE
E6-1: track_position on write + V2 flowsheet schemas (1.6.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.5.0
+  version: 1.6.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -362,6 +362,16 @@ components:
           type: integer
         track_title:
           type: string
+        track_position:
+          type: string
+          description: >
+            Track position on the release (e.g., "A1", "B2", "5", "1-12"). Written
+            by the dj-site flowsheet picker (catalog-track-search plan §5.3 / Track 3)
+            when the DJ selects a track from the resolved release. Omitted when
+            the DJ enters a free-text track_title without a tracklist lookup or
+            when the release has no resolvable identity. String-typed to match
+            Discogs's `release_track.position` (vinyl side notation, multi-disc
+            prefixes).
         rotation_id:
           type: integer
         request_flag:
@@ -411,6 +421,13 @@ components:
       properties:
         track_title:
           type: string
+        track_position:
+          type: string
+          description: >
+            Track position on the release (e.g., "A1", "B2", "5", "1-12"). Set
+            when re-picking a track via the flowsheet picker; cleared (omitted)
+            when a DJ edits the entry to a free-text track_title. String-typed
+            to match Discogs's `release_track.position`.
         artist_name:
           type: string
         album_title:
@@ -601,6 +618,16 @@ components:
             track_title:
               type: string
               nullable: true
+            track_position:
+              type: string
+              nullable: true
+              description: >
+                Track position on the release (e.g., "A1", "B2", "5", "1-12"). Set
+                by the dj-site flowsheet picker (catalog-track-search plan §5.3 /
+                Track 3) when the DJ selected a track from the resolved release;
+                null when the track_title was entered free-form or the release had
+                no resolvable identity. String-typed to match Discogs's
+                `release_track.position`.
             record_label:
               type: string
               nullable: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -107,6 +107,50 @@ describe('OpenAPI Specification', () => {
     it('should define OnAirStatusResponse', () => {
       expect(spec.components.schemas.OnAirStatusResponse).toBeDefined();
     });
+
+    describe('track_position field (catalog-track-search Track 3 / E6)', () => {
+      function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
+        const schema = spec.components.schemas[schemaName] as
+          | { properties?: Record<string, Record<string, unknown>>; allOf?: Array<{ properties?: Record<string, Record<string, unknown>> }> }
+          | undefined;
+        if (!schema) return undefined;
+        if (schema.properties?.[prop]) return schema.properties[prop];
+        for (const branch of schema.allOf ?? []) {
+          if (branch.properties?.[prop]) return branch.properties[prop];
+        }
+        return undefined;
+      }
+
+      // String-typed to match Discogs's `release_track.position` (vinyl "A1",
+      // CD "5", multi-disc "1-12"). FlowsheetEntryBase + FlowsheetSongEntry
+      // already use this convention on the read side; E6-1 fills the write-side
+      // gap (FlowsheetCreateSongFromCatalog, FlowsheetUpdateRequest) and the V2
+      // response shape (FlowsheetV2TrackEntry).
+
+      it('FlowsheetCreateSongFromCatalog should accept optional string track_position', () => {
+        const trackPosition = getProperty('FlowsheetCreateSongFromCatalog', 'track_position');
+        expect(trackPosition).toBeDefined();
+        expect(trackPosition?.type).toBe('string');
+      });
+
+      it('FlowsheetCreateSongFromCatalog should not require track_position', () => {
+        const schema = spec.components.schemas.FlowsheetCreateSongFromCatalog as { required?: string[] };
+        expect(schema.required ?? []).not.toContain('track_position');
+      });
+
+      it('FlowsheetUpdateRequest should accept optional string track_position', () => {
+        const trackPosition = getProperty('FlowsheetUpdateRequest', 'track_position');
+        expect(trackPosition).toBeDefined();
+        expect(trackPosition?.type).toBe('string');
+      });
+
+      it('FlowsheetV2TrackEntry should carry nullable string track_position in read responses', () => {
+        const trackPosition = getProperty('FlowsheetV2TrackEntry', 'track_position');
+        expect(trackPosition).toBeDefined();
+        expect(trackPosition?.type).toBe('string');
+        expect(trackPosition?.nullable).toBe(true);
+      });
+    });
   });
 
   describe('Catalog Schemas', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -9,6 +9,9 @@ import { describe, it, expect } from 'vitest';
 import {
   type FlowsheetEntryResponse,
   type FlowsheetSongEntry,
+  type FlowsheetCreateSongFromCatalog,
+  type FlowsheetUpdateRequest,
+  type FlowsheetV2TrackEntry,
   type Album,
   type AlbumSearchResult,
   type Label,
@@ -581,6 +584,63 @@ describe('Generated TypeScript Types', () => {
       };
 
       expect(entry.track_position).toBe('A1');
+    });
+
+    // Write-side schemas (PR #134 / E6-1). These pin the *generated TypeScript*
+    // contract that BS/dj-site/iOS callers actually import. If a future
+    // api.yaml edit accidentally promotes `track_position` to required (e.g.,
+    // adds it to the schema's `required:` list), openapi-typescript will emit
+    // `track_position: string` instead of `track_position?: string` and these
+    // tests fail-fast before that lands.
+    it('FlowsheetCreateSongFromCatalog accepts optional track_position', () => {
+      const withoutPosition: FlowsheetCreateSongFromCatalog = {
+        album_id: 1001,
+        track_title: 'la paradoja',
+        request_flag: false,
+      };
+
+      const withPosition: FlowsheetCreateSongFromCatalog = {
+        ...withoutPosition,
+        track_position: 'A1',
+      };
+
+      expect(withoutPosition.track_position).toBeUndefined();
+      expect(withPosition.track_position).toBe('A1');
+    });
+
+    it('FlowsheetUpdateRequest accepts optional track_position', () => {
+      const empty: FlowsheetUpdateRequest = {};
+      const withPosition: FlowsheetUpdateRequest = {
+        track_position: '1-12',
+      };
+
+      expect(empty.track_position).toBeUndefined();
+      expect(withPosition.track_position).toBe('1-12');
+    });
+
+    it('FlowsheetV2TrackEntry accepts optional + nullable track_position', () => {
+      const baseEntry: FlowsheetV2TrackEntry = {
+        id: 1,
+        show_id: 42,
+        play_order: 100,
+        add_time: '2024-06-15T14:30:00.000Z',
+        entry_type: 'track',
+        request_flag: false,
+      };
+
+      const withPosition: FlowsheetV2TrackEntry = {
+        ...baseEntry,
+        track_position: 'B3',
+      };
+
+      const nullPosition: FlowsheetV2TrackEntry = {
+        ...baseEntry,
+        track_position: null,
+      };
+
+      expect(baseEntry.track_position).toBeUndefined();
+      expect(withPosition.track_position).toBe('B3');
+      expect(nullPosition.track_position).toBeNull();
     });
   });
 

--- a/tests/v2-flowsheet.test.ts
+++ b/tests/v2-flowsheet.test.ts
@@ -180,6 +180,27 @@ describe('V2 Generated Types', () => {
 
       expect(entry.segue).toBe(true);
     });
+
+    // PR #134 / E6-1: track_position carries the Discogs `release_track.position`
+    // shape (vinyl "A1", CD "5", multi-disc "1-12") and is `nullable: true` on
+    // the read side. Pin both the string and null paths.
+    it('should accept a string track_position on a track entry', () => {
+      const entry: FlowsheetV2TrackEntry = {
+        ...sampleTrack,
+        track_position: 'A1',
+      };
+
+      expect(entry.track_position).toBe('A1');
+    });
+
+    it('should accept a null track_position on a track entry', () => {
+      const entry: FlowsheetV2TrackEntry = {
+        ...sampleTrack,
+        track_position: null,
+      };
+
+      expect(entry.track_position).toBeNull();
+    });
   });
 
   describe('FlowsheetV2ShowStartEntry', () => {


### PR DESCRIPTION
## Summary

Fills the write-side + V2 gap for `track_position` (catalog-track-search plan §5.3 / Track 3). Read-side schemas (`FlowsheetEntryBase`, `FlowsheetSongEntry`) already carried this field from prior work; this adds it to:

- `FlowsheetCreateSongFromCatalog` — picker-driven creates
- `FlowsheetUpdateRequest` — picker-driven edits
- `FlowsheetV2TrackEntry` — V2 read shape (`nullable: true`)

All additive, optional. Minor bump 1.5.0 → 1.6.0.

## Why string instead of integer

The plan §4.3 says `INT NULL` but the existing `FlowsheetEntryBase.track_position` (and Discogs's own `release_track.position`) is **string** — vinyl side notation (`"A1"`, `"B3"`) and multi-disc prefixes (`"1-12"`) need it. Consistency with the existing convention wins; BS#835's migration should follow as `TEXT NULL` rather than `INT NULL`. Noted in the issue body.

## Issue reshape

The original #111 was scoped against the v1 plan: a new `GET /library/{id}/tracks` endpoint schema + `FlowsheetEntryInput.track_position`. v2 dropped the endpoint (Backend composes via existing LML `/discogs/release/{id}`) and renamed the schemas. Updated the issue title, body, and removed the stale BS#830 dependency in the same pass.

## Test plan

- [x] `npm run generate:typescript` regenerates `src/generated/openapi-types.d.ts` cleanly
- [x] `npm run check:breaking` reports no breaking changes
- [x] `npm test` — all 427 tests pass (4 new in `tests/api-spec.test.ts > Flowsheet Schemas > track_position field`)
- [x] Generated types show `track_position?: string` / `track_position?: string | null` consistently across all five schemas
- [ ] CI greens

Closes #111.