### PR TITLE
fix(setup-dev): pass already-picked ports forward to avoid collision

### DIFF
--- a/scripts/__tests__/setup-dev-environment.test.sh
+++ b/scripts/__tests__/setup-dev-environment.test.sh
@@ -256,8 +256,48 @@ teardown() {
     grep -A5 "is_port_available()" "$SCRIPT_PATH" | grep -q "lsof"
 }
 
-@test "find_available_port skips already-resolved ports" {
-    grep -A20 "find_available_port()" "$SCRIPT_PATH" | grep -q "RESOLVED_PORTS"
+@test "find_available_port returns default port when free" {
+    source "$SCRIPT_PATH"
+    is_port_available() { return 0; }
+    [ "$(find_available_port 8080)" = "8080" ]
+}
+
+@test "find_available_port walks past occupied ports" {
+    source "$SCRIPT_PATH"
+    is_port_available() {
+        case "$1" in 8080|8081) return 1 ;; *) return 0 ;; esac
+    }
+    [ "$(find_available_port 8080)" = "8082" ]
+}
+
+@test "find_available_port skips ports passed as already-taken" {
+    source "$SCRIPT_PATH"
+    is_port_available() { return 0; }
+    # 8080 is free per the stub, but caller marks it taken from a prior pick.
+    [ "$(find_available_port 8080 8080)" = "8081" ]
+}
+
+# Regression test for the subshell-collision bug: when consecutive defaults
+# are all occupied, sequential command-substitution calls used to return the
+# same port because RESOLVED_PORTS+= died in the subshell. The fix is for
+# callers to pass already-picked ports forward as extra args.
+@test "find_available_port avoids collision across command-substitution calls" {
+    source "$SCRIPT_PATH"
+    is_port_available() {
+        case "$1" in 8080|8081|8082|8083) return 1 ;; *) return 0 ;; esac
+    }
+    BACKEND_PORT=$(find_available_port 8080)
+    AUTH_PORT=$(find_available_port 8082 "$BACKEND_PORT")
+    [ "$BACKEND_PORT" = "8084" ]
+    [ "$AUTH_PORT" = "8085" ]
+    [ "$BACKEND_PORT" != "$AUTH_PORT" ]
+}
+
+@test "find_available_port fails after exhausting the 20-port window" {
+    source "$SCRIPT_PATH"
+    is_port_available() { return 1; }
+    run find_available_port 8080
+    [ "$status" -ne 0 ]
 }
 
 @test "resolve_ports reads backend .env in frontend-only mode" {

--- a/scripts/setup-dev-environment.sh
+++ b/scripts/setup-dev-environment.sh
@@ -90,13 +90,22 @@ is_port_available() {
     ! lsof -iTCP:"$1" -sTCP:LISTEN -P -n >/dev/null 2>&1
 }
 
-RESOLVED_PORTS=()
-
+# Find an available port starting at $1, walking up to 20 ports forward.
+# Additional arguments are ports the caller has already picked in earlier
+# sequential calls; they're treated as occupied even if nothing is listening
+# yet. The taken-list is passed explicitly rather than stored in a global
+# because every call site uses command substitution -- a shared array would
+# mutate the subshell's copy and never propagate back.
 find_available_port() {
     local port=$1
+    local -a taken=("${@:2}")
+    local i t in_taken
     for (( i=0; i<20; i++ )); do
-        if is_port_available "$port" && [[ ! " ${RESOLVED_PORTS[*]:-} " =~ " $port " ]]; then
-            RESOLVED_PORTS+=("$port")
+        in_taken=0
+        for t in "${taken[@]}"; do
+            if [[ "$t" == "$port" ]]; then in_taken=1; break; fi
+        done
+        if (( in_taken == 0 )) && is_port_available "$port"; then
             echo "$port"
             return 0
         fi
@@ -360,16 +369,16 @@ resolve_ports() {
         AUTH_PORT=${AUTH_PORT:-$DEFAULT_AUTH_PORT}
         log_info "Using backend ports from .env: backend=$BACKEND_PORT, auth=$AUTH_PORT"
     else
-        DB_PORT=$(find_available_port $DEFAULT_DB_PORT) || exit 1
-        BACKEND_PORT=$(find_available_port $DEFAULT_BACKEND_PORT) || exit 1
-        AUTH_PORT=$(find_available_port $DEFAULT_AUTH_PORT) || exit 1
+        DB_PORT=$(find_available_port "$DEFAULT_DB_PORT") || exit 1
+        BACKEND_PORT=$(find_available_port "$DEFAULT_BACKEND_PORT" "$DB_PORT") || exit 1
+        AUTH_PORT=$(find_available_port "$DEFAULT_AUTH_PORT" "$DB_PORT" "$BACKEND_PORT") || exit 1
         log_success "Database port: $DB_PORT"
         log_success "Backend port: $BACKEND_PORT"
         log_success "Auth port: $AUTH_PORT"
     fi
 
     if [[ "$BACKEND_ONLY" != true ]]; then
-        FRONTEND_PORT=$(find_available_port $DEFAULT_FRONTEND_PORT) || exit 1
+        FRONTEND_PORT=$(find_available_port "$DEFAULT_FRONTEND_PORT" "$BACKEND_PORT" "$AUTH_PORT") || exit 1
         log_success "Frontend port: $FRONTEND_PORT"
     fi
 
@@ -665,5 +674,8 @@ main() {
     wait
 }
 
-# Run main function
-main "$@"
+# Run main function when executed directly. The guard lets tests source this
+# file to exercise individual functions without triggering the orchestrator.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
Closes #136.

## Problem

`find_available_port` in `scripts/setup-dev-environment.sh` tracked already-picked ports in a global `RESOLVED_PORTS` array. Every call site invokes it through `$(...)` command substitution, which runs in a subshell — so `RESOLVED_PORTS+=("$port")` only mutated the subshell's copy and the parent shell saw an empty array on every call.

When 8080–8083 were all occupied (multiple worktrees, orphaned services), backend and auth both walked to 8084 and collided. The `lsof` fallback didn't catch it because nothing was bound to the picked port yet — the script writes it to `.env` first and `npm run dev` fires later. The frontend `.env.local` inherited the collision and dj-site requests landed at whichever service bound first, surfacing as CORS / "header not allowed" errors or silent service death.

## Approach

Issue [#136](https://github.com/WXYC/wxyc-shared/issues/136) laid out three options. This PR lands option (1): make the function pure by passing already-picked ports as additional arguments. Pure-functional, no shared state, immune to any subshell semantics, smallest diff.

```diff
 find_available_port() {
     local port=$1
+    local -a taken=("${@:2}")
     ...
 }
-DB_PORT=$(find_available_port $DEFAULT_DB_PORT) || exit 1
-BACKEND_PORT=$(find_available_port $DEFAULT_BACKEND_PORT) || exit 1
-AUTH_PORT=$(find_available_port $DEFAULT_AUTH_PORT) || exit 1
+DB_PORT=$(find_available_port "$DEFAULT_DB_PORT") || exit 1
+BACKEND_PORT=$(find_available_port "$DEFAULT_BACKEND_PORT" "$DB_PORT") || exit 1
+AUTH_PORT=$(find_available_port "$DEFAULT_AUTH_PORT" "$DB_PORT" "$BACKEND_PORT") || exit 1
```

Frontend gets `BACKEND_PORT` + `AUTH_PORT` forwarded too (it doesn't collide with `DB_PORT` in practice, but the four sequential calls are now self-consistent).

## Test plan

The existing test for this behavior was a `grep -q "RESOLVED_PORTS"` smoke check that asserted the *string* appeared in the function body — it would have passed even after deleting the array. Replaced with five behavioral bats tests that source the script (enabled by a new `BASH_SOURCE` guard at the bottom of the script) and stub `is_port_available`:

- [x] `find_available_port returns default port when free`
- [x] `find_available_port walks past occupied ports`
- [x] `find_available_port skips ports passed as already-taken`
- [x] `find_available_port avoids collision across command-substitution calls` — the bug regression test; with 8080–8083 stubbed as occupied, asserts backend=8084 and auth=8085, distinct.
- [x] `find_available_port fails after exhausting the 20-port window`

Verified red→green: the two new tests that exercise the bug fail on `main`, pass after the fix. All 45 tests pass locally (`npm run test:setup-script`).

## Acceptance criteria (from #136)

- [x] With 8080–8083 already bound, the script picks distinct, non-colliding ports — covered by the regression test.
- [x] Happy-path runs (defaults free) still pick 8080/8082/3000 — covered by `returns default port when free`.
- [x] `--frontend-only` / `--backend-only` unaffected — those branches don't touch `find_available_port` for the colliding pair (frontend-only reads from `.env`; backend-only skips the frontend pick).
- [x] Behavioral shell test pins the no-collision property by stubbing `is_port_available`.