### PR TITLE
Advertise metadata_status on V2 flowsheet response schemas

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -276,6 +276,8 @@ components:
                 flowsheet entry was created via the dj-site picker after release selection
                 (catalog-track-search plan §5.3 / Track 3). String-typed to match Discogs's
                 `release_track.position`. Null for free-text entries and legacy rows.
+            metadata_status:
+              $ref: '#/components/schemas/MetadataStatus'
 
     FlowsheetSongEntry:
       description: Song entry in the flowsheet
@@ -671,6 +673,8 @@ components:
               type: boolean
               nullable: true
               description: Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.
+            metadata_status:
+              $ref: '#/components/schemas/MetadataStatus'
 
     FlowsheetV2ShowStartEntry:
       description: V2 show start event - when a show begins
@@ -1811,6 +1815,22 @@ components:
         - apple_music
         - cache
         - none
+
+    MetadataStatus:
+      type: string
+      enum:
+        - pending
+        - enriching
+        - enriched_match
+        - enriched_no_match
+        - failed_no_retry
+      description: >
+        Enrichment lifecycle for a track row in the V2 flowsheet response. Source-of-truth is
+        the `metadata_status_enum` Postgres type in Backend-Service (see WXYC/Backend-Service#891).
+        Set to `pending` on insert; the enrichment worker (WXYC/Backend-Service#892) flips it
+        to `enriching` while a Discogs lookup is in flight, then to one of the three terminal
+        states. iOS branches on this to decide whether to render inline metadata or fall back
+        to the proxy-fetch path (WXYC/wxyc-ios-64#270). Only emitted on track entries.
 
     AlbumMetadata:
       type: object

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -151,6 +151,63 @@ describe('OpenAPI Specification', () => {
         expect(trackPosition?.nullable).toBe(true);
       });
     });
+
+    describe('metadata_status field (BS#891 / Epic C)', () => {
+      function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
+        const schema = spec.components.schemas[schemaName] as
+          | { properties?: Record<string, Record<string, unknown>>; allOf?: Array<{ properties?: Record<string, Record<string, unknown>> }> }
+          | undefined;
+        if (!schema) return undefined;
+        if (schema.properties?.[prop]) return schema.properties[prop];
+        for (const branch of schema.allOf ?? []) {
+          if (branch.properties?.[prop]) return branch.properties[prop];
+        }
+        return undefined;
+      }
+
+      it('should define MetadataStatus enum with all 5 BS-side values', () => {
+        const metadataStatus = spec.components.schemas.MetadataStatus as { type?: string; enum?: string[] };
+        expect(metadataStatus).toBeDefined();
+        expect(metadataStatus.type).toBe('string');
+        expect(metadataStatus.enum).toEqual([
+          'pending',
+          'enriching',
+          'enriched_match',
+          'enriched_no_match',
+          'failed_no_retry',
+        ]);
+      });
+
+      it('FlowsheetEntryResponse should $ref MetadataStatus on metadata_status', () => {
+        const ms = getProperty('FlowsheetEntryResponse', 'metadata_status');
+        expect(ms).toBeDefined();
+        expect(ms?.$ref).toBe('#/components/schemas/MetadataStatus');
+      });
+
+      it('FlowsheetEntryResponse should not require metadata_status (absent on non-track / pre-Epic-C rows)', () => {
+        const schema = spec.components.schemas.FlowsheetEntryResponse as {
+          allOf?: Array<{ required?: string[] }>;
+          required?: string[];
+        };
+        const required = [...(schema.required ?? []), ...(schema.allOf ?? []).flatMap((b) => b.required ?? [])];
+        expect(required).not.toContain('metadata_status');
+      });
+
+      it('FlowsheetV2TrackEntry should $ref MetadataStatus on metadata_status', () => {
+        const ms = getProperty('FlowsheetV2TrackEntry', 'metadata_status');
+        expect(ms).toBeDefined();
+        expect(ms?.$ref).toBe('#/components/schemas/MetadataStatus');
+      });
+
+      it('FlowsheetV2TrackEntry should not require metadata_status', () => {
+        const schema = spec.components.schemas.FlowsheetV2TrackEntry as {
+          allOf?: Array<{ required?: string[] }>;
+          required?: string[];
+        };
+        const required = [...(schema.required ?? []), ...(schema.allOf ?? []).flatMap((b) => b.required ?? [])];
+        expect(required).not.toContain('metadata_status');
+      });
+    });
   });
 
   describe('Catalog Schemas', () => {


### PR DESCRIPTION
## Summary

- Adds `MetadataStatus` enum schema (5 values, exactly matching Backend's `metadata_status_enum` Postgres type from BS#891).
- Adds `metadata_status: { \$ref: MetadataStatus }` to `FlowsheetEntryResponse` and `FlowsheetV2TrackEntry` (both optional).
- TDD: 5 new assertions in `tests/api-spec.test.ts` covering the enum shape, the field reference on both schemas, and the optional-not-required constraint. All 442 tests pass.

## Why now

BS shipped `metadata_status` on the V2 wire when BS#891 / [BS#1004](https://github.com/WXYC/Backend-Service/pull/1004) merged on 2026-05-22. Prod probe (2026-05-28) confirms the field is live on every track row. The iOS decoder [WXYC/wxyc-ios-64#287](https://github.com/WXYC/wxyc-ios-64/pull/287) merged today against the wire format; until this PR lands, generated TS types in `@wxyc/shared/dtos` still don't expose the field, so dj-site and BS compile against a stale contract.

## Field shape decisions

**Optional, not nullable.** `transformToV2` (`apps/backend/services/flowsheet.service.ts:786`) emits `metadata_status` only on the `track` branch — non-track entries (show markers, talksets, breakpoints) omit the key entirely; track entries always carry one of the 5 enum strings. Optional models "key may be absent"; nullable would model "key always present, value may be null" — wrong for this field.

**`enriching_since` is deliberately out of scope.** It's selected into the SQL projection at `flowsheet.service.ts:115` but stripped by `transformToV2` — not on the wire today. If it should be, that's a Backend change first; OpenAPI follows.

## Validation

- [x] `npm run check:breaking` — no breaking changes detected (purely additive).
- [x] `npm run generate:typescript` — emits `MetadataStatus` const + type and field refs on both schemas.
- [x] `npm test` — 442/442 pass.
- [x] `npm run lint` (`tsc --noEmit`) — clean.

## Related

- Upstream column: WXYC/Backend-Service#891 (closed); CDC worker: WXYC/Backend-Service#892.
- iOS decoder: WXYC/wxyc-ios-64#287 (merged 2026-05-28).
- iOS consumer (queued): WXYC/wxyc-ios-64#270.

Closes #147