### PR TITLE
feat(api): FlowsheetCreateSongFreeform.rotation_id for unlinked-rotation submissions (1.10.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.9.0
+  version: 1.10.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -405,6 +405,15 @@ components:
           type: string
         label_id:
           type: integer
+        rotation_id:
+          type: integer
+          description: >
+            Rotation linkage for a track on a rotation album that isn't in the
+            WXYC library catalog (BS#1308). The Backend snapshot/else branch
+            persists `rotation_id` alongside `album_id IS NULL` so the V2 read
+            path can JOIN back to `rotation` for `rotation_bin` and the iOS
+            rotation-artwork resolver can find the entry. `rotation_bin` is
+            derived on read and intentionally not declared here.
 
     FlowsheetCreateMessage:
       type: object

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -152,6 +152,26 @@ describe('OpenAPI Specification', () => {
       });
     });
 
+    describe('rotation_id on FlowsheetCreateSongFreeform (BS#1308)', () => {
+      function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
+        const schema = spec.components.schemas[schemaName] as
+          | { properties?: Record<string, Record<string, unknown>> }
+          | undefined;
+        return schema?.properties?.[prop];
+      }
+
+      it('FlowsheetCreateSongFreeform should accept optional integer rotation_id', () => {
+        const rotationId = getProperty('FlowsheetCreateSongFreeform', 'rotation_id');
+        expect(rotationId).toBeDefined();
+        expect(rotationId?.type).toBe('integer');
+      });
+
+      it('FlowsheetCreateSongFreeform should not require rotation_id', () => {
+        const schema = spec.components.schemas.FlowsheetCreateSongFreeform as { required?: string[] };
+        expect(schema.required ?? []).not.toContain('rotation_id');
+      });
+    });
+
     describe('metadata_status field (BS#891 / Epic C)', () => {
       function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
         const schema = spec.components.schemas[schemaName] as

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -10,6 +10,7 @@ import {
   type FlowsheetEntryResponse,
   type FlowsheetSongEntry,
   type FlowsheetCreateSongFromCatalog,
+  type FlowsheetCreateSongFreeform,
   type FlowsheetUpdateRequest,
   type FlowsheetV2TrackEntry,
   type Album,
@@ -606,6 +607,31 @@ describe('Generated TypeScript Types', () => {
 
       expect(withoutPosition.track_position).toBeUndefined();
       expect(withPosition.track_position).toBe('A1');
+    });
+
+    // BS#1308 — POST /flowsheet/ for a track on a rotation album that isn't in
+    // the WXYC library catalog. BS already persists `rotation_id` alongside
+    // `album_id IS NULL` in the snapshot/else branch
+    // (apps/backend/controllers/flowsheet.controller.ts), but the freeform
+    // wire schema didn't declare `rotation_id`, forcing dj-site to either
+    // synthesize a negative `album_id` (defect class: dj-site#564/#608/#698/#701)
+    // or drop the linkage on the wire (PR #699 shape). Declaring it here
+    // matches what BS already accepts.
+    it('FlowsheetCreateSongFreeform accepts optional rotation_id', () => {
+      const withoutRotation: FlowsheetCreateSongFreeform = {
+        artist_name: 'Noura Mint Seymali',
+        album_title: 'Tzenni',
+        track_title: 'Tzenni',
+        request_flag: false,
+      };
+
+      const withRotation: FlowsheetCreateSongFreeform = {
+        ...withoutRotation,
+        rotation_id: 5001,
+      };
+
+      expect(withoutRotation.rotation_id).toBeUndefined();
+      expect(withRotation.rotation_id).toBe(5001);
     });
 
     it('FlowsheetUpdateRequest accepts optional track_position', () => {


### PR DESCRIPTION
## Summary

- Adds optional `rotation_id` to `FlowsheetCreateSongFreeform` in `api.yaml` so dj-site can preserve rotation linkage when POSTing a track on a rotation album that isn't in the WXYC library catalog.
- Pure wire-schema change: Backend's `addEntry` handler already persists `rotation_id` alongside `album_id IS NULL` in the snapshot/else branch (the BS#933 path); DB columns are nullable; `rotation_bin` is derived via JOIN on read.
- Bumps `info.version` 1.9.0 → 1.10.0. `check:breaking` reports non-breaking.

Closes #157. Unblocks WXYC/Backend-Service#1308, WXYC/dj-site#608, WXYC/dj-site#701.

## Test plan

- [x] `npm test` — 456 tests pass (added 1 spec-inspection + 1 type-pin for the new property).
- [x] `npm run lint` (`tsc --noEmit`) — clean.
- [x] `npm run check:breaking` — non-breaking.
- [ ] After merge: tag publish → BS PR bumps the dep + adds integration regression asserting persisted row has `album_id IS NULL` + `rotation_id = <input>`.