### PR TITLE
feat(api): LookupResponse.timeout for LML hard-cap (1.6.1)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.6.0
+  version: 1.6.1
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -2433,6 +2433,18 @@ components:
           $ref: '#/components/schemas/CacheStats'
         identity:
           $ref: '#/components/schemas/LookupIdentityBlock'
+        timeout:
+          type: boolean
+          default: false
+          description: >
+            True when LML's server-side hard cap fired and the search pipeline
+            was abandoned mid-execution (LML#370). `results` may be partial or
+            empty in that case. Callers can use this to distinguish "no match"
+            (empty `results`, `timeout: false`) from "ran out of time"
+            (`results` may be empty, `timeout: true`). The hard cap is an
+            internal LML safety floor independent of the caller's
+            `X-Caller-Budget-Ms` header; see LML#338 / LML#340 / LML#370 for
+            the cascade-budget design.
 
     # ====================================
     # Identity Block (§3.2.2 / §3.2.5 cascade)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -504,6 +504,22 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  describe('Lookup Hard Cap (LML#370)', () => {
+    it('should add LookupResponse.timeout as an optional boolean defaulting to false', () => {
+      const schema = spec.components.schemas.LookupResponse as {
+        properties: Record<string, { type?: string; default?: unknown; description?: string }>;
+        required?: string[];
+      };
+      expect(schema.properties.timeout).toBeDefined();
+      expect(schema.properties.timeout.type).toBe('boolean');
+      expect(schema.properties.timeout.default).toBe(false);
+      // Not required — existing consumers continue to ignore the field; new
+      // consumers that read it can distinguish "no match" from "ran out of
+      // time" on the LML hard-cap path.
+      expect(schema.required ?? []).not.toContain('timeout');
+    });
+  });
+
   describe('Proxy Response Schemas', () => {
     it('should define AlbumMetadataResponse with enriched fields', () => {
       const schema = spec.components.schemas.AlbumMetadataResponse as {


### PR DESCRIPTION
## Summary
- Adds optional `timeout: boolean` (default `false`) to `LookupResponse` in `api.yaml` so callers can distinguish "no match" from "ran out of time" when LML's server-side hard cap fires.
- Bumps `info.version` and `package.json` from 1.6.0 → 1.6.1 (patch per Tag Stability Policy — additive non-breaking change).
- New contract test in `tests/api-spec.test.ts` pinning shape + default + non-required.

## Why now
[WXYC/library-metadata-lookup#370](https://github.com/WXYC/library-metadata-lookup/issues/370) ships a server-side hard cap on `execute_search_pipeline` wall time so cascade-exhaustion queries can't burn 414s of Discogs quota for an answer no one is waiting for. Without this field on the response, callers have no way to differentiate empty-because-no-match from empty-because-timed-out. The LML PR depends on this contract landing first.

## Test plan
- [x] `npm run check:breaking` — clean
- [x] `npm test` — 433/433 passing (incl. new test)
- [x] `npm run lint` — clean
- [x] `npm run generate:typescript` — `LookupResponse.timeout: boolean` present in the regenerated `src/generated/openapi-types.d.ts`

Closes #141