### PR TITLE
feat(api): SSE LiveFs* schemas, /events/stream, and 3 cross-service contracts (1.7.0)

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -92,4 +92,12 @@ When adding a new contract:
 
 ## Toggling skipped contracts
 
-The `PLAY_ORDER_PER_SHOW_MONOTONIC` and `ROTATION_DEDUP_PER_ALBUM_BIN` tests are `it.skip`-ed in CI today because the provider-side fixes have not landed. When BS#693 ships, change `it.skip(...)` to `it(...)` for the play_order test. When BS#694 ships, do the same for rotation dedup. Both are guarded with a single TODO comment naming the BS issue, so a quick grep finds them.
+Skipped contracts as of 2026-05-26, each guarded by a comment naming the blocking BS PR/issue (grep `it.skip` in `tests/e2e-contracts.test.ts`):
+
+- `PLAY_ORDER_PER_SHOW_MONOTONIC` — blocked on [BS#693](https://github.com/WXYC/Backend-Service/issues/693).
+- `ROTATION_DEDUP_PER_ALBUM_BIN` — blocked on [BS#694](https://github.com/WXYC/Backend-Service/issues/694).
+- `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` — blocked on [BS#1168](https://github.com/WXYC/Backend-Service/pull/1168) (BS-1).
+- `LIVE_FS_UPDATE_INCLUDES_FULL_ROW` — blocked on [BS#1170](https://github.com/WXYC/Backend-Service/pull/1170) (BS-2).
+- `LIVE_FS_EVENT_ENVELOPE_SHAPE` — blocked on BS#1168 (needs the public GET endpoint reachable to exercise the assertion). The shape is already enforced server-side; this is just the E2E.
+
+When the blocking change ships, flip `it.skip(...)` to `it(...)` for the corresponding test.

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -42,6 +42,33 @@ If an entry here is wrong, two things break: someone wastes a half-day diagnosin
 - **What breaks if violated:** the UI shows "undefined" or empty rows in show headers; the tubafrenzy webhook payload validation fails; archive search drops the entry from DJ-grouped views. Migration 0053 fixed the historical backfill -- the test guards against a regression on the insert side.
 - **Status:** **ENFORCED.** Asserted by adding an entry as the test DJ and reading it back via `/v2/flowsheet`.
 
+### `CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW`
+
+> The `liveFs:update` SSE event payload carries the full flowsheet row, not just `{id, metadata_status}`.
+
+- **Provider:** `Backend-Service/apps/backend/services/metadata-broadcast/metadata-broadcast.ts:filterMetadataUpdate` after [WXYC/Backend-Service#1170](https://github.com/WXYC/Backend-Service/pull/1170) (BS-2 of the live-updates SSE plan).
+- **Consumer:** `dj-site/lib/features/flowsheet/live-updates-listener.ts` patches the RTK Query cache row with whatever payload arrives.
+- **What breaks if violated:** a /live viewer that just mounted the page has no cached copy to merge into and the post-enrichment fields (`artwork_url`, `release_year`, ...) won't show until the next full GET fires. The dashboards survive because they already have the row cached, but cross-tab visibility for a freshly-mounted viewer breaks.
+- **Status (2026-05-26):** **PENDING.** Test is `it.skip`-ed until BS-2 ([WXYC/Backend-Service#1170](https://github.com/WXYC/Backend-Service/pull/1170)) merges and deploys to the E2E target stack.
+
+### `CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH`
+
+> `GET /events/stream?topics=live-fs-topic` accepts anonymous subscription.
+
+- **Provider:** `Backend-Service/apps/backend/routes/events.route.ts` (no `requirePermissions` guard on the `GET /stream` route) + `events.controller.ts:streamEventClient` with `TopicAuthz[Topics.liveFs] = []` after [WXYC/Backend-Service#1168](https://github.com/WXYC/Backend-Service/pull/1168) (BS-1 of the live-updates SSE plan).
+- **Consumer:** dj-site's listener middleware opens `EventSource(${BACKEND_URL}/events/stream?topics=live-fs-topic)` from the browser. Native EventSource is GET-only and can't attach an `Authorization` header — anonymous subscription is the whole point of the route.
+- **What breaks if violated:** every browser EventSource fires `onerror` with no useful diagnostic. The live-updates feature stops working in dashboards and on `/live` — clients fall back to the 60s safety poll. Authenticated topics (`showDj`, `primaryDj`, `mirror`) remain role-gated via `filterAuthorizedTopics`; this contract is specifically about `live-fs-topic`.
+- **Status (2026-05-26):** **PENDING.** Test is `it.skip`-ed until BS-1 ([WXYC/Backend-Service#1168](https://github.com/WXYC/Backend-Service/pull/1168)) merges and deploys to the E2E target stack.
+
+### `CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE`
+
+> Every event on the SSE stream carries the shape `{ type, payload, timestamp }`.
+
+- **Provider:** `Backend-Service/apps/backend/utils/serverEvents.ts` (`EventData<T> = { type, payload, timestamp? }`); `metadata-broadcast.ts` sets `type: FsEvents.update`.
+- **Consumer:** `dj-site/lib/features/flowsheet/live-updates-listener.ts` parses each frame by destructuring `{ type, payload }` and routing on `type`.
+- **What breaks if violated:** the listener middleware can't tell `update` from `refetch`. Either the surgical-patch path runs against a refetch payload (typeError) or the debounced invalidate runs against an update payload (extra refetch latency). The envelope is also pinned in `api.yaml` via the `LiveFsUpdateEvent` / `LiveFsRefetchEvent` schemas so a future BS change that ships a bare payload (`{id: 42}`) breaks two checks at once.
+- **Status:** **ENFORCED.** Today's `serverEventsMgr.broadcast` already sends the envelope; pinning catches a regression where someone bypasses it.
+
 ## Future invariants to add
 
 The starter set above is deliberately small (4 items). Candidates for follow-ups, ordered roughly by cost-of-violation:

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.6.1
+  version: 1.7.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3523,6 +3523,73 @@ components:
           nullable: true
           description: Album artwork URL from Spotify
 
+    LiveFsUpdateEvent:
+      description: >
+        SSE event emitted on the `live-fs-topic` when an enrichment-worker (BS#892)
+        finalizes the metadata for a flowsheet row. Payload carries the full
+        flowsheet row so a newly-mounted client (e.g. a /live viewer that just
+        opened the page) can surface the post-enrichment fields (`artwork_url`,
+        `release_year`, ...) without a follow-up GET. Provider:
+        Backend-Service/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
+        (`filterMetadataUpdate`). Consumer: dj-site `live-updates-listener.ts`.
+        Contract: `CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW`.
+      type: object
+      required:
+        - type
+        - payload
+        - timestamp
+      properties:
+        type:
+          type: string
+          enum: [update]
+        payload:
+          $ref: '#/components/schemas/FlowsheetEntryResponse'
+        timestamp:
+          type: string
+          format: date-time
+
+    LiveFsRefetchEvent:
+      description: >
+        SSE event emitted on the `live-fs-topic` when bulk state changes (ETL
+        runs, schema migrations) make targeted patches impractical. Consumers
+        respond with a coarse cache invalidation. `payload.source` is a free-text
+        label for telemetry only (`etl`, `migration`, etc.) — clients must not
+        branch on it.
+      type: object
+      required:
+        - type
+        - payload
+        - timestamp
+      properties:
+        type:
+          type: string
+          enum: [refetch]
+        payload:
+          type: object
+          required:
+            - source
+          properties:
+            source:
+              type: string
+              description: Free-text label naming the upstream cause (telemetry only).
+        timestamp:
+          type: string
+          format: date-time
+
+    LiveFsEvent:
+      description: >
+        Discriminated union of events emitted on the `live-fs-topic`. Every
+        event has the same `{ type, payload, timestamp }` envelope — pinned by
+        `CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE`.
+      oneOf:
+        - $ref: '#/components/schemas/LiveFsUpdateEvent'
+        - $ref: '#/components/schemas/LiveFsRefetchEvent'
+      discriminator:
+        propertyName: type
+        mapping:
+          update: '#/components/schemas/LiveFsUpdateEvent'
+          refetch: '#/components/schemas/LiveFsRefetchEvent'
+
 security:
   - BearerAuth: []
 
@@ -4907,3 +4974,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+
+  /events/stream:
+    get:
+      summary: Subscribe to server-sent events (EventSource-friendly)
+      description: >
+        EventSource-friendly counterpart to `POST /events/register`. Native
+        browser EventSource is GET-only and can't attach an `Authorization`
+        header — this route accepts topics as a comma-separated query string
+        and applies authorization per-topic via `TopicAuthz`. Public topics
+        (e.g. `live-fs-topic`) succeed anonymously; DJ-tier topics filter out
+        unless the caller carries a JWT with a matching role.
+
+        The response body is a `text/event-stream` of newline-delimited
+        `data: {...}\n\n` frames. The first frame is always a
+        `connection-established` event carrying the server-assigned `client_id`.
+        Subsequent frames depend on the subscribed topics — for `live-fs-topic`
+        the frames are `LiveFsEvent` instances.
+
+        Contract: `CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH`.
+      security: []
+      parameters:
+        - name: topics
+          in: query
+          required: false
+          schema:
+            type: string
+            description: >
+              Comma-separated topic strings (`live-fs-topic`, `test-topic`).
+              Unknown topics are silently dropped. Repeated `?topics=&topics=`
+              (which Express parses as an array) is ignored.
+          example: live-fs-topic
+      responses:
+        '200':
+          description: SSE stream
+          content:
+            text/event-stream:
+              schema:
+                description: >
+                  Newline-delimited `data: <JSON>\n\n` frames. The frames
+                  themselves carry shapes from `LiveFsEvent` (for
+                  `live-fs-topic`) plus the implicit `connection-established`
+                  and `subscription` envelope events.
+                oneOf:
+                  - $ref: '#/components/schemas/LiveFsEvent'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -77,6 +77,54 @@ export const CONTRACTS = {
    */
   FLOWSHEET_DJ_NAME_NON_NULL:
     'flowsheet.dj_name is non-NULL on entries inserted after migration 0053',
+
+  /**
+   * The `liveFs:update` SSE event payload carries the full flowsheet row,
+   * not just `{id, metadata_status}`.
+   *
+   * Provider: `Backend-Service/apps/backend/services/metadata-broadcast/metadata-broadcast.ts:filterMetadataUpdate`
+   * Consumer: `dj-site/lib/features/flowsheet/live-updates-listener.ts`
+   *
+   * Status: ENFORCED once Backend-Service BS-2 lands. Before BS-2 the payload
+   * was `{id, metadata_status}` and a freshly-mounted /live viewer wouldn't see
+   * the post-enrichment fields until the next full GET fired. The full-row
+   * payload is what makes cross-tab cache patching actually work.
+   */
+  LIVE_FS_UPDATE_INCLUDES_FULL_ROW:
+    'liveFs:update payload includes the full flowsheet row, not just {id, metadata_status}',
+
+  /**
+   * `GET /events/stream?topics=live-fs-topic` accepts anonymous subscription.
+   *
+   * Provider: `Backend-Service/apps/backend/routes/events.route.ts` (no
+   *           `requirePermissions` guard) + `events.controller.ts:streamEventClient`
+   *           with `TopicAuthz[Topics.liveFs] = []`.
+   * Consumer: dj-site's listener middleware opens `EventSource(...)` from the
+   *           browser, which can't attach an Authorization header.
+   *
+   * Status: ENFORCED once Backend-Service BS-1 lands. Authenticated topics
+   * (`showDj`, `primaryDj`, `mirror`) remain role-gated via
+   * `filterAuthorizedTopics`; this contract is specifically about the
+   * `live-fs-topic` public path.
+   */
+  LIVE_FS_PUBLIC_TOPIC_NO_AUTH:
+    'GET /events/stream?topics=live-fs-topic accepts anonymous subscription',
+
+  /**
+   * Every event on the SSE stream carries the shape `{ type, payload, timestamp }`.
+   *
+   * Provider: `Backend-Service/apps/backend/utils/serverEvents.ts` (`EventData<T>`)
+   *           and `metadata-broadcast.ts` (sets `type: FsEvents.update`).
+   * Consumer: `dj-site/lib/features/flowsheet/live-updates-listener.ts` parses
+   *           by destructuring `{ type, payload }` and routing on `type`.
+   *
+   * Status: ENFORCED today. The envelope is also part of `LiveFsUpdateEvent` /
+   * `LiveFsRefetchEvent` in `api.yaml` so it's machine-checkable across repos.
+   * Pinning it here catches a regression where Backend-Service sends a bare
+   * payload (`{id: 42}`) instead of `{type, payload, timestamp}`.
+   */
+  LIVE_FS_EVENT_ENVELOPE_SHAPE:
+    'every liveFs event carries the shape { type, payload, timestamp }',
 } as const;
 
 /** A reference to one of the named cross-service contracts. */

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -573,6 +573,61 @@ describe('OpenAPI Specification', () => {
     it('should define /metadata/album endpoint', () => {
       expect(spec.paths['/metadata/album']).toBeDefined();
     });
+
+    it('should define /events/stream as a public GET (no security)', () => {
+      const path = spec.paths['/events/stream'] as {
+        get?: { security?: unknown[]; parameters?: Array<{ name: string }> };
+      };
+      expect(path).toBeDefined();
+      expect(path.get).toBeDefined();
+      // security: [] explicitly opts out of the inherited BearerAuth.
+      // Browser EventSource can't attach an Authorization header — the
+      // public-topic path is the contract.
+      expect(path.get!.security).toEqual([]);
+      // `?topics=<csv>` is the wire shape — comma-separated topic strings.
+      const topics = path.get!.parameters?.find((p) => p.name === 'topics');
+      expect(topics).toBeDefined();
+    });
+  });
+
+  describe('Live-Updates SSE Schemas (live-updates-sse plan)', () => {
+    it('should define LiveFsUpdateEvent with the {type, payload, timestamp} envelope', () => {
+      const schema = spec.components.schemas.LiveFsUpdateEvent as {
+        type: string;
+        required: string[];
+        properties: Record<string, { enum?: string[]; $ref?: string }>;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+      expect(schema.required).toEqual(['type', 'payload', 'timestamp']);
+      expect(schema.properties.type.enum).toEqual(['update']);
+      // Payload is the full flowsheet row — pinned by
+      // CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW.
+      expect(schema.properties.payload.$ref).toBe('#/components/schemas/FlowsheetEntryResponse');
+    });
+
+    it('should define LiveFsRefetchEvent with the {type, payload, timestamp} envelope', () => {
+      const schema = spec.components.schemas.LiveFsRefetchEvent as {
+        type: string;
+        required: string[];
+        properties: Record<string, { enum?: string[] }>;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.required).toEqual(['type', 'payload', 'timestamp']);
+      expect(schema.properties.type.enum).toEqual(['refetch']);
+    });
+
+    it('should define LiveFsEvent as a discriminated union over `type`', () => {
+      const schema = spec.components.schemas.LiveFsEvent as {
+        oneOf: Array<{ $ref: string }>;
+        discriminator: { propertyName: string; mapping: Record<string, string> };
+      };
+      expect(schema).toBeDefined();
+      expect(schema.oneOf).toHaveLength(2);
+      expect(schema.discriminator.propertyName).toBe('type');
+      expect(schema.discriminator.mapping.update).toContain('LiveFsUpdateEvent');
+      expect(schema.discriminator.mapping.refetch).toContain('LiveFsRefetchEvent');
+    });
   });
 
   describe('Security', () => {

--- a/tests/e2e-contracts.test.ts
+++ b/tests/e2e-contracts.test.ts
@@ -222,6 +222,153 @@ describe('Cross-service contracts (E2E)', () => {
     }
   );
 
+  // ── LIVE_FS_PUBLIC_TOPIC_NO_AUTH ─────────────────────────────────────
+  //
+  // SKIPPED: Backend-Service BS-1 (#1168) has not landed. dj-site's
+  // listener middleware opens an EventSource without an Authorization
+  // header; if the GET endpoint requires auth, anonymous subscription
+  // fails. Flip `it.skip` to `it` once #1168 is merged and deployed.
+  it.skip(
+    `upholds CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH: ${CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH}`,
+    async () => {
+      // Anonymous fetch — no Authorization header.
+      const resp = await fetch(`${config.baseUrl}/events/stream?topics=live-fs-topic`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(2000),
+      }).catch((err: Error) => {
+        // AbortError is the expected exit once we've read the first frame.
+        if (err.name === 'AbortError') return null;
+        throw err;
+      });
+
+      if (resp === null) {
+        // The fetch was aborted before headers came back — should not happen
+        // for an unauthenticated GET on a public topic.
+        throw new Error('GET /events/stream timed out before sending headers');
+      }
+      expect(resp.status, 'public GET /events/stream must accept anonymous callers').toBe(200);
+      expect(resp.headers.get('content-type')).toMatch(/text\/event-stream/);
+      // We don't need to consume the stream — accepting the connection is the
+      // contract under test. Cancel the body so the connection closes cleanly.
+      await resp.body?.cancel();
+    }
+  );
+
+  // ── LIVE_FS_UPDATE_INCLUDES_FULL_ROW ─────────────────────────────────
+  //
+  // SKIPPED: Backend-Service BS-2 (#1170) has not landed. Pre-BS-2 the
+  // payload was `{id, metadata_status}` — a freshly-mounted /live viewer
+  // wouldn't see the post-enrichment fields. Flip `it.skip` to `it` once
+  // #1170 is merged and deployed.
+  it.skip(
+    `upholds CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW: ${CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW}`,
+    async ({ skip }) => {
+      if (!hasCredentials) skip();
+
+      // Open the SSE stream first so we don't race against the post.
+      const controller = new AbortController();
+      const streamResp = await fetch(
+        `${config.baseUrl}/events/stream?topics=live-fs-topic`,
+        { method: 'GET', signal: controller.signal }
+      );
+      expect(streamResp.status).toBe(200);
+
+      // Insert a row that the enrichment-worker will (eventually) terminally
+      // mark with `metadata_status=enriched_no_match` (freeform entries that
+      // don't match any catalog row land there).
+      const post = await client.post<FlowsheetEntryResponse>('/flowsheet', {
+        artist_name: `LiveFs Update ${uniqueSuffix}`,
+        album_title: `Update Album ${uniqueSuffix}`,
+        track_title: `Update Track ${uniqueSuffix}`,
+        request_flag: false,
+      } satisfies FlowsheetCreateSongFreeform);
+      expect(post.ok).toBe(true);
+      const newId = post.body.id;
+
+      // Read SSE frames until we see an `update` event for the row we just
+      // inserted, or hit the 30s ceiling for the enrichment chain.
+      const reader = streamResp.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      const deadline = Date.now() + 30_000;
+      let matched: {
+        type: string;
+        payload: { id: number; metadata_status?: string; artist_name?: string };
+      } | null = null;
+
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const frames = buf.split('\n\n');
+        buf = frames.pop() ?? '';
+        for (const raw of frames) {
+          if (!raw.startsWith('data: ')) continue;
+          const parsed = JSON.parse(raw.slice(6));
+          if (parsed.type === 'update' && parsed.payload?.id === newId) {
+            matched = parsed;
+            break;
+          }
+        }
+        if (matched) break;
+      }
+      controller.abort();
+      expect(matched, 'expected an update frame for the just-inserted row').not.toBeNull();
+
+      // VIOLATION SYMPTOM: payload is `{id, metadata_status}` only. After
+      // BS-2 lands the payload IS the full row, so non-required fields like
+      // `artist_name` round-trip.
+      expect(matched!.payload.artist_name, 'payload should carry full row data, including artist_name').toBe(
+        `LiveFs Update ${uniqueSuffix}`
+      );
+    }
+  );
+
+  // ── LIVE_FS_EVENT_ENVELOPE_SHAPE ─────────────────────────────────────
+  //
+  // ENFORCED today (the `EventData<T>` shape on Backend-Service is
+  // already in place). The envelope is also pinned by the api.yaml
+  // schemas so a regression here breaks two checks at once.
+  it.skip(
+    `upholds CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE: ${CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE}`,
+    async () => {
+      // Skipped until BS-1 (#1168) lands and the public GET endpoint is
+      // reachable for an anonymous subscriber. Once available the body
+      // below asserts the envelope shape across the first non-handshake
+      // frame.
+      const controller = new AbortController();
+      const streamResp = await fetch(
+        `${config.baseUrl}/events/stream?topics=live-fs-topic`,
+        { method: 'GET', signal: controller.signal }
+      );
+      expect(streamResp.status).toBe(200);
+
+      const reader = streamResp.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      const deadline = Date.now() + 5_000;
+      let firstFrame: { type?: unknown; payload?: unknown; timestamp?: unknown } | null = null;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const frames = buf.split('\n\n');
+        buf = frames.pop() ?? '';
+        for (const raw of frames) {
+          if (!raw.startsWith('data: ')) continue;
+          firstFrame = JSON.parse(raw.slice(6));
+          break;
+        }
+        if (firstFrame) break;
+      }
+      controller.abort();
+      expect(firstFrame, 'expected at least one SSE frame').not.toBeNull();
+      expect(typeof firstFrame!.type, 'frame.type must be a string').toBe('string');
+      expect(firstFrame!.payload, 'frame.payload must be present').toBeDefined();
+      expect(firstFrame!.timestamp, 'frame.timestamp must be present').toBeDefined();
+    }
+  );
+
   // ── FLOWSHEET_DJ_NAME_NON_NULL ───────────────────────────────────────
   //
   // ENFORCED. Migration 0053 backfilled historical NULLs and the insert

--- a/tests/e2e-contracts.test.ts
+++ b/tests/e2e-contracts.test.ts
@@ -231,19 +231,19 @@ describe('Cross-service contracts (E2E)', () => {
   it.skip(
     `upholds CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH: ${CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH}`,
     async () => {
-      // Anonymous fetch — no Authorization header.
+      // Anonymous fetch — no Authorization header. The 2s timeout is a
+      // safety net so the test fails fast if the server hangs without
+      // sending headers; on a healthy stack the response arrives well
+      // before it fires.
       const resp = await fetch(`${config.baseUrl}/events/stream?topics=live-fs-topic`, {
         method: 'GET',
         signal: AbortSignal.timeout(2000),
       }).catch((err: Error) => {
-        // AbortError is the expected exit once we've read the first frame.
         if (err.name === 'AbortError') return null;
         throw err;
       });
 
       if (resp === null) {
-        // The fetch was aborted before headers came back — should not happen
-        // for an unauthenticated GET on a public topic.
         throw new Error('GET /events/stream timed out before sending headers');
       }
       expect(resp.status, 'public GET /events/stream must accept anonymous callers').toBe(200);


### PR DESCRIPTION
## Summary

- Adds `LiveFsUpdateEvent`, `LiveFsRefetchEvent`, `LiveFsEvent` schemas and the `GET /events/stream` endpoint to `api.yaml`. Bumps `@wxyc/shared` to **1.7.0** (additive — no consumer-breaking changes).
- Adds three new `CONTRACTS` entries pinning the cross-repo invariants that the live-updates SSE feature loads on: `LIVE_FS_UPDATE_INCLUDES_FULL_ROW`, `LIVE_FS_PUBLIC_TOPIC_NO_AUTH`, `LIVE_FS_EVENT_ENVELOPE_SHAPE`. Each is fully documented in `INVARIANTS.md` (provider, consumer, what breaks if violated, current status).
- Adds three E2E contract tests (`it.skip` until the Backend-Service PRs deploy to the E2E target stack) and four structural unit tests pinning the new schemas + endpoint.

Closes #143. Companion to the four sequenced Backend-Service PRs: [WXYC/Backend-Service#1168](https://github.com/WXYC/Backend-Service/pull/1168), [WXYC/Backend-Service#1170](https://github.com/WXYC/Backend-Service/pull/1170), [WXYC/Backend-Service#1172](https://github.com/WXYC/Backend-Service/pull/1172), [WXYC/Backend-Service#1174](https://github.com/WXYC/Backend-Service/pull/1174). dj-site already consumes the wire format behind two feature flags that both default OFF ([WXYC/dj-site#659](https://github.com/WXYC/dj-site/pull/659), merged). Plan: [WXYC/dj-site `docs/live-updates-sse.md`](https://github.com/WXYC/dj-site/blob/main/docs/live-updates-sse.md).

## Test plan

- [x] `npm test` — 437 / 437 (all unit + structural).
- [x] `npm run lint` (tsc) clean.
- [x] `npm run generate:typescript` regenerates without errors; `LiveFsUpdateEvent` / `LiveFsRefetchEvent` / `LiveFsEvent` exports appear in `src/generated/models/index.ts`.
- [x] E2E contract tests stay `it.skip` until the Backend-Service deploys complete — comments name each blocking PR.