### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.7.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.7.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.8.0",
+  "version": "1.11.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bumps the published package version to **1.11.0** so consumers (Backend-Service, dj-site) can pin against the schema additions accumulated in `api.yaml` since the 1.8.0 release:

- #158 — `FlowsheetCreateSongFreeform.rotation_id` (api.yaml 1.9.0)
- #160 — artist-search-alias schemas and bulk endpoint (api.yaml 1.10.0)
- #161 — `dj_name_override` on `/flowsheet/join` (api.yaml 1.11.0)

Skips publishing intermediate 1.9.0 and 1.10.0 — those api.yaml bumps land together in this single package release. Stale #159 (`chore(release): 1.9.0`) closed as superseded; its branch was two minors behind.

All additions are additive (optional properties / new endpoint), already verified non-breaking by `check:breaking` on each of the underlying PRs.

## Test plan

- [x] Local: `npm ci --ignore-scripts && npm run generate:typescript && npm run build && npm run lint && npm test` — 460/460 passing
- [x] `package.json` and `package-lock.json` aligned at 1.11.0 (lockfile was incidentally at 1.7.0; bumped in step)
- [ ] CI green on this PR
- [ ] **After merge:** tag the merged commit and push to trigger `publish.yml`:
  ```
  git fetch origin
  git tag v1.11.0 origin/main
  git push origin v1.11.0
  ```

Closes #162