### PR TITLE
feat(api): add dj_name_override to /flowsheet/join request schema

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.10.0
+  version: 1.11.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3970,6 +3970,16 @@ paths:
                 specialty_id:
                   type: integer
                   description: ID of specialty show entry
+                dj_name_override:
+                  type: string
+                  maxLength: 255
+                  description: >
+                    Optional per-show override for the public DJ name; supersedes
+                    the caller's `auth_user.dj_name` on the `show_start` marker
+                    and `shows.legacy_dj_name`. Empty or whitespace-only values
+                    are treated as absent. Scoped to the new-show (start-show)
+                    path; the co-host /join branch intentionally ignores this
+                    field. Max length matches `auth_user.dj_name varchar(255)`.
       responses:
         '200':
           description: Successfully joined/started show

--- a/api.yaml
+++ b/api.yaml
@@ -3974,12 +3974,15 @@ paths:
                   type: string
                   maxLength: 255
                   description: >
-                    Optional per-show override for the public DJ name; supersedes
-                    the caller's `auth_user.dj_name` on the `show_start` marker
-                    and `shows.legacy_dj_name`. Empty or whitespace-only values
-                    are treated as absent. Scoped to the new-show (start-show)
-                    path; the co-host /join branch intentionally ignores this
-                    field. Max length matches `auth_user.dj_name varchar(255)`.
+                    Optional per-show override for the public DJ name. When
+                    present and non-empty after trim, supersedes the caller's
+                    `auth_user.dj_name`-derived name on the `show_start` marker
+                    text, on the `flowsheet.dj_name` column of every entry in
+                    this show, and on `shows.legacy_dj_name`. Empty or
+                    whitespace-only values are treated as absent. Scoped to the
+                    new-show (start-show) path; the co-host /join branch
+                    intentionally ignores this field. Max length matches
+                    `auth_user.dj_name varchar(255)`.
       responses:
         '200':
           description: Successfully joined/started show

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -172,6 +172,46 @@ describe('OpenAPI Specification', () => {
       });
     });
 
