### PR TITLE
chore(release): 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.7.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bumps the published package version to **1.9.0** so consumers (Backend-Service, dj-site) can pin against the schema additions from #158 (`FlowsheetCreateSongFreeform.rotation_id`).

Minor bump per semver — the underlying spec change is additive (optional property), already verified non-breaking by `check:breaking` on #158.

After merge: tag `v1.9.0` against the merged commit and push to trigger `publish.yml`.

## Test plan

- [x] `npm version minor` on a tree rebased on origin/main → 1.8.0 → 1.9.0.
- [ ] Post-merge: `git tag v1.9.0 origin/main && git push origin v1.9.0` → `publish.yml` runs against the merged commit.