### PR TITLE
fix(ci): declare packages:read on reusable drift workflow

### DIFF
--- a/.github/workflows/check-charset-corpus-drift.yml
+++ b/.github/workflows/check-charset-corpus-drift.yml
@@ -46,11 +46,17 @@ concurrency:
   group: charset-corpus-drift-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
-# comments on PRs, or creates releases; all writes to external services
-# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+# Workflow-level GITHUB_TOKEN scope. For reusable workflows, the effective
+# permissions in the called workflow's jobs — including the GITHUB_TOKEN the
+# caller forwards via `secrets.npm-token` — are the INTERSECTION of caller
+# and callee permission blocks. We must therefore declare every scope any
+# consumer could need to forward, even scopes no step in this file uses
+# directly, or the caller's grant gets silently narrowed away. `packages: read`
+# rides on the forwarded npm-token; without declaring it here, `npm pack` 401s
+# even when the caller declared `permissions: packages: read`.
 permissions:
   contents: read
+  packages: read
 
 jobs:
   drift-check:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ permissions:
   packages: read   # `npm pack @wxyc/shared` authenticates to npm.pkg.github.com via the caller's GITHUB_TOKEN, forwarded as the `npm-token` secret
 ```
 
-Granting less makes the `npm pack` step fail with an opaque 401 — the workflow does fail (not startup_failure), but a reader of the caller's `permissions:` block won't see why. The reusable workflow itself declares `permissions: contents: read` at workflow level; `packages: read` rides on the secret the caller forwards, so it has to come from the caller's own permissions block.
+Granting less makes the `npm pack` step fail with an opaque 401 — the workflow does fail (not startup_failure), but `--silent` suppresses the error message and a reader of the caller's `permissions:` block won't see why.
+
+**Both sides must declare every forwarded scope.** Reusable-workflow permissions intersect (caller ∩ callee) at job dispatch, and the intersection also governs the GITHUB_TOKEN the caller forwards into `secrets.npm-token`. Concretely: if the callee declares only `contents: read`, the forwarded token gets narrowed to `contents: read` regardless of what the caller granted — `npm pack` will 401. This file therefore declares `permissions: contents: read + packages: read` at workflow level even though no step in this file uses `packages: read` directly; it's there so the caller's grant can survive the intersection. The 2026-05-12 → 2026-05-14 org-wide drift outage (commit `a90dc3a` first added the narrow `permissions: contents: read` block; PR fixing it added `packages: read` back) is the receipt.
 
 **Escalating the required caller permissions is itself a breaking change** (rule 5 above — observable behavior). If a revision of this workflow needs another scope from the caller (e.g., `id-token: write` for OIDC), cut `gha/v2` and migrate consumers. The asymmetry matters: dropping a required scope is non-breaking; adding one breaks every caller that hardened to the previous floor.
 


### PR DESCRIPTION
## Summary

- Adds `packages: read` to the workflow-level `permissions:` block on `check-charset-corpus-drift.yml`. The reusable-workflow permission intersection rule was narrowing the GITHUB_TOKEN forwarded as `secrets.npm-token` down to `contents: read` only, breaking `npm pack` for every consumer since [`a90dc3a`](https://github.com/WXYC/wxyc-shared/commit/a90dc3a) (2026-05-12 09:53 PDT).
- Updates the [\"Caller permissions contract\"](https://github.com/WXYC/wxyc-shared/blob/main/CLAUDE.md#caller-permissions-contract) section in CLAUDE.md to document the intersection rule (the prior text incorrectly said the scope rode on the forwarded secret alone) and pins the 2026-05-12 → 2026-05-14 org-wide drift outage as the receipt.

Closes #138.

## Tag stability classification

**Non-breaking** per [Tag Stability Policy](https://github.com/WXYC/wxyc-shared/blob/main/CLAUDE.md#tag-stability-policy-read-before-editing-githubworkflows). Strictly more permissive callee scope; no input/secret/output signature change; no consumer relied on the failing-state behavior. **Re-point `gha/v1` forward after merge** per the documented bump procedure:

```bash
git fetch origin
git tag -f gha/v1 origin/main
git push --force origin gha/v1
```

## Test plan

- [ ] CI green on this PR.
- [ ] After `gha/v1` is re-pointed, the drift checks on [wxyc-etl#126](https://github.com/WXYC/wxyc-etl/pull/126), [request-o-matic#143](https://github.com/WXYC/request-o-matic/pull/143), and [wikidata-cache#40](https://github.com/WXYC/wikidata-cache/pull/40) flip from red to green.