+    describe('dj_name_override on POST /flowsheet/join (BS#1295)', () => {
+      function getJoinRequestSchema(): {
+        properties?: Record<string, Record<string, unknown>>;
+        required?: string[];
+      } {
+        const join = spec.paths['/flowsheet/join'] as {
+          post?: {
+            requestBody?: {
+              content?: {
+                'application/json'?: {
+                  schema?: {
+                    properties?: Record<string, Record<string, unknown>>;
+                    required?: string[];
+                  };
+                };
+              };
+            };
+          };
+        };
+        return join?.post?.requestBody?.content?.['application/json']?.schema ?? {};
+      }
+
+      it('POST /flowsheet/join should accept optional string dj_name_override', () => {
+        const schema = getJoinRequestSchema();
+        const override = schema.properties?.dj_name_override;
+        expect(override).toBeDefined();
+        expect(override?.type).toBe('string');
+      });
+
+      it('dj_name_override should cap maxLength at 255 to match auth_user.dj_name', () => {
+        const override = getJoinRequestSchema().properties?.dj_name_override;
+        expect(override?.maxLength).toBe(255);
+      });
+
+      it('dj_name_override should not be in the required list', () => {
+        const schema = getJoinRequestSchema();
+        expect(schema.required ?? []).not.toContain('dj_name_override');
+      });
+    });
+
     describe('metadata_status field (BS#891 / Epic C)', () => {
       function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
         const schema = spec.components.schemas[schemaName] as

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -611,13 +611,14 @@ describe('Generated TypeScript Types', () => {
     });
 
     // BS#1295 — POST /flowsheet/join carries an optional `dj_name_override`
-    // that supersedes the caller's `auth_user.dj_name` on the `show_start`
-    // marker and `shows.legacy_dj_name` for the lifetime of the show. Scoped
-    // to the start-show path; the co-host /join branch intentionally ignores
-    // it (BS-side enforcement, not surfaced on the wire). The inline schema
-    // means we reach into the path operation directly rather than a named
-    // component — mirrors how BS's `JoinRequestBody` lives in
-    // apps/backend/controllers/flowsheet.controller.ts.
+    // that supersedes the caller's `auth_user.dj_name`-derived name on the
+    // `show_start` marker text, the `flowsheet.dj_name` column of every
+    // entry in this show, and `shows.legacy_dj_name` for the lifetime of
+    // the show. Scoped to the start-show path; the co-host /join branch
+    // intentionally ignores it (BS-side enforcement, not surfaced on the
+    // wire). The inline schema means we reach into the path operation
+    // directly rather than a named component — mirrors how BS's
+    // `JoinRequestBody` lives in apps/backend/controllers/flowsheet.controller.ts.
     it('POST /flowsheet/join accepts optional dj_name_override', () => {
       type JoinBody =
         paths['/flowsheet/join']['post']['requestBody']['content']['application/json'];

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import type { paths } from '../src/generated/openapi-types.js';
 import {
   type FlowsheetEntryResponse,
   type FlowsheetSongEntry,
@@ -607,6 +608,32 @@ describe('Generated TypeScript Types', () => {
 
       expect(withoutPosition.track_position).toBeUndefined();
       expect(withPosition.track_position).toBe('A1');
+    });
+
+    // BS#1295 — POST /flowsheet/join carries an optional `dj_name_override`
+    // that supersedes the caller's `auth_user.dj_name` on the `show_start`
+    // marker and `shows.legacy_dj_name` for the lifetime of the show. Scoped
+    // to the start-show path; the co-host /join branch intentionally ignores
+    // it (BS-side enforcement, not surfaced on the wire). The inline schema
+    // means we reach into the path operation directly rather than a named
+    // component — mirrors how BS's `JoinRequestBody` lives in
+    // apps/backend/controllers/flowsheet.controller.ts.
+    it('POST /flowsheet/join accepts optional dj_name_override', () => {
+      type JoinBody =
+        paths['/flowsheet/join']['post']['requestBody']['content']['application/json'];
+
+      const withoutOverride: JoinBody = {
+        dj_id: 42,
+        show_name: 'Aubrey Hearst',
+      };
+
+      const withOverride: JoinBody = {
+        ...withoutOverride,
+        dj_name_override: 'DJ Guest Host',
+      };
+
+      expect(withoutOverride.dj_name_override).toBeUndefined();
+      expect(withOverride.dj_name_override).toBe('DJ Guest Host');
     });
 
     // BS#1308 — POST /flowsheet/ for a track on a rotation album that isn't in


### PR DESCRIPTION
## Summary

Adds optional `dj_name_override` (string, maxLength 255) to the POST `/flowsheet/join` request body and bumps `api.yaml info.version` 1.10.0 → 1.11.0 (additive non-breaking). Publishes the wire contract that Backend already accepts on the start-show path so downstream `@wxyc/shared` consumers (notably dj-site) can pass the field through.

## Background

The marker-text + override decisions were locked in [WXYC/Backend-Service#1295](https://github.com/WXYC/Backend-Service/issues/1295) (epic [WXYC/Backend-Service#1288](https://github.com/WXYC/Backend-Service/issues/1288), Aubrey Hearst on-air incident). The Backend-side change shipped in [WXYC/Backend-Service#1320](https://github.com/WXYC/Backend-Service/pull/1320) (`d8140231`) and was self-contained because BS's `JoinRequestBody` is locally defined in `apps/backend/controllers/flowsheet.controller.ts`, not imported from `@wxyc/shared`. This PR brings the published contract in line so consumers that DO import from `@wxyc/shared` get the field via codegen.

## Field shape (locked, not up for re-litigation)

Optional string, `maxLength: 255` to match `auth_user.dj_name varchar(255)`. Empty / whitespace values are normalized to absent on the Backend (not a wire-level constraint, so callers don't have to pre-check before sending). Scoped to the new-show / start-show path; the co-host /join branch ignores it (Backend-side enforcement, not surfaced on the wire).

## Tests

Mirrors the pattern from #157 (the `rotation_id` PR):

- `tests/api-spec.test.ts` — three assertions on `paths['/flowsheet/join'].post.requestBody.content['application/json']`: declared as string, `maxLength === 255`, not in the `required` list. The schema is inline (not a named component) because BS's `JoinRequestBody` is locally defined.
- `tests/generated-types.test.ts` — compile-check that indexes through the openapi-typescript `paths` interface to confirm codegen reflects the spec.

`npm test`: 460 passed (456 baseline + 3 spec + 1 generated-types). `npm run lint` clean. `npm run check:breaking` reports no breaking changes.

## Versioning

`api.yaml info.version` bumped 1.10.0 → 1.11.0. `package.json` left untouched — versions on that file lag behind via `chore(release): X.Y.Z` commits at publish time, matching the cadence in `git log -- package.json` (e.g. `8f40d1a chore(release): 1.9.0` post-dating `2f2c95a feat(api): ... (1.8.0)`).

## Cross-references

- Closes #160
- Epic [WXYC/Backend-Service#1288](https://github.com/WXYC/Backend-Service/issues/1288)
- Locked BS-side decisions in [WXYC/Backend-Service#1295](https://github.com/WXYC/Backend-Service/issues/1295)
- BS-side implementation [WXYC/Backend-Service#1320](https://github.com/WXYC/Backend-Service/pull/1320)
- Unblocks WXYC/dj-site#694
- Pattern precedent #157 (`rotation_id` on `FlowsheetCreateSongFreeform`)