### PR TITLE
chore(e2e-runner): bootstrap script + runbook for wxyc-e2e-runner EC2

### DIFF
--- a/scripts/e2e-runner/README.md
+++ b/scripts/e2e-runner/README.md
@@ -1,0 +1,118 @@
+# wxyc-e2e-runner
+
+Provisioning runbook for the dedicated EC2 instance that hosts the self-hosted GitHub Actions runner used by the staging-gate E2E suites in Backend-Service, library-metadata-lookup, and dj-site.
+
+Plan-of-record: [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80). This phase: [#165](https://github.com/WXYC/wxyc-shared/issues/165).
+
+## Topology
+
+| Item | Value |
+|------|-------|
+| AWS account | `503977661500` (Jake's personal AWS, same account as wxyc-canary) |
+| Region | `us-east-1` |
+| Instance type | `t3.small` |
+| OS | Ubuntu 24.04 LTS (noble) |
+| Hostname | `wxyc-e2e-runner` |
+| GHA runner label | `e2e-runner` |
+| GHA runner scope | Organization (`WXYC`) |
+| Estimated cost | ~$15/mo on-demand, ~$5/mo reserved |
+
+The runner is intentionally separate from the Backend-Service EC2 box (account `203767826763`, instance `i-0685e373989cd5daa`) so that a wedge on either side does not take down the other. The runner box is stateless and disposable — if it dies, replace it from the AMI and re-run `bootstrap.sh`.
+
+## Provisioning
+
+### 1. Launch the instance
+
+Console or `aws ec2 run-instances` from the `wxyc-canary` AWS account (`503977661500`):
+
+- AMI: latest Ubuntu 24.04 LTS for `x86_64`
+- Instance type: `t3.small`
+- Subnet: any public subnet in `us-east-1`
+- Security group: outbound 443 only (runner polls GitHub over outbound HTTPS; no inbound required)
+- Key pair: existing personal key
+- IAM instance profile: none required for the runner itself (workflows that need AWS use repo-scoped OIDC)
+- Storage: 20 GiB gp3
+- Tag `Name=wxyc-e2e-runner`
+
+### 2. SSH and run the bootstrap
+
+```bash
+scp scripts/e2e-runner/bootstrap.sh ubuntu@<runner-ip>:/tmp/bootstrap.sh
+ssh ubuntu@<runner-ip>
+# On the box:
+RUNNER_TOKEN=$(gh api -X POST /orgs/WXYC/actions/runners/registration-token --jq .token)
+sudo GHA_RUNNER_TOKEN="${RUNNER_TOKEN}" \
+     GHA_RUNNER_URL=https://github.com/WXYC \
+     bash /tmp/bootstrap.sh
+```
+
+The bootstrap is idempotent. Re-running it after a partial failure resumes from the failed step.
+
+### 3. Verify
+
+On the box:
+
+```bash
+systemctl status 'actions.runner.*.service'
+```
+
+On GitHub: <https://github.com/organizations/WXYC/settings/actions/runners> should show `wxyc-e2e-runner` as **Idle** with label `e2e-runner`.
+
+### 4. Smoke run
+
+From the local checkout, dispatch the wxyc-shared E2E suite against prod URLs targeting the runner:
+
+```yaml
+# Smoke workflow used only for phase 1 acceptance; not retained.
+name: e2e-runner-smoke
+on: workflow_dispatch
+jobs:
+  smoke:
+    runs-on: [self-hosted, e2e-runner]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm ci
+      - env:
+          E2E_BASE_URL: https://api.wxyc.org
+          E2E_AUTH_URL: https://api.wxyc.org/auth
+          E2E_TEST_DJ_EMAIL: ${{ secrets.E2E_TEST_DJ_EMAIL }}
+          E2E_TEST_DJ_PASSWORD: ${{ secrets.E2E_TEST_DJ_PASSWORD }}
+        run: npm run test:e2e
+```
+
+A green run completes phase 1. After that, this workflow is removed; the runner sits idle until phases 2/3/4 wire real gate workflows to it.
+
+## Operations
+
+### Replacing the instance
+
+The bootstrap script is the source-of-truth. To rebuild:
+
+1. Terminate the old instance.
+2. Launch a fresh Ubuntu 24.04 instance with the same SG + tag.
+3. Re-run the bootstrap with a fresh registration token.
+4. Remove the dead runner from <https://github.com/organizations/WXYC/settings/actions/runners> (or it will auto-deregister after 14 days idle).
+
+### Updating the runner agent
+
+GitHub auto-updates the runner agent. To pin a version, set `RUNNER_VERSION` when invoking the bootstrap.
+
+### Canary probe (separate ticket)
+
+The runner liveness probe lives in [wxyc-canary](https://github.com/WXYC/wxyc-canary). It calls `GET /orgs/WXYC/actions/runners/<id>` every 5 min and alarms if `status != "online"` for ≥10 min. Implemented as part of phase 1 acceptance but tracked separately in the canary repo.
+
+## Cost
+
+t3.small on-demand in `us-east-1` is ~$0.0208/h ≈ $15/mo. A 1-year Standard Reserved Instance drops to ~$8/mo. EBS 20 GiB gp3 is ~$1.60/mo. Total ≤ $20/mo.
+
+Per [cost-conscious-infra](https://github.com/WXYC/wiki/issues/80) constraints, do not scale this box up without confirming the workload requires it. If the E2E suites outgrow `t3.small`, prefer the reversible levers (instance class bump, scheduled stop/start outside business hours).
+
+## Security notes
+
+- The runner has no inbound exposure. The SG only needs egress 443.
+- The runner runs jobs as user `runner` with Docker group membership. Workflows that mount the Docker socket can break out of the user boundary — keep that in mind if you ever schedule untrusted workflows here (current scope is WXYC repos only, no public forks).
+- Registration token is short-lived (~1h). Never commit it.
+- Use org-level runners (not repo-level) so token grants are visible org-wide.

--- a/scripts/e2e-runner/README.md
+++ b/scripts/e2e-runner/README.md
@@ -15,7 +15,7 @@ Plan-of-record: [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80). This pha
 | Hostname | `wxyc-e2e-runner` |
 | GHA runner label | `e2e-runner` |
 | GHA runner scope | Organization (`WXYC`) |
-| Estimated cost | ~$15/mo on-demand, ~$5/mo reserved |
+| Estimated cost | ~$15/mo on-demand, ~$8/mo reserved (see [Cost](#cost) for the math) |
 
 The runner is intentionally separate from the Backend-Service EC2 box (account `203767826763`, instance `i-0685e373989cd5daa`) so that a wedge on either side does not take down the other. The runner box is stateless and disposable — if it dies, replace it from the AMI and re-run `bootstrap.sh`.
 
@@ -28,7 +28,7 @@ Console or `aws ec2 run-instances` from the `wxyc-canary` AWS account (`50397766
 - AMI: latest Ubuntu 24.04 LTS for `x86_64`
 - Instance type: `t3.small`
 - Subnet: any public subnet in `us-east-1`
-- Security group: outbound 443 only (runner polls GitHub over outbound HTTPS; no inbound required)
+- Security group: outbound 443 only at steady state (runner polls GitHub over outbound HTTPS; no inbound required). Note: `bootstrap.sh` itself needs egress to a wider set of hosts at provisioning time — `download.docker.com`, `deb.nodesource.com`, `ppa.launchpad.net` (deadsnakes), `archive.ubuntu.com`, and `github.com/actions/runner/releases`. Leave egress 443 open to all destinations during bootstrap; tighten only if your threat model demands it (and re-open before any re-bootstrap)
 - Key pair: existing personal key
 - IAM instance profile: none required for the runner itself (workflows that need AWS use repo-scoped OIDC)
 - Storage: 20 GiB gp3
@@ -60,10 +60,12 @@ On GitHub: <https://github.com/organizations/WXYC/settings/actions/runners> shou
 
 ### 4. Smoke run
 
-From the local checkout, dispatch the wxyc-shared E2E suite against prod URLs targeting the runner:
+For phase 1 acceptance, drop the workflow below onto a scratch branch as `.github/workflows/e2e-runner-smoke.yml`, push, dispatch from the Actions tab, then revert the branch once it's green. The workflow is intentionally not committed to `main` — it's a one-off acceptance probe, not retained tooling.
 
 ```yaml
 # Smoke workflow used only for phase 1 acceptance; not retained.
+# Paste into .github/workflows/e2e-runner-smoke.yml on a scratch branch,
+# dispatch via `workflow_dispatch`, then revert.
 name: e2e-runner-smoke
 on: workflow_dispatch
 jobs:
@@ -83,7 +85,7 @@ jobs:
         run: npm run test:e2e
 ```
 
-A green run completes phase 1. After that, this workflow is removed; the runner sits idle until phases 2/3/4 wire real gate workflows to it.
+A green run completes phase 1. After that, delete the scratch branch; the runner sits idle until phases 2/3/4 wire real gate workflows to it.
 
 ## Operations
 
@@ -94,7 +96,7 @@ The bootstrap script is the source-of-truth. To rebuild:
 1. Terminate the old instance.
 2. Launch a fresh Ubuntu 24.04 instance with the same SG + tag.
 3. Re-run the bootstrap with a fresh registration token.
-4. Remove the dead runner from <https://github.com/organizations/WXYC/settings/actions/runners> (or it will auto-deregister after 14 days idle).
+4. Remove the dead runner from <https://github.com/organizations/WXYC/settings/actions/runners> (GitHub auto-removes runners that have been *offline* for 14 days; a runner stuck in `Idle` polls successfully and is never auto-removed).
 
 ### Updating the runner agent
 
@@ -108,7 +110,7 @@ The runner liveness probe lives in [wxyc-canary](https://github.com/WXYC/wxyc-ca
 
 t3.small on-demand in `us-east-1` is ~$0.0208/h ≈ $15/mo. A 1-year Standard Reserved Instance drops to ~$8/mo. EBS 20 GiB gp3 is ~$1.60/mo. Total ≤ $20/mo.
 
-Per [cost-conscious-infra](https://github.com/WXYC/wiki/issues/80) constraints, do not scale this box up without confirming the workload requires it. If the E2E suites outgrow `t3.small`, prefer the reversible levers (instance class bump, scheduled stop/start outside business hours).
+Cost-conscious-infra rule: do not scale this box up without confirming the workload requires it. If the E2E suites outgrow `t3.small`, prefer reversible levers (instance class bump, scheduled stop/start outside business hours) over permanent storage increases — EBS volumes can grow but cannot shrink.
 
 ## Security notes
 

--- a/scripts/e2e-runner/bootstrap.sh
+++ b/scripts/e2e-runner/bootstrap.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Bootstrap script for wxyc-e2e-runner EC2 instance.
+#
+# Target OS: Ubuntu 24.04 LTS (noble) on t3.small (or larger) in
+# AWS account 503977661500, us-east-1. The runner is shared by
+# Backend-Service, library-metadata-lookup, and dj-site for their
+# E2E gate jobs (target via `runs-on: [self-hosted, e2e-runner]`).
+#
+# Idempotent: safe to re-run. Each install step short-circuits if
+# the target is already in the requested state.
+#
+# Usage (as root or via sudo):
+#   sudo GHA_RUNNER_TOKEN=<org-runner-registration-token> \
+#        GHA_RUNNER_URL=https://github.com/WXYC \
+#        bash bootstrap.sh
+#
+# The runner registration token is org-scoped and short-lived (~1h).
+# Obtain via: gh api -X POST /orgs/WXYC/actions/runners/registration-token
+#
+# All steps log to stderr with a [step] prefix; stdout is reserved
+# for command output. Failures exit non-zero with the failing step's
+# name in the trap message.
+
+set -euo pipefail
+
+NODE_MAJOR="${NODE_MAJOR:-24}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
+RUNNER_USER="${RUNNER_USER:-runner}"
+RUNNER_HOME="/home/${RUNNER_USER}"
+RUNNER_DIR="${RUNNER_HOME}/actions-runner"
+RUNNER_LABELS="${RUNNER_LABELS:-e2e-runner}"
+RUNNER_NAME="${RUNNER_NAME:-wxyc-e2e-runner}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.319.1}"
+RUNNER_ARCH="${RUNNER_ARCH:-x64}"
+RUNNER_TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
+RUNNER_URL_BASE="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}"
+
+CURRENT_STEP="<init>"
+log() { printf '[%s] [%s] %s\n' "$(date -u +%FT%TZ)" "${CURRENT_STEP}" "$*" >&2; }
+step() { CURRENT_STEP="$1"; log "===== ${CURRENT_STEP} ====="; }
+on_error() {
+  local exit_code=$?
+  printf '[%s] [%s] FAILED with exit code %d\n' \
+    "$(date -u +%FT%TZ)" "${CURRENT_STEP}" "${exit_code}" >&2
+  exit "${exit_code}"
+}
+trap on_error ERR
+
+require_root() {
+  if [[ "${EUID}" -ne 0 ]]; then
+    echo "bootstrap.sh must run as root (use sudo)" >&2
+    exit 64
+  fi
+}
+
+require_env() {
+  local var=$1
+  if [[ -z "${!var:-}" ]]; then
+    echo "Required env var ${var} is unset" >&2
+    exit 64
+  fi
+}
+
+step "preflight"
+require_root
+require_env GHA_RUNNER_TOKEN
+require_env GHA_RUNNER_URL
+log "ubuntu codename: $(. /etc/os-release && echo "${VERSION_CODENAME}")"
+
+step "apt-base"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq \
+  ca-certificates curl gnupg lsb-release jq git build-essential \
+  software-properties-common unzip
+
+step "docker"
+if ! command -v docker >/dev/null 2>&1; then
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${VERSION_CODENAME}") stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update -qq
+  apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  systemctl enable --now docker
+else
+  log "docker already installed: $(docker --version)"
+fi
+
+step "node-${NODE_MAJOR}"
+if ! command -v node >/dev/null 2>&1 || [[ "$(node -v 2>/dev/null | sed 's/^v//; s/\..*//')" != "${NODE_MAJOR}" ]]; then
+  curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+  apt-get install -y -qq nodejs
+else
+  log "node already at v${NODE_MAJOR}: $(node -v)"
+fi
+log "npm: $(npm -v)"
+
+step "python-${PYTHON_VERSION}"
+# Ubuntu 24.04 ships python3.12 by default; verify and install venv tooling.
+if ! command -v "python${PYTHON_VERSION}" >/dev/null 2>&1; then
+  add-apt-repository -y ppa:deadsnakes/ppa
+  apt-get update -qq
+  apt-get install -y -qq "python${PYTHON_VERSION}" "python${PYTHON_VERSION}-venv"
+fi
+apt-get install -y -qq "python${PYTHON_VERSION}-venv" python3-pip
+log "python: $(python"${PYTHON_VERSION}" --version)"
+
+step "playwright-deps"
+# Install Playwright OS dependencies for the chromium/firefox/webkit
+# browsers. Browsers themselves are installed per-job via
+# `npx playwright install` in the workflow.
+apt-get install -y -qq \
+  libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+  libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \
+  libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
+  libatspi2.0-0 libwayland-client0
+
+step "runner-user"
+if ! id -u "${RUNNER_USER}" >/dev/null 2>&1; then
+  useradd -m -s /bin/bash "${RUNNER_USER}"
+fi
+usermod -aG docker "${RUNNER_USER}"
+
+step "runner-download"
+if [[ ! -x "${RUNNER_DIR}/config.sh" ]]; then
+  install -d -o "${RUNNER_USER}" -g "${RUNNER_USER}" "${RUNNER_DIR}"
+  cd "${RUNNER_DIR}"
+  sudo -u "${RUNNER_USER}" curl -fsSL -o "${RUNNER_TARBALL}" "${RUNNER_URL_BASE}/${RUNNER_TARBALL}"
+  sudo -u "${RUNNER_USER}" tar xzf "${RUNNER_TARBALL}"
+  rm -f "${RUNNER_TARBALL}"
+else
+  log "runner already extracted at ${RUNNER_DIR}"
+fi
+
+step "runner-config"
+cd "${RUNNER_DIR}"
+if [[ ! -f .runner ]]; then
+  sudo -u "${RUNNER_USER}" ./config.sh \
+    --url "${GHA_RUNNER_URL}" \
+    --token "${GHA_RUNNER_TOKEN}" \
+    --name "${RUNNER_NAME}" \
+    --labels "${RUNNER_LABELS}" \
+    --runnergroup default \
+    --work _work \
+    --unattended \
+    --replace
+else
+  log "runner already configured: $(jq -r .agentName .runner 2>/dev/null || echo unknown)"
+fi
+
+step "runner-service"
+# `svc.sh install` writes /etc/systemd/system/actions.runner.*.service
+# and `svc.sh start` enables + starts it.
+if ! systemctl list-units --type=service --all | grep -q '^actions\.runner\.'; then
+  ./svc.sh install "${RUNNER_USER}"
+  ./svc.sh start
+else
+  log "runner service already installed"
+  systemctl restart 'actions.runner.*.service' || true
+fi
+
+step "done"
+log "wxyc-e2e-runner bootstrap complete"
+log "verify runner status: systemctl status 'actions.runner.*.service'"
+log "verify org-side: https://github.com/organizations/WXYC/settings/actions/runners"

--- a/scripts/e2e-runner/bootstrap.sh
+++ b/scripts/e2e-runner/bootstrap.sh
@@ -101,13 +101,21 @@ fi
 log "npm: $(npm -v)"
 
 step "python-${PYTHON_VERSION}"
-# Ubuntu 24.04 ships python3.12 by default; verify and install venv tooling.
+# Ubuntu 24.04 ships python3.12 by default; install only if absent, then
+# ensure venv + pip tooling is present. We split the "interpreter present?"
+# check from the "venv/pip present?" check because Ubuntu's python3 image
+# can ship the interpreter without venv.
 if ! command -v "python${PYTHON_VERSION}" >/dev/null 2>&1; then
   add-apt-repository -y ppa:deadsnakes/ppa
   apt-get update -qq
   apt-get install -y -qq "python${PYTHON_VERSION}" "python${PYTHON_VERSION}-venv"
 fi
-apt-get install -y -qq "python${PYTHON_VERSION}-venv" python3-pip
+if ! dpkg -s "python${PYTHON_VERSION}-venv" >/dev/null 2>&1 \
+  || ! dpkg -s python3-pip >/dev/null 2>&1; then
+  apt-get install -y -qq "python${PYTHON_VERSION}-venv" python3-pip
+else
+  log "python venv/pip already installed"
+fi
 log "python: $(python"${PYTHON_VERSION}" --version)"
 
 step "playwright-deps"
@@ -155,13 +163,16 @@ fi
 
 step "runner-service"
 # `svc.sh install` writes /etc/systemd/system/actions.runner.*.service
-# and `svc.sh start` enables + starts it.
+# and `svc.sh start` enables + starts it. On re-run, restart the existing
+# unit so we pick up any config changes — let the ERR trap surface a
+# restart failure instead of swallowing it; a runner that won't restart
+# is exactly the case that should fail loudly.
 if ! systemctl list-units --type=service --all | grep -q '^actions\.runner\.'; then
   ./svc.sh install "${RUNNER_USER}"
   ./svc.sh start
 else
-  log "runner service already installed"
-  systemctl restart 'actions.runner.*.service' || true
+  log "runner service already installed; restarting to pick up config"
+  systemctl restart 'actions.runner.*.service'
 fi
 
 step "done"


### PR DESCRIPTION
Phase 1 of the staging-gate epic ([WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80)). Refs [#165](https://github.com/WXYC/wxyc-shared/issues/165).

## Summary

- `scripts/e2e-runner/bootstrap.sh` — idempotent first-boot setup for an Ubuntu 24.04 t3.small EC2 box. Installs Docker, Node 24, Python 3.12, Playwright OS deps, and registers an org-level GHA runner with label `e2e-runner` via systemd.
- `scripts/e2e-runner/README.md` — provisioning runbook (AWS account 503977661500 us-east-1, SG/IAM, registration token flow, smoke-run workflow, replacement procedure, cost envelope ~$20/mo).

## What is *not* in this PR

- The actual EC2 provisioning (operational step against AWS account 503977661500).
- Canary probe for runner liveness (lives in [wxyc-canary](https://github.com/WXYC/wxyc-canary), tracked on the parent issue).
- Any workflow wiring in BS / LML / dj-site / wxyc-shared — that is phases 2/3/4/5.

This PR adds documentation + a reproducible bootstrap. After it merges, the runner provisioning and the canary probe close out the rest of #165.

## Test plan

- [ ] `bash -n scripts/e2e-runner/bootstrap.sh` syntactically valid (verified locally).
- [ ] `shellcheck --severity=warning scripts/e2e-runner/bootstrap.sh` clean (verified locally).
- [ ] Bootstrap runs end-to-end on a fresh Ubuntu 24.04 t3.small (operational, post-merge).
- [ ] GHA runner registers as `Idle` with label `e2e-runner` on https://github.com/organizations/WXYC/settings/actions/runners (operational, post-merge).
- [ ] Smoke workflow from the README executes `npm run test:e2e` on the runner targeting prod URLs and passes (operational, post-merge).