### PR TITLE
test(contracts): un-skip 3 LIVE_FS_* cross-repo contracts

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -49,7 +49,7 @@ If an entry here is wrong, two things break: someone wastes a half-day diagnosin
 - **Provider:** `Backend-Service/apps/backend/services/metadata-broadcast/metadata-broadcast.ts:filterMetadataUpdate` after [WXYC/Backend-Service#1170](https://github.com/WXYC/Backend-Service/pull/1170) (BS-2 of the live-updates SSE plan).
 - **Consumer:** `dj-site/lib/features/flowsheet/live-updates-listener.ts` patches the RTK Query cache row with whatever payload arrives.
 - **What breaks if violated:** a /live viewer that just mounted the page has no cached copy to merge into and the post-enrichment fields (`artwork_url`, `release_year`, ...) won't show until the next full GET fires. The dashboards survive because they already have the row cached, but cross-tab visibility for a freshly-mounted viewer breaks.
-- **Status (2026-05-26):** **PENDING.** Test is `it.skip`-ed until BS-2 ([WXYC/Backend-Service#1170](https://github.com/WXYC/Backend-Service/pull/1170)) merges and deploys to the E2E target stack.
+- **Status (2026-05-28):** **ENFORCED.** BS-2 ([WXYC/Backend-Service#1170](https://github.com/WXYC/Backend-Service/pull/1170)) merged and deployed; the contract test runs against the E2E target.
 
 ### `CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH`
 
@@ -58,7 +58,7 @@ If an entry here is wrong, two things break: someone wastes a half-day diagnosin
 - **Provider:** `Backend-Service/apps/backend/routes/events.route.ts` (no `requirePermissions` guard on the `GET /stream` route) + `events.controller.ts:streamEventClient` with `TopicAuthz[Topics.liveFs] = []` after [WXYC/Backend-Service#1168](https://github.com/WXYC/Backend-Service/pull/1168) (BS-1 of the live-updates SSE plan).
 - **Consumer:** dj-site's listener middleware opens `EventSource(${BACKEND_URL}/events/stream?topics=live-fs-topic)` from the browser. Native EventSource is GET-only and can't attach an `Authorization` header — anonymous subscription is the whole point of the route.
 - **What breaks if violated:** every browser EventSource fires `onerror` with no useful diagnostic. The live-updates feature stops working in dashboards and on `/live` — clients fall back to the 60s safety poll. Authenticated topics (`showDj`, `primaryDj`, `mirror`) remain role-gated via `filterAuthorizedTopics`; this contract is specifically about `live-fs-topic`.
-- **Status (2026-05-26):** **PENDING.** Test is `it.skip`-ed until BS-1 ([WXYC/Backend-Service#1168](https://github.com/WXYC/Backend-Service/pull/1168)) merges and deploys to the E2E target stack.
+- **Status (2026-05-28):** **ENFORCED.** BS-1 ([WXYC/Backend-Service#1168](https://github.com/WXYC/Backend-Service/pull/1168)) merged and deployed; the contract test runs against the E2E target.
 
 ### `CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE`
 
@@ -92,12 +92,9 @@ When adding a new contract:
 
 ## Toggling skipped contracts
 
-Skipped contracts as of 2026-05-26, each guarded by a comment naming the blocking BS PR/issue (grep `it.skip` in `tests/e2e-contracts.test.ts`):
+Skipped contracts as of 2026-05-28, each guarded by a comment naming the blocking BS PR/issue (grep `it.skip` in `tests/e2e-contracts.test.ts`):
 
 - `PLAY_ORDER_PER_SHOW_MONOTONIC` — blocked on [BS#693](https://github.com/WXYC/Backend-Service/issues/693).
 - `ROTATION_DEDUP_PER_ALBUM_BIN` — blocked on [BS#694](https://github.com/WXYC/Backend-Service/issues/694).
-- `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` — blocked on [BS#1168](https://github.com/WXYC/Backend-Service/pull/1168) (BS-1).
-- `LIVE_FS_UPDATE_INCLUDES_FULL_ROW` — blocked on [BS#1170](https://github.com/WXYC/Backend-Service/pull/1170) (BS-2).
-- `LIVE_FS_EVENT_ENVELOPE_SHAPE` — blocked on BS#1168 (needs the public GET endpoint reachable to exercise the assertion). The shape is already enforced server-side; this is just the E2E.
 
 When the blocking change ships, flip `it.skip(...)` to `it(...)` for the corresponding test.

--- a/docs/plans/unskip-live-fs-contracts.md
+++ b/docs/plans/unskip-live-fs-contracts.md
@@ -1,0 +1,93 @@
+# Plan: Un-skip 3 `LIVE_FS_*` cross-repo contract tests
+
+## Issue
+
+[WXYC/wxyc-shared#145](https://github.com/WXYC/wxyc-shared/issues/145) — three skipped contract tests in `tests/e2e-contracts.test.ts` were blocked on Backend-Service PRs (BS-1 #1168, BS-2 #1170) that have since merged and auto-deployed. Flip the skips and update `INVARIANTS.md` accordingly.
+
+## Goal
+
+Close the cross-repo contract loop documented in `INVARIANTS.md` for live-updates SSE, so a regression on the BS side (revoking public anonymous access, dropping a payload field, breaking the envelope) is caught by `npm run test:e2e:contracts` in CI.
+
+## Three contracts, three different gating decisions
+
+The issue body says "the three `it.skip(...)` calls become `it.skipIf(!hasCredentials)(...)`". That phrasing works for **one** of the three; for the other two it would needlessly skip CI runs that should pass against any healthy stack. The test bodies clarify which is which:
+
+| Contract | Current state | Right new state | Reason |
+|---|---|---|---|
+| `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` | `it.skip(...)` | **`it(...)`** (plain) | The whole point of the test is to assert anonymous access works. Gating on `hasCredentials` would mask the regression we're trying to catch — a test that needs no creds should run regardless of whether creds are configured. |
+| `LIVE_FS_UPDATE_INCLUDES_FULL_ROW` | `it.skip(...)` with `if (!hasCredentials) skip()` body | **`it.skipIf(!hasCredentials)(...)`** | Test inserts a flowsheet row via authed `client.post`. Needs creds. Already had the inner `skip()` guard, which becomes redundant once `it.skipIf` does the same job at the test-definition level. |
+| `LIVE_FS_EVENT_ENVELOPE_SHAPE` | `it.skip(...)` | **`it(...)`** (plain) | Anonymous fetch + read first frame. No creds needed. Same anonymous shape as `LIVE_FS_PUBLIC_TOPIC_NO_AUTH`. |
+
+The two anonymous tests rely on at least one SSE frame arriving within a 5–30s budget. On a quiet stack with no enrichment activity, there are no frames — see "Risk: flakiness" below.
+
+## Changes
+
+### `tests/e2e-contracts.test.ts`
+
+Three precise edits:
+
+1. **`LIVE_FS_PUBLIC_TOPIC_NO_AUTH`** (currently line 231) — replace `it.skip(` with `it(`. Delete the preceding "SKIPPED: Backend-Service BS-1 (#1168) has not landed..." comment block.
+
+2. **`LIVE_FS_UPDATE_INCLUDES_FULL_ROW`** (currently line 263) — replace `it.skip(` with `it.skipIf(!hasCredentials)(`. Drop the inner `if (!hasCredentials) skip()` line since the gate now lives at the test-definition level. Delete the "SKIPPED: Backend-Service BS-2 (#1170) has not landed..." comment block.
+
+3. **`LIVE_FS_EVENT_ENVELOPE_SHAPE`** (currently line 332) — replace `it.skip(` with `it(`. Drop the inner "Skipped until BS-1 (#1168) lands..." comment, keeping the rest of the test body intact.
+
+### `INVARIANTS.md`
+
+Two precise edits:
+
+1. The per-contract **Status** lines (currently lines 52 and 61) change from:
+   > **Status (2026-05-26):** **PENDING.** Test is `it.skip`-ed until BS-2/BS-1 ([WXYC/Backend-Service#NNNN](...)) merges and deploys to the E2E target stack.
+
+   to:
+   > **Status (2026-05-28):** **ENFORCED.** BS-2 / BS-1 ([WXYC/Backend-Service#NNNN](...)) merged and deployed; test runs against the E2E target.
+
+   The `LIVE_FS_EVENT_ENVELOPE_SHAPE` status (currently line 70) is already **ENFORCED** in copy ("today's `serverEventsMgr.broadcast` already sends the envelope; pinning catches a regression"). The accompanying comment in the test file was the only "PENDING" surface, so no INVARIANTS edit is needed there — but I'll update the date stamp to 2026-05-28 for consistency.
+
+2. The **Toggling skipped contracts** list (currently lines 99–101) drops the three `LIVE_FS_*` entries, leaving only the two remaining skipped contracts (`PLAY_ORDER_PER_SHOW_MONOTONIC`, `ROTATION_DEDUP_PER_ALBUM_BIN`).
+
+## Risk: flakiness in the two anonymous tests
+
+Both `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` and `LIVE_FS_EVENT_ENVELOPE_SHAPE` depend on SSE frames arriving within their respective deadlines (2s / 5s). Looking at each:
+
+- **`LIVE_FS_PUBLIC_TOPIC_NO_AUTH`** doesn't read any frames — it asserts the *connection* succeeds (status 200, `text/event-stream` content-type), then cancels the body. Robust regardless of stack activity. No flakiness risk.
+
+- **`LIVE_FS_EVENT_ENVELOPE_SHAPE`** *does* read frames — it loops `await reader.read()` until a `data:` frame arrives or 5s elapses. On a quiet stack with no enrichment activity, no frames arrive and the test fails with "expected at least one SSE frame". This is genuinely flaky against `api.wxyc.org` outside DJ-active hours.
+
+**Trade-off.** The cleanest fix is to make the envelope test self-trigger: POST a flowsheet row (like `LIVE_FS_UPDATE_INCLUDES_FULL_ROW` does), wait for the matching frame, assert envelope shape. That converts the envelope test into an authed test, gated on `hasCredentials`. Net change to the spec is small.
+
+**Decision.** Make the envelope test self-trigger and gate it on `hasCredentials`. The contract is "every emitted frame has `{type, payload, timestamp}`", and the only way to reliably observe a frame is to cause one to be emitted. The bonus: the existing 5s deadline becomes the timeout for "enrichment fires" and the test no longer depends on ambient stack activity.
+
+Updated final table:
+
+| Contract | Right new state | Reason |
+|---|---|---|
+| `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` | `it(...)` | Pure connection check, no frames consumed. |
+| `LIVE_FS_UPDATE_INCLUDES_FULL_ROW` | `it.skipIf(!hasCredentials)(...)` | Inserts row, reads frames. |
+| `LIVE_FS_EVENT_ENVELOPE_SHAPE` | `it.skipIf(!hasCredentials)(...)` | Inserts row to guarantee a frame arrives, then asserts envelope shape. |
+
+This reverses the "two of three should not gate on creds" table earlier — the envelope test gets self-triggering for reliability.
+
+## Constraints honored
+
+| Issue constraint | How it's met |
+|---|---|
+| "Tests must remain runnable both with and without `E2E_TEST_DJ_EMAIL` configured" | `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` runs unconditionally (no creds needed). The other two use `it.skipIf(!hasCredentials)` so a credential-less run still passes. |
+| "No package version bump — test-only change" | No edits to `package.json` / `api.yaml` / `src/contracts.ts`. |
+| "Sentry / PostHog spans should NOT be emitted from the SSE-anonymous test" | `tests/e2e-contracts.test.ts` doesn't import Sentry or PostHog at all — the test runner is plain Vitest against `node:fetch`. No change needed. |
+
+## Acceptance
+
+- `npm run test:e2e:contracts` passes locally against `E2E_BASE_URL=http://localhost:8080` (when credentials are configured) and against `https://api.wxyc.org` (in CI's release-validation flow).
+- The 3 newly-active tests pass against prod.
+- `INVARIANTS.md` no longer lists the three contracts under **Toggling skipped contracts**.
+- Status lines for `LIVE_FS_UPDATE_INCLUDES_FULL_ROW` and `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` change from **PENDING** to **ENFORCED**.
+- No new dependencies, no `src/` changes — test-only diff.
+
+## File summary
+
+| File | Action | Notes |
+|---|---|---|
+| `tests/e2e-contracts.test.ts` | modify | Flip 3 `it.skip` → `it` / `it.skipIf(!hasCredentials)`; rewrite envelope test to self-trigger; drop 3 "SKIPPED:" comment blocks |
+| `INVARIANTS.md` | modify | 2 status lines PENDING → ENFORCED; drop 3 entries from the "Toggling skipped contracts" list |
+| `docs/plans/unskip-live-fs-contracts.md` | new | This file |

--- a/tests/e2e-contracts.test.ts
+++ b/tests/e2e-contracts.test.ts
@@ -5,11 +5,10 @@
  * documents the named invariant in its description so a failure in CI
  * names the contract that broke.
  *
- * Two of the four contracts (PLAY_ORDER_PER_SHOW_MONOTONIC,
- * ROTATION_DEDUP_PER_ALBUM_BIN) are NOT yet enforced on the server side
- * as of 2026-05-01. Those tests are `it.skip`-ed; the assertion bodies
- * still describe target state. To enable them, replace `it.skip` with
- * `it` once the BS-side fix lands (see comments inline).
+ * Two contracts (PLAY_ORDER_PER_SHOW_MONOTONIC, ROTATION_DEDUP_PER_ALBUM_BIN)
+ * are NOT yet enforced on the server side. Those tests are `it.skip`-ed; the
+ * assertion bodies still describe target state. To enable them, replace
+ * `it.skip` with `it` once the BS-side fix lands (see comments inline).
  *
  * Prerequisites:
  *   - Backend service at $E2E_BASE_URL (default http://localhost:8080)
@@ -224,11 +223,9 @@ describe('Cross-service contracts (E2E)', () => {
 
   // ── LIVE_FS_PUBLIC_TOPIC_NO_AUTH ─────────────────────────────────────
   //
-  // SKIPPED: Backend-Service BS-1 (#1168) has not landed. dj-site's
-  // listener middleware opens an EventSource without an Authorization
-  // header; if the GET endpoint requires auth, anonymous subscription
-  // fails. Flip `it.skip` to `it` once #1168 is merged and deployed.
-  it.skip(
+  // Pure anonymous connection check — no creds required, so the test runs
+  // unconditionally on every CI invocation.
+  it(
     `upholds CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH: ${CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH}`,
     async () => {
       // Anonymous fetch — no Authorization header. The 2s timeout is a
@@ -256,15 +253,10 @@ describe('Cross-service contracts (E2E)', () => {
 
   // ── LIVE_FS_UPDATE_INCLUDES_FULL_ROW ─────────────────────────────────
   //
-  // SKIPPED: Backend-Service BS-2 (#1170) has not landed. Pre-BS-2 the
-  // payload was `{id, metadata_status}` — a freshly-mounted /live viewer
-  // wouldn't see the post-enrichment fields. Flip `it.skip` to `it` once
-  // #1170 is merged and deployed.
-  it.skip(
+  // Posts a flowsheet row via the authed client, so this test needs creds.
+  it.skipIf(!hasCredentials)(
     `upholds CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW: ${CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW}`,
-    async ({ skip }) => {
-      if (!hasCredentials) skip();
-
+    async () => {
       // Open the SSE stream first so we don't race against the post.
       const controller = new AbortController();
       const streamResp = await fetch(
@@ -326,16 +318,18 @@ describe('Cross-service contracts (E2E)', () => {
 
   // ── LIVE_FS_EVENT_ENVELOPE_SHAPE ─────────────────────────────────────
   //
-  // ENFORCED today (the `EventData<T>` shape on Backend-Service is
-  // already in place). The envelope is also pinned by the api.yaml
-  // schemas so a regression here breaks two checks at once.
-  it.skip(
+  // The envelope (`{ type, payload, timestamp }`) is already enforced
+  // server-side via `EventData<T>` and pinned at the schema layer in
+  // `api.yaml`. This test exercises the wire format end-to-end against
+  // a live stack.
+  //
+  // Self-triggers via an authed flowsheet insert so a quiet stack
+  // doesn't leave the test waiting on an event that never arrives. The
+  // anonymous code path (no creds, plain GET) is already exercised by
+  // LIVE_FS_PUBLIC_TOPIC_NO_AUTH above.
+  it.skipIf(!hasCredentials)(
     `upholds CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE: ${CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE}`,
     async () => {
-      // Skipped until BS-1 (#1168) lands and the public GET endpoint is
-      // reachable for an anonymous subscriber. Once available the body
-      // below asserts the envelope shape across the first non-handshake
-      // frame.
       const controller = new AbortController();
       const streamResp = await fetch(
         `${config.baseUrl}/events/stream?topics=live-fs-topic`,
@@ -343,10 +337,21 @@ describe('Cross-service contracts (E2E)', () => {
       );
       expect(streamResp.status).toBe(200);
 
+      // Trigger an enrichment event by inserting a freeform row. The
+      // metadata pipeline reliably emits a terminal-status liveFs:update
+      // within the 30s ceiling on any healthy stack.
+      const post = await client.post<FlowsheetEntryResponse>('/flowsheet', {
+        artist_name: `LiveFs Envelope ${uniqueSuffix}`,
+        album_title: `Envelope Album ${uniqueSuffix}`,
+        track_title: `Envelope Track ${uniqueSuffix}`,
+        request_flag: false,
+      } satisfies FlowsheetCreateSongFreeform);
+      expect(post.ok).toBe(true);
+
       const reader = streamResp.body!.getReader();
       const decoder = new TextDecoder();
       let buf = '';
-      const deadline = Date.now() + 5_000;
+      const deadline = Date.now() + 30_000;
       let firstFrame: { type?: unknown; payload?: unknown; timestamp?: unknown } | null = null;
       while (Date.now() < deadline) {
         const { value, done } = await reader.read();

--- a/tests/e2e-contracts.test.ts
+++ b/tests/e2e-contracts.test.ts
@@ -35,6 +35,14 @@ import type {
 } from '../src/generated/models/index.js';
 
 /**
+ * Wire-format topic name for the liveFs SSE topic. Backend-Service's
+ * `Topics.liveFs` resolves to this string; dj-site's listener middleware
+ * subscribes to it via `?topics=live-fs-topic`. Pinned by the three
+ * LIVE_FS_* contracts below.
+ */
+const LIVE_FS_TOPIC = 'live-fs-topic';
+
+/**
  * Set of role values recognized by the backend's `requirePermissions`
  * middleware after `normalizeRole()` runs. A JWT carrying any of these
  * is sufficient to authorize an authenticated request.
@@ -232,7 +240,7 @@ describe('Cross-service contracts (E2E)', () => {
       // safety net so the test fails fast if the server hangs without
       // sending headers; on a healthy stack the response arrives well
       // before it fires.
-      const resp = await fetch(`${config.baseUrl}/events/stream?topics=live-fs-topic`, {
+      const resp = await fetch(`${config.baseUrl}/events/stream?topics=${LIVE_FS_TOPIC}`, {
         method: 'GET',
         signal: AbortSignal.timeout(2000),
       }).catch((err: Error) => {
@@ -260,7 +268,7 @@ describe('Cross-service contracts (E2E)', () => {
       // Open the SSE stream first so we don't race against the post.
       const controller = new AbortController();
       const streamResp = await fetch(
-        `${config.baseUrl}/events/stream?topics=live-fs-topic`,
+        `${config.baseUrl}/events/stream?topics=${LIVE_FS_TOPIC}`,
         { method: 'GET', signal: controller.signal }
       );
       expect(streamResp.status).toBe(200);
@@ -307,9 +315,8 @@ describe('Cross-service contracts (E2E)', () => {
       controller.abort();
       expect(matched, 'expected an update frame for the just-inserted row').not.toBeNull();
 
-      // VIOLATION SYMPTOM: payload is `{id, metadata_status}` only. After
-      // BS-2 lands the payload IS the full row, so non-required fields like
-      // `artist_name` round-trip.
+      // VIOLATION SYMPTOM: payload is `{id, metadata_status}` only — non-
+      // required fields like `artist_name` are missing from the broadcast.
       expect(matched!.payload.artist_name, 'payload should carry full row data, including artist_name').toBe(
         `LiveFs Update ${uniqueSuffix}`
       );
@@ -332,7 +339,7 @@ describe('Cross-service contracts (E2E)', () => {
     async () => {
       const controller = new AbortController();
       const streamResp = await fetch(
-        `${config.baseUrl}/events/stream?topics=live-fs-topic`,
+        `${config.baseUrl}/events/stream?topics=${LIVE_FS_TOPIC}`,
         { method: 'GET', signal: controller.signal }
       );
       expect(streamResp.status).toBe(200);


### PR DESCRIPTION
## Summary

- Flips three `it.skip(...)` → live contract tests now that BS-1 (#1168) and BS-2 (#1170) are deployed to `api.wxyc.org`:
  - `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` → plain `it(...)` (anonymous connection check, no creds needed).
  - `LIVE_FS_UPDATE_INCLUDES_FULL_ROW` → `it.skipIf(!hasCredentials)(...)` (posts an authed row).
  - `LIVE_FS_EVENT_ENVELOPE_SHAPE` → `it.skipIf(!hasCredentials)(...)` and rewritten to self-trigger via an authed insert (the prior shape waited on ambient frames, which is flaky on a quiet stack). Anonymous path is already covered by `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` + the `api.yaml` schema pin.
- `INVARIANTS.md`: two contracts move from **PENDING** to **ENFORCED**; drops the three rows from the "Toggling skipped contracts" list.
- Plan at `docs/plans/unskip-live-fs-contracts.md`.

## Test plan

- [ ] `npm test` passes (437 unit tests; smoke-tested locally)
- [ ] `npm run test:e2e:contracts` runs the three newly-active tests against `https://api.wxyc.org` in CI's release-validation flow
- [ ] No `package.json` / `api.yaml` / `src/contracts.ts` changes — test-only diff

Closes #145