### PR TITLE
feat(api): StreamingCheckResponse.errored_sources for partial-error retry signal (1.8.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.7.1
+  version: 1.8.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3382,9 +3382,22 @@ components:
         on_streaming:
           type: boolean
           nullable: true
-          description: True if found on any service, false if absent on all, null if inconclusive.
+          description: |
+            True if found on any service, false if all services confirmed absent (no errors),
+            null if inconclusive — either no services checked OR at least one service raised
+            an error (see `errored_sources`). Treat null as "do not persist" / "retry later".
         sources:
           $ref: '#/components/schemas/StreamingCheckSources'
+        errored_sources:
+          type: array
+          items:
+            type: string
+          description: |
+            Names of services whose check raised an exception (transient network/rate-limit/
+            scraping failure). Empty when every dispatched check completed without raising.
+            When non-empty, callers should consider the listed services unchecked and may
+            schedule a selective retry. Independent of `on_streaming`: a service can both
+            match (populating `sources.<service>`) and other services can error.
 
     # ===================
     # Proxy / Config Types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -708,6 +708,22 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  describe('Streaming Check (LML#376 partial-error semantics)', () => {
+    it('should define StreamingCheckResponse.errored_sources as an optional string[]', () => {
+      const schema = spec.components.schemas.StreamingCheckResponse as {
+        properties: Record<string, { type?: string; items?: { type?: string } }>;
+        required?: string[];
+      };
+      expect(schema.properties.errored_sources).toBeDefined();
+      expect(schema.properties.errored_sources.type).toBe('array');
+      expect(schema.properties.errored_sources.items?.type).toBe('string');
+      // Not required — preserves backward compat for clients pinned to the
+      // pre-1.8.0 schema. LML always emits it (defaulting to []); strict-
+      // validating consumers should treat absence as [].
+      expect(schema.required ?? []).not.toContain('errored_sources');
+    });
+  });
+
   describe('Security', () => {
     it('should define BearerAuth security scheme', () => {
       expect(spec.components.securitySchemes?.BearerAuth).toBeDefined();


### PR DESCRIPTION
Closes #150.

Adds an optional `errored_sources: string[]` to `StreamingCheckResponse` (1.7.1 → 1.8.0) so LML's streaming-availability orchestrator can distinguish "all services confirmed no-match" from "some services errored, others returned no-match" without breaking the wire contract.

## Why

Pre-fix LML collapses both cases to `on_streaming=false`. Backend's `addAlbum` and tubafrenzy's `StreamingCheckLibraryReleaseListener` then persist the `false` to MySQL — albums actually on three streaming services get permanently flagged "WXYC exclusive" because one of four service checks raised once. There is no retry path.

The LML-side fix (filed at [WXYC/library-metadata-lookup#376](https://github.com/WXYC/library-metadata-lookup/issues/376)) makes any-service-errored cases return `null` instead. Backend's existing `streamingResult.value.on_streaming !== null` guard then protects against persistence, and tubafrenzy's `updateOnStreaming` writes `NULL` to MySQL when passed `null` — closing the bug for both consumers without consumer-side code changes. `errored_sources` is informational: it enables a future selective-retry job to re-check only the services that errored instead of re-running every leg.

## What changed

- **`api.yaml`** — new `errored_sources` property on `StreamingCheckResponse`; tightened `on_streaming`'s description to spell out the post-fix semantics (`false` ⇒ all confirmed, `null` ⇒ inconclusive or partial error).
- **`package.json` + `api.yaml`** — 1.7.1 → 1.8.0 (additive feature ⇒ MINOR).
- **`tests/api-spec.test.ts`** — asserts the new property is `array<string>` and NOT marked required.

## The non-required call

`errored_sources` is intentionally not in `required:`. Matches the established additive-response-field convention in this spec (`api_version` at api.yaml's `LookupResponse`; `identity` at the same) so oasdiff doesn't flag the change as breaking and pre-1.8.0 strict-validating clients keep working. LML always emits the field (defaulting to `[]`); clients can safely treat absence as `[]`.

## Sequencing

This PR lands first. LML PR follows (regenerates `generated/api_models.py`, updates `streaming/models.py` + the orchestrator verdict, adds the failing test for the bug case). No Backend-Service or tubafrenzy code change needed.

## Verification

- `npm test` — 444 passing (including the new `errored_sources` shape assertion).
- `npm run build` — clean.
- `npm run lint` — clean.
- `bash scripts/check-breaking-changes.sh` — `No breaking changes detected.`
