### PR TITLE
feat(api): add artwork_checked_at to DiscogsReleaseMetadata (1.7.1)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.7.0
+  version: 1.7.1
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -2994,6 +2994,19 @@ components:
         artwork_url:
           type: string
           nullable: true
+        artwork_checked_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            Timestamp of the most recent live Discogs API call that resolved
+            this release's artwork. `null` means LML's bulk loader populated
+            the row but the live API has not been queried yet (the "never
+            asked" state); a value means LML hit the live API and either
+            populated `artwork_url` or confirmed Discogs has no cover. LML
+            uses this to distinguish bulk-loader gaps (which it back-fills)
+            from genuinely-imageless releases (which it does not refetch).
+            See WXYC/discogs-etl#239 + WXYC/library-metadata-lookup#423.
         release_url:
           type: string
         cached:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -479,6 +479,7 @@ describe('OpenAPI Specification', () => {
       type?: string;
       default?: unknown;
       nullable?: boolean;
+      format?: string;
       items?: { $ref?: string; type?: string };
       $ref?: string;
     };
@@ -509,6 +510,26 @@ describe('OpenAPI Specification', () => {
       expect(schema.properties.warm_cache.default).toBeUndefined();
       // Read-path callers leave this absent to avoid doubling Discogs-API load.
       expect(schema.required ?? []).not.toContain('warm_cache');
+    });
+
+    it('should attach artwork_checked_at to DiscogsReleaseMetadata as optional date-time', () => {
+      // Additive nullable signal for LML's cache-hit predicate (WXYC/library-metadata-lookup#423).
+      // Distinguishes "never asked" (NULL) from "asked, no cover" (timestamp set) so
+      // LML stops re-fetching genuinely-imageless releases. Backed by the schema column in
+      // WXYC/discogs-etl#239.
+      const schema = spec.components.schemas.DiscogsReleaseMetadata as {
+        properties: Record<string, SchemaProp>;
+        required?: string[];
+      };
+
+      const prop = schema.properties.artwork_checked_at;
+      expect(prop).toBeDefined();
+      expect(prop.type).toBe('string');
+      expect(prop.format).toBe('date-time');
+      expect(prop.nullable).toBe(true);
+      // Must stay optional — required-list addition would break every existing
+      // consumer of DiscogsReleaseMetadata (BS, dj-site, iOS, Android).
+      expect(schema.required ?? []).not.toContain('artwork_checked_at');
     });
 
     it('should attach the extended-metadata fields to DiscogsMatchResult', () => {


### PR DESCRIPTION
## Summary

Additive nullable field `artwork_checked_at` on the existing `DiscogsReleaseMetadata` schema. Bumps to v1.7.1 — non-breaking; `npm run check:breaking` returns clean.

```yaml
artwork_checked_at:
  type: string
  format: date-time
  nullable: true
  description: |
    Timestamp of the most recent live Discogs API call that resolved
    this release's artwork. `null` means LML's bulk loader populated
    the row but the live API has not been queried yet (the "never
    asked" state); a value means LML hit the live API and either
    populated `artwork_url` or confirmed Discogs has no cover.
```

## Why

Library-metadata-lookup needs this field to distinguish "we asked Discogs and there is no cover" (timestamp set) from "we never asked" (NULL). Without the distinction, LML's cache-hit predicate either:

- over-fetches (re-asks Discogs forever on imageless releases — current state after [WXYC/library-metadata-lookup#414](https://github.com/WXYC/library-metadata-lookup/issues/414) / PR #415), or
- under-fetches (serves stale NULL on bulk-loaded rows — pre-#414).

The schema column is in place via [WXYC/discogs-etl#239](https://github.com/WXYC/discogs-etl/issues/239) (merged). LML's predicate consumer is [WXYC/library-metadata-lookup#423](https://github.com/WXYC/library-metadata-lookup/issues/423) — that PR depends on this field being in the model.

## Consumer impact

Field is optional + nullable, so existing consumers (Backend-Service, dj-site, iOS, Android) keep parsing responses without code changes until they regenerate their models. The next regen on each consumer surfaces the field as a typed nullable property.

## Test plan

- [x] `npm run check:breaking` → "No breaking changes detected"
- [x] `npm test` → 442 tests, 12 files, all passing
- [x] `npm run generate:typescript` → openapi-typescript output regenerated cleanly
- [x] `npm run generate:swift` + `npm run generate:kotlin` → both regenerated; consumers can pick up on their next codegen run
