### PR TITLE
feat(ci): bs-lml-gate coordinator workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint config for wxyc-shared workflows.
+#
+# self-hosted-runner.labels lists custom labels we register on org-level
+# self-hosted runners. Without this, actionlint flags `runs-on:
+# [self-hosted, e2e-runner]` as an unknown label.
+self-hosted-runner:
+  labels:
+    - e2e-runner

--- a/.github/workflows/bs-lml-gate.yml
+++ b/.github/workflows/bs-lml-gate.yml
@@ -30,9 +30,9 @@ on:
         type: boolean
         default: false
       justification:
-        description: 'Required when skip_gate=true. Audited.'
+        description: 'Audited (markdown is escaped). Required when skip_gate=true; ignored otherwise.'
         type: string
-        required: false
+        required: true
 
 permissions:
   contents: read
@@ -47,6 +47,11 @@ env:
   # Set in the repo as a *variable* (not secret). Created once by the
   # setup checklist in README — points at the long-lived pinned issue.
   BYPASS_TRACKER_ISSUE: ${{ vars.GATE_BYPASS_ISSUE_NUMBER }}
+  # Pin of WXYC/wxyc-canary commit to install for the smoke suite.
+  # Bump intentionally when canary contracts change; see install step.
+  # This pin must include the `prepare` script (wxyc-canary#47) so
+  # `npm install -g github:...` actually builds dist/cli.js.
+  CANARY_PIN: 4462530c131c92605e777a58e496776fde8561af
 
 jobs:
   gate:
@@ -96,6 +101,12 @@ jobs:
           POLL_URL: ${{ vars.LML_STAGING_BASE_URL }}/health
         run: ./scripts/bs-lml-gate/poll-staging-health.sh
 
+      # /version routes are added by phase 4 (WXYC/Backend-Service#1335) and
+      # phase 3 (WXYC/library-metadata-lookup#496) — both list "Stamp build
+      # SHA at /version" in their scopes. Until those land, these steps
+      # will 404; that's fine because staging envs themselves don't exist
+      # until those phases either. Override VERIFY_JQ_PATH if the eventual
+      # /version response nests the sha (e.g. '.build.commit').
       - name: Verify BS-staging /version matches main
         if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
         env:
@@ -133,23 +144,41 @@ jobs:
           E2E_TEST_DJ_PASSWORD: ${{ secrets.E2E_TEST_DJ_PASSWORD }}
         run: npm run test:e2e
 
+      # Pinned to wxyc-canary main @ <SHA> (Phase 5a + the prepare-script
+      # fix in wxyc-canary#47). Bump intentionally when canary contracts
+      # change. Prepare runs on git installs so dist/cli.js gets built.
       - name: Install wxyc-canary CLI
         if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
-        # Pinned to wxyc-canary main @ 36178c8 (Phase 5a, wxyc-canary#43).
-        # Bump intentionally when canary contracts change.
-        run: npm install -g github:WXYC/wxyc-canary#36178c85fbe920523ac5482c4766537abc2aa5ef
+        run: |
+          npm install -g github:WXYC/wxyc-canary#${{ env.CANARY_PIN }}
+          wxyc-canary --help >/dev/null   # smoke-test the install produced a working bin
 
       - name: Run canary smoke suite against staging
         if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
         env:
-          ORIGIN_URL: ${{ vars.BS_STAGING_BASE_URL }}
+          # CLI flags: BS base URL, BS auth URL, LML base URL, suite name.
+          # Env: CANARY_DJ_EMAIL/PASSWORD for the authenticated checks,
+          # CANARY_LML_API_KEY for the lml-auth check, CANARY_ORIGIN_URL
+          # for the Origin header on better-auth requests (must match
+          # BETTER_AUTH_TRUSTED_ORIGINS for the staging deploy).
           CANARY_DJ_EMAIL: ${{ secrets.E2E_TEST_DJ_EMAIL }}
           CANARY_DJ_PASSWORD: ${{ secrets.E2E_TEST_DJ_PASSWORD }}
           CANARY_LML_API_KEY: ${{ secrets.LML_API_KEY_STAGING }}
-        run: wxyc-canary check --suite=smoke
+          CANARY_ORIGIN_URL: ${{ vars.BS_STAGING_BASE_URL }}
+        run: |
+          wxyc-canary check \
+            --base-url='${{ vars.BS_STAGING_BASE_URL }}' \
+            --auth-url='${{ vars.BS_STAGING_AUTH_URL }}' \
+            --lml-url='${{ vars.LML_STAGING_BASE_URL }}' \
+            --suite=smoke
 
+      # Bypass audit MUST run before any prod push. The push steps below
+      # gate on `success() &&` (load-bearing — see below): if log-bypass
+      # exits non-zero, success() goes false and both push steps skip.
+      # The noop guard prevents misleading "promoted" audit entries when
+      # prods are already at main.
       - name: Audit bypass to tracker issue (before any prod push)
-        if: inputs.skip_gate == true
+        if: inputs.skip_gate == true && steps.noop.outputs.noop != 'true'
         env:
           BYPASS_REPO: ${{ env.BYPASS_TRACKER_REPO }}
           BYPASS_ISSUE_NUMBER: ${{ env.BYPASS_TRACKER_ISSUE }}
@@ -161,8 +190,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/bs-lml-gate/log-bypass.sh
 
+      # `success() &&` is explicit here (and load-bearing): it ensures
+      # that if ANY prior step failed — verify, E2E, canary, audit — the
+      # prod push is skipped. Do not remove without first replacing it
+      # with an equivalent guard, or the gate will silently bypass.
       - name: Push Backend-Service prod
-        if: steps.noop.outputs.noop != 'true'
+        id: push_bs
+        if: success() && steps.noop.outputs.noop != 'true'
         env:
           PUSH_REPO: WXYC/Backend-Service
           PUSH_TARGET_SHA: ${{ steps.shas.outputs.bs_main_sha }}
@@ -171,7 +205,11 @@ jobs:
         run: ./scripts/bs-lml-gate/push-prod.sh
 
       - name: Push library-metadata-lookup prod
-        if: steps.noop.outputs.noop != 'true'
+        id: push_lml
+        # `always()` here: BS push may have succeeded; we still want to
+        # attempt LML so we don't compound a partial promotion by silent
+        # skip. The job summary distinguishes the two outcomes.
+        if: always() && steps.push_bs.outcome != 'skipped' && steps.noop.outputs.noop != 'true'
         env:
           PUSH_REPO: WXYC/library-metadata-lookup
           PUSH_TARGET_SHA: ${{ steps.shas.outputs.lml_main_sha }}
@@ -181,7 +219,20 @@ jobs:
 
       - name: Job summary
         if: always()
+        env:
+          BS_OUTCOME: ${{ steps.push_bs.outcome }}
+          LML_OUTCOME: ${{ steps.push_lml.outcome }}
         run: |
+          render_outcome() {
+            # success | failure | skipped | cancelled (from step outcome)
+            case "$1" in
+              success) echo "advanced" ;;
+              failure) echo ":warning: **push failed**" ;;
+              skipped) echo "skipped (no-op or prior step failed)" ;;
+              "")      echo "not reached" ;;
+              *)       echo "$1" ;;
+            esac
+          }
           {
             echo "## bs-lml-gate run"
             echo ""
@@ -191,13 +242,13 @@ jobs:
             bs_new='${{ steps.shas.outputs.bs_main_sha }}'
             lml_old='${{ steps.shas.outputs.lml_prod_sha }}'
             lml_new='${{ steps.shas.outputs.lml_main_sha }}'
-            bs_outcome='advanced'
-            lml_outcome='advanced'
-            [[ "$bs_old" == "$bs_new" ]] && bs_outcome='no-op (already at main)'
-            [[ "$lml_old" == "$lml_new" ]] && lml_outcome='no-op (already at main)'
-            echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | ${bs_outcome} |"
-            echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | ${lml_outcome} |"
+            echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | $(render_outcome "$BS_OUTCOME") |"
+            echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | $(render_outcome "$LML_OUTCOME") |"
             echo ""
+            if [[ "$BS_OUTCOME" == "success" && "$LML_OUTCOME" != "success" && "$LML_OUTCOME" != "skipped" ]]; then
+              echo ":rotating_light: **Split promotion**: BS prod advanced but LML did not. Manually fast-forward LML prod to its current main SHA, or roll BS prod back. See runbook (wiki#81)."
+              echo ""
+            fi
             if [[ "${{ inputs.skip_gate }}" == "true" ]]; then
               echo "**Bypass:** gate skipped per workflow_dispatch input. Justification logged at ${BYPASS_TRACKER_REPO}#${BYPASS_TRACKER_ISSUE}."
             fi

--- a/.github/workflows/bs-lml-gate.yml
+++ b/.github/workflows/bs-lml-gate.yml
@@ -1,0 +1,204 @@
+name: bs-lml-gate
+
+# Coordinator for Backend-Service + library-metadata-lookup prod promotion.
+#
+# After either repo's staging deploy reports healthy, it dispatches here.
+# This workflow re-resolves both `main` SHAs, verifies both staging envs,
+# runs E2E + canary smoke, and on pass fast-forwards each repo's `prod`
+# branch to its `main` SHA. The repos' existing prod auto-deploys then
+# fire on `push: prod`.
+#
+# Helpers live alongside this workflow at scripts/bs-lml-gate/ (not
+# scripts/) so the gate's blast radius is obvious from one directory
+# listing. Each helper has bats tests in scripts/__tests__/bs-lml-gate/.
+#
+# Design notes:
+#   - client_payload.source_sha is informational only. The gate always
+#     re-queries main so a stale dispatch can't regress prod.
+#   - concurrency: cancel-in-progress is false because a cancelled
+#     mid-push would leave one repo's prod advanced and the other not.
+#   - prod pushes use repo-scoped fine-grained PATs, not GITHUB_TOKEN,
+#     so the audit log shows the promoter bot rather than the GHA actor.
+
+on:
+  repository_dispatch:
+    types: [bs-staging-deployed, lml-staging-deployed]
+  workflow_dispatch:
+    inputs:
+      skip_gate:
+        description: 'Bypass staging checks (still posts audit comment).'
+        type: boolean
+        default: false
+      justification:
+        description: 'Required when skip_gate=true. Audited.'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  issues: write   # for the bypass audit comment
+
+concurrency:
+  group: bs-lml-gate
+  cancel-in-progress: false
+
+env:
+  BYPASS_TRACKER_REPO: ${{ github.repository }}
+  # Set in the repo as a *variable* (not secret). Created once by the
+  # setup checklist in README — points at the long-lived pinned issue.
+  BYPASS_TRACKER_ISSUE: ${{ vars.GATE_BYPASS_ISSUE_NUMBER }}
+
+jobs:
+  gate:
+    runs-on: [self-hosted, e2e-runner]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout wxyc-shared (for E2E suite + helpers)
+        uses: actions/checkout@v6
+
+      - name: Resolve current main + prod SHAs for both repos
+        id: shas
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/bs-lml-gate/resolve-shas.sh
+
+      - name: Summarize triggering dispatch + resolved SHAs
+        run: |
+          echo "Dispatch event: ${{ github.event_name }}"
+          echo "Dispatch type:  ${{ github.event.action || 'workflow_dispatch' }}"
+          echo "Dispatch source repo: ${{ github.event.client_payload.source_repo || 'n/a' }}"
+          echo "Dispatch source sha:  ${{ github.event.client_payload.source_sha  || 'n/a' }}"
+          echo "BS  main: ${{ steps.shas.outputs.bs_main_sha }}"
+          echo "BS  prod: ${{ steps.shas.outputs.bs_prod_sha }}"
+          echo "LML main: ${{ steps.shas.outputs.lml_main_sha }}"
+          echo "LML prod: ${{ steps.shas.outputs.lml_prod_sha }}"
+
+      - name: Early-exit if both prod already match main (nothing to promote)
+        id: noop
+        run: |
+          if [[ "${{ steps.shas.outputs.bs_main_sha }}" == "${{ steps.shas.outputs.bs_prod_sha }}" \
+             && "${{ steps.shas.outputs.lml_main_sha }}" == "${{ steps.shas.outputs.lml_prod_sha }}" ]]; then
+            echo "noop=true" >>"$GITHUB_OUTPUT"
+            echo "Both prod branches already at main; nothing to do."
+          else
+            echo "noop=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Poll BS-staging /health
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          POLL_URL: ${{ vars.BS_STAGING_BASE_URL }}/healthcheck
+        run: ./scripts/bs-lml-gate/poll-staging-health.sh
+
+      - name: Poll LML-staging /health
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          POLL_URL: ${{ vars.LML_STAGING_BASE_URL }}/health
+        run: ./scripts/bs-lml-gate/poll-staging-health.sh
+
+      - name: Verify BS-staging /version matches main
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          VERIFY_URL: ${{ vars.BS_STAGING_BASE_URL }}/version
+          EXPECTED_SHA: ${{ steps.shas.outputs.bs_main_sha }}
+        run: ./scripts/bs-lml-gate/verify-version.sh
+
+      - name: Verify LML-staging /version matches main
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          VERIFY_URL: ${{ vars.LML_STAGING_BASE_URL }}/version
+          EXPECTED_SHA: ${{ steps.shas.outputs.lml_main_sha }}
+        run: ./scripts/bs-lml-gate/verify-version.sh
+
+      - name: Setup Node
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies + build (E2E needs the dist)
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        run: |
+          npm ci --ignore-scripts
+          npm run generate:typescript
+          npm run build
+
+      - name: Run wxyc-shared E2E against BS-staging
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          E2E_BASE_URL: ${{ vars.BS_STAGING_BASE_URL }}
+          E2E_AUTH_URL: ${{ vars.BS_STAGING_AUTH_URL }}
+          E2E_TEST_DJ_EMAIL: ${{ secrets.E2E_TEST_DJ_EMAIL }}
+          E2E_TEST_DJ_PASSWORD: ${{ secrets.E2E_TEST_DJ_PASSWORD }}
+        run: npm run test:e2e
+
+      - name: Install wxyc-canary CLI
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        # Pinned to wxyc-canary main @ 36178c8 (Phase 5a, wxyc-canary#43).
+        # Bump intentionally when canary contracts change.
+        run: npm install -g github:WXYC/wxyc-canary#36178c85fbe920523ac5482c4766537abc2aa5ef
+
+      - name: Run canary smoke suite against staging
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          ORIGIN_URL: ${{ vars.BS_STAGING_BASE_URL }}
+          CANARY_DJ_EMAIL: ${{ secrets.E2E_TEST_DJ_EMAIL }}
+          CANARY_DJ_PASSWORD: ${{ secrets.E2E_TEST_DJ_PASSWORD }}
+          CANARY_LML_API_KEY: ${{ secrets.LML_API_KEY_STAGING }}
+        run: wxyc-canary check --suite=smoke
+
+      - name: Audit bypass to tracker issue (before any prod push)
+        if: inputs.skip_gate == true
+        env:
+          BYPASS_REPO: ${{ env.BYPASS_TRACKER_REPO }}
+          BYPASS_ISSUE_NUMBER: ${{ env.BYPASS_TRACKER_ISSUE }}
+          BYPASS_ACTOR: ${{ github.actor }}
+          BYPASS_JUSTIFICATION: ${{ inputs.justification }}
+          BYPASS_BS_SHA: ${{ steps.shas.outputs.bs_main_sha }}
+          BYPASS_LML_SHA: ${{ steps.shas.outputs.lml_main_sha }}
+          BYPASS_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/bs-lml-gate/log-bypass.sh
+
+      - name: Push Backend-Service prod
+        if: steps.noop.outputs.noop != 'true'
+        env:
+          PUSH_REPO: WXYC/Backend-Service
+          PUSH_TARGET_SHA: ${{ steps.shas.outputs.bs_main_sha }}
+          PUSH_CURRENT_SHA: ${{ steps.shas.outputs.bs_prod_sha }}
+          PUSH_PAT: ${{ secrets.PROD_PUSH_TOKEN_BS }}
+        run: ./scripts/bs-lml-gate/push-prod.sh
+
+      - name: Push library-metadata-lookup prod
+        if: steps.noop.outputs.noop != 'true'
+        env:
+          PUSH_REPO: WXYC/library-metadata-lookup
+          PUSH_TARGET_SHA: ${{ steps.shas.outputs.lml_main_sha }}
+          PUSH_CURRENT_SHA: ${{ steps.shas.outputs.lml_prod_sha }}
+          PUSH_PAT: ${{ secrets.PROD_PUSH_TOKEN_LML }}
+        run: ./scripts/bs-lml-gate/push-prod.sh
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## bs-lml-gate run"
+            echo ""
+            echo "| Repo | Old prod | New prod | Outcome |"
+            echo "| --- | --- | --- | --- |"
+            bs_old='${{ steps.shas.outputs.bs_prod_sha }}'
+            bs_new='${{ steps.shas.outputs.bs_main_sha }}'
+            lml_old='${{ steps.shas.outputs.lml_prod_sha }}'
+            lml_new='${{ steps.shas.outputs.lml_main_sha }}'
+            bs_outcome='advanced'
+            lml_outcome='advanced'
+            [[ "$bs_old" == "$bs_new" ]] && bs_outcome='no-op (already at main)'
+            [[ "$lml_old" == "$lml_new" ]] && lml_outcome='no-op (already at main)'
+            echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | ${bs_outcome} |"
+            echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | ${lml_outcome} |"
+            echo ""
+            if [[ "${{ inputs.skip_gate }}" == "true" ]]; then
+              echo "**Bypass:** gate skipped per workflow_dispatch input. Justification logged at ${BYPASS_TRACKER_REPO}#${BYPASS_TRACKER_ISSUE}."
+            fi
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bs-lml-gate.yml
+++ b/.github/workflows/bs-lml-gate.yml
@@ -208,6 +208,7 @@ jobs:
       # The noop guard prevents misleading "promoted" audit entries when
       # prods are already at main.
       - name: Audit bypass to tracker issue (before any prod push)
+        id: audit
         if: inputs.skip_gate == true && steps.noop.outputs.noop != 'true'
         env:
           BYPASS_REPO: ${{ env.BYPASS_TRACKER_REPO }}
@@ -260,10 +261,20 @@ jobs:
           # target==current, and empty when the step didn't run.
           BS_DID_PUSH: ${{ steps.push_bs.outputs.did_push }}
           LML_DID_PUSH: ${{ steps.push_lml.outputs.did_push }}
+          # Audit outcome distinguishes "audit ran and succeeded"
+          # (footer reference is valid) from "audit was skipped"
+          # (no comment posted — footer would lie).
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+          # noop tells us whether the push-step skips are due to
+          # nothing-to-do (good) vs prior-step-failure (bad). Without
+          # this the table can't distinguish them.
+          NOOP: ${{ steps.noop.outputs.noop }}
+          SKIP_GATE: ${{ inputs.skip_gate }}
         run: |
           render_outcome() {
             # $1 = step outcome (success|failure|skipped|cancelled|"")
             # $2 = did_push output (true|false|"")
+            # $3 = "true" iff noop early-exit fired
             case "$1" in
               success)
                 if [[ "$2" == "false" ]]; then
@@ -273,7 +284,13 @@ jobs:
                 fi
                 ;;
               failure)   echo ":warning: **push failed**" ;;
-              skipped)   echo "skipped (no-op or prior step failed)" ;;
+              skipped)
+                if [[ "$3" == "true" ]]; then
+                  echo "unchanged (both prods already at main)"
+                else
+                  echo "skipped (prior step failed)"
+                fi
+                ;;
               cancelled) echo ":octagonal_sign: cancelled mid-push" ;;
               "")        echo "not reached" ;;
               *)         echo "$1" ;;
@@ -288,12 +305,14 @@ jobs:
             bs_new='${{ steps.shas.outputs.bs_main_sha }}'
             lml_old='${{ steps.shas.outputs.lml_prod_sha }}'
             lml_new='${{ steps.shas.outputs.lml_main_sha }}'
-            echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | $(render_outcome "$BS_OUTCOME" "$BS_DID_PUSH") |"
-            echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | $(render_outcome "$LML_OUTCOME" "$LML_DID_PUSH") |"
+            echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | $(render_outcome "$BS_OUTCOME" "$BS_DID_PUSH" "$NOOP") |"
+            echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | $(render_outcome "$LML_OUTCOME" "$LML_DID_PUSH" "$NOOP") |"
             echo ""
-            # Split-promotion only happens if BS actually pushed and
-            # LML didn't (or vice versa). did_push=false on either side
-            # means no API call landed, so no split.
+            # Split-promotion only happens if one side actually pushed
+            # and the other didn't. did_push=false on either side means
+            # no API call landed, so no split. Note that emit_output is
+            # now fail-loud in push-prod.sh, so a successful push is
+            # guaranteed to have did_push=true (no false negatives).
             if [[ "$BS_DID_PUSH" == "true" && "$LML_DID_PUSH" != "true" ]]; then
               echo ":rotating_light: **Split promotion**: BS prod advanced but LML did not. Manually fast-forward LML prod to its current main SHA, or roll BS prod back. See runbook (wiki#81)."
               echo ""
@@ -304,7 +323,15 @@ jobs:
               echo ":rotating_light: **Split promotion (inverted)**: LML prod advanced but BS did not. This violates the gate's ordering invariant; investigate the workflow."
               echo ""
             fi
-            if [[ "${{ inputs.skip_gate }}" == "true" ]]; then
+            # Only print the bypass footer if the audit step actually
+            # ran and succeeded — otherwise it would point at a tracker
+            # comment that doesn't exist (e.g., noop + skip_gate=true
+            # skips the audit step, so no comment was posted).
+            if [[ "$SKIP_GATE" == "true" && "$AUDIT_OUTCOME" == "success" ]]; then
               echo "**Bypass:** gate skipped per workflow_dispatch input. Justification logged at ${BYPASS_TRACKER_REPO}#${BYPASS_TRACKER_ISSUE}."
+            elif [[ "$SKIP_GATE" == "true" && "$NOOP" == "true" ]]; then
+              echo "**Bypass requested but suppressed:** both prods already at main; nothing to promote. No audit comment posted."
+            elif [[ "$SKIP_GATE" == "true" ]]; then
+              echo "**Bypass requested but blocked:** audit step did not succeed (\`$AUDIT_OUTCOME\`); no prod was advanced."
             fi
           } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bs-lml-gate.yml
+++ b/.github/workflows/bs-lml-gate.yml
@@ -334,13 +334,15 @@ jobs:
               # it does — the gate's correctness depends on this.
               echo ":rotating_light: **Split promotion (inverted)**: LML prod advanced but BS did not. This violates the gate's ordering invariant; investigate the workflow."
               echo ""
-            elif [[ "$BS_OUTCOME" == "failure" && "$LML_OUTCOME" != "success" ]]; then
-              # BS push step failed (gh error OR emit_output write
-              # error after a successful PATCH). The ref MAY have
-              # moved on the BS side; LML definitely didn't push.
-              # Verify before deciding whether to retry the gate
-              # or recover manually.
-              echo ":warning: **Possible split promotion**: BS push step failed; the API PATCH may have landed before the failure. Check Backend-Service \`prod\` HEAD against \`${bs_new:0:12}\` directly via the GitHub API. If advanced, follow the split-promotion section of the runbook (wiki#81)."
+            elif [[ ( "$BS_OUTCOME" == "failure" || "$BS_OUTCOME" == "cancelled" ) && "$LML_OUTCOME" != "success" ]]; then
+              # BS push step ended in failure or cancellation. Both
+              # leave the same ambiguity: the gh API PATCH may have
+              # landed before the bad-state outcome (gh error,
+              # emit_output write error, runner SIGTERM). LML
+              # definitely didn't push. Verify the BS prod ref
+              # directly before deciding whether to retry or
+              # recover manually.
+              echo ":warning: **Possible split promotion**: BS push step ended in \`$BS_OUTCOME\`; the API PATCH may have landed before the bad-state outcome. Check Backend-Service \`prod\` HEAD against \`${bs_new:0:12}\` directly via the GitHub API. If advanced, follow the split-promotion section of the runbook (wiki#81)."
               echo ""
             fi
             # Only print the bypass footer if the audit step actually

--- a/.github/workflows/bs-lml-gate.yml
+++ b/.github/workflows/bs-lml-gate.yml
@@ -30,9 +30,15 @@ on:
         type: boolean
         default: false
       justification:
-        description: 'Audited (markdown is escaped). Required when skip_gate=true; ignored otherwise.'
+        # `required: true` would force a justification on every
+        # workflow_dispatch (including normal re-runs where it's
+        # ignored), so we keep this as `required: false` and let
+        # log-bypass.sh enforce non-emptiness when skip_gate=true.
+        # The form description is the contract; the script is the
+        # enforcement.
+        description: 'Required when skip_gate=true; ignored otherwise. Audited (markdown is escaped).'
         type: string
-        required: true
+        required: false
 
 permissions:
   contents: read
@@ -68,15 +74,28 @@ jobs:
         run: ./scripts/bs-lml-gate/resolve-shas.sh
 
       - name: Summarize triggering dispatch + resolved SHAs
+        # client_payload is attacker-controllable via the
+        # repository_dispatch API (requires repo:write — non-trivial
+        # but possible via PAT compromise). Pass through env so a
+        # malicious payload value cannot break out of shell quoting.
+        env:
+          DISPATCH_EVENT:       ${{ github.event_name }}
+          DISPATCH_TYPE:        ${{ github.event.action || 'workflow_dispatch' }}
+          DISPATCH_SOURCE_REPO: ${{ github.event.client_payload.source_repo || 'n/a' }}
+          DISPATCH_SOURCE_SHA:  ${{ github.event.client_payload.source_sha  || 'n/a' }}
+          BS_MAIN:  ${{ steps.shas.outputs.bs_main_sha }}
+          BS_PROD:  ${{ steps.shas.outputs.bs_prod_sha }}
+          LML_MAIN: ${{ steps.shas.outputs.lml_main_sha }}
+          LML_PROD: ${{ steps.shas.outputs.lml_prod_sha }}
         run: |
-          echo "Dispatch event: ${{ github.event_name }}"
-          echo "Dispatch type:  ${{ github.event.action || 'workflow_dispatch' }}"
-          echo "Dispatch source repo: ${{ github.event.client_payload.source_repo || 'n/a' }}"
-          echo "Dispatch source sha:  ${{ github.event.client_payload.source_sha  || 'n/a' }}"
-          echo "BS  main: ${{ steps.shas.outputs.bs_main_sha }}"
-          echo "BS  prod: ${{ steps.shas.outputs.bs_prod_sha }}"
-          echo "LML main: ${{ steps.shas.outputs.lml_main_sha }}"
-          echo "LML prod: ${{ steps.shas.outputs.lml_prod_sha }}"
+          echo "Dispatch event: $DISPATCH_EVENT"
+          echo "Dispatch type:  $DISPATCH_TYPE"
+          echo "Dispatch source repo: $DISPATCH_SOURCE_REPO"
+          echo "Dispatch source sha:  $DISPATCH_SOURCE_SHA"
+          echo "BS  main: $BS_MAIN"
+          echo "BS  prod: $BS_PROD"
+          echo "LML main: $LML_MAIN"
+          echo "LML prod: $LML_PROD"
 
       - name: Early-exit if both prod already match main (nothing to promote)
         id: noop
@@ -156,20 +175,31 @@ jobs:
       - name: Run canary smoke suite against staging
         if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
         env:
-          # CLI flags: BS base URL, BS auth URL, LML base URL, suite name.
-          # Env: CANARY_DJ_EMAIL/PASSWORD for the authenticated checks,
-          # CANARY_LML_API_KEY for the lml-auth check, CANARY_ORIGIN_URL
-          # for the Origin header on better-auth requests (must match
-          # BETTER_AUTH_TRUSTED_ORIGINS for the staging deploy).
-          CANARY_DJ_EMAIL: ${{ secrets.E2E_TEST_DJ_EMAIL }}
+          # All URLs + secrets via env (NOT inline `${{ ... }}` in the
+          # run script) so a repo variable containing an apostrophe
+          # cannot break out of shell quoting and inject commands. The
+          # var-write privilege is lower than secret-write, so this
+          # tightens the gate against an admin-account compromise.
+          BS_BASE_URL:  ${{ vars.BS_STAGING_BASE_URL }}
+          BS_AUTH_URL:  ${{ vars.BS_STAGING_AUTH_URL }}
+          LML_BASE_URL: ${{ vars.LML_STAGING_BASE_URL }}
+          CANARY_DJ_EMAIL:    ${{ secrets.E2E_TEST_DJ_EMAIL }}
           CANARY_DJ_PASSWORD: ${{ secrets.E2E_TEST_DJ_PASSWORD }}
           CANARY_LML_API_KEY: ${{ secrets.LML_API_KEY_STAGING }}
+          # CANARY_ORIGIN_URL is the Origin header sent on better-auth
+          # requests; it must match BS staging's BETTER_AUTH_TRUSTED_ORIGINS.
+          # Today BETTER_AUTH_TRUSTED_ORIGINS in production is the dj-site
+          # frontend URL — the staging equivalent (vars.BS_STAGING_BASE_URL
+          # = the API URL) will only work if phase 4 (BS#1335) configures
+          # BS staging to trust its own API origin, OR if a separate
+          # CANARY_STAGING_ORIGIN repo var is added pointing at the dj-site
+          # staging URL. Revisit when phase 4 wiring is in.
           CANARY_ORIGIN_URL: ${{ vars.BS_STAGING_BASE_URL }}
         run: |
           wxyc-canary check \
-            --base-url='${{ vars.BS_STAGING_BASE_URL }}' \
-            --auth-url='${{ vars.BS_STAGING_AUTH_URL }}' \
-            --lml-url='${{ vars.LML_STAGING_BASE_URL }}' \
+            --base-url="$BS_BASE_URL" \
+            --auth-url="$BS_AUTH_URL" \
+            --lml-url="$LML_BASE_URL" \
             --suite=smoke
 
       # Bypass audit MUST run before any prod push. The push steps below
@@ -206,10 +236,13 @@ jobs:
 
       - name: Push library-metadata-lookup prod
         id: push_lml
-        # `always()` here: BS push may have succeeded; we still want to
-        # attempt LML so we don't compound a partial promotion by silent
-        # skip. The job summary distinguishes the two outcomes.
-        if: always() && steps.push_bs.outcome != 'skipped' && steps.noop.outputs.noop != 'true'
+        # Same `success() &&` rule as BS push: if anything earlier
+        # failed (verify, E2E, canary, audit, OR the BS push itself),
+        # skip LML to keep prod consistent. iter-2 tried `always() &&
+        # push_bs.outcome != 'skipped'` but that ran LML on BS failure,
+        # producing exactly the split-prod state the gate is supposed
+        # to prevent.
+        if: success() && steps.noop.outputs.noop != 'true'
         env:
           PUSH_REPO: WXYC/library-metadata-lookup
           PUSH_TARGET_SHA: ${{ steps.shas.outputs.lml_main_sha }}
@@ -222,15 +255,28 @@ jobs:
         env:
           BS_OUTCOME: ${{ steps.push_bs.outcome }}
           LML_OUTCOME: ${{ steps.push_lml.outcome }}
+          # did_push is "true" when push-prod actually called the
+          # refs API, "false" when it short-circuited at
+          # target==current, and empty when the step didn't run.
+          BS_DID_PUSH: ${{ steps.push_bs.outputs.did_push }}
+          LML_DID_PUSH: ${{ steps.push_lml.outputs.did_push }}
         run: |
           render_outcome() {
-            # success | failure | skipped | cancelled (from step outcome)
+            # $1 = step outcome (success|failure|skipped|cancelled|"")
+            # $2 = did_push output (true|false|"")
             case "$1" in
-              success) echo "advanced" ;;
-              failure) echo ":warning: **push failed**" ;;
-              skipped) echo "skipped (no-op or prior step failed)" ;;
-              "")      echo "not reached" ;;
-              *)       echo "$1" ;;
+              success)
+                if [[ "$2" == "false" ]]; then
+                  echo "unchanged (already at main)"
+                else
+                  echo "advanced"
+                fi
+                ;;
+              failure)   echo ":warning: **push failed**" ;;
+              skipped)   echo "skipped (no-op or prior step failed)" ;;
+              cancelled) echo ":octagonal_sign: cancelled mid-push" ;;
+              "")        echo "not reached" ;;
+              *)         echo "$1" ;;
             esac
           }
           {
@@ -242,11 +288,20 @@ jobs:
             bs_new='${{ steps.shas.outputs.bs_main_sha }}'
             lml_old='${{ steps.shas.outputs.lml_prod_sha }}'
             lml_new='${{ steps.shas.outputs.lml_main_sha }}'
-            echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | $(render_outcome "$BS_OUTCOME") |"
-            echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | $(render_outcome "$LML_OUTCOME") |"
+            echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | $(render_outcome "$BS_OUTCOME" "$BS_DID_PUSH") |"
+            echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | $(render_outcome "$LML_OUTCOME" "$LML_DID_PUSH") |"
             echo ""
-            if [[ "$BS_OUTCOME" == "success" && "$LML_OUTCOME" != "success" && "$LML_OUTCOME" != "skipped" ]]; then
+            # Split-promotion only happens if BS actually pushed and
+            # LML didn't (or vice versa). did_push=false on either side
+            # means no API call landed, so no split.
+            if [[ "$BS_DID_PUSH" == "true" && "$LML_DID_PUSH" != "true" ]]; then
               echo ":rotating_light: **Split promotion**: BS prod advanced but LML did not. Manually fast-forward LML prod to its current main SHA, or roll BS prod back. See runbook (wiki#81)."
+              echo ""
+            elif [[ "$LML_DID_PUSH" == "true" && "$BS_DID_PUSH" != "true" ]]; then
+              # Should never happen under the current `success() &&`
+              # gating (LML can't push if BS didn't), but flag it if
+              # it does — the gate's correctness depends on this.
+              echo ":rotating_light: **Split promotion (inverted)**: LML prod advanced but BS did not. This violates the gate's ordering invariant; investigate the workflow."
               echo ""
             fi
             if [[ "${{ inputs.skip_gate }}" == "true" ]]; then

--- a/.github/workflows/bs-lml-gate.yml
+++ b/.github/workflows/bs-lml-gate.yml
@@ -308,11 +308,23 @@ jobs:
             echo "| Backend-Service | \`${bs_old:0:12}\` | \`${bs_new:0:12}\` | $(render_outcome "$BS_OUTCOME" "$BS_DID_PUSH" "$NOOP") |"
             echo "| library-metadata-lookup | \`${lml_old:0:12}\` | \`${lml_new:0:12}\` | $(render_outcome "$LML_OUTCOME" "$LML_DID_PUSH" "$NOOP") |"
             echo ""
-            # Split-promotion only happens if one side actually pushed
-            # and the other didn't. did_push=false on either side means
-            # no API call landed, so no split. Note that emit_output is
-            # now fail-loud in push-prod.sh, so a successful push is
-            # guaranteed to have did_push=true (no false negatives).
+            # Split-promotion detection has two layers:
+            #
+            # 1. did_push-confirmed splits: emit_output writes
+            #    `did_push=true` AFTER the gh PATCH succeeds; if one
+            #    side has did_push=true and the other doesn't, the
+            #    split is real.
+            #
+            # 2. Possible-split on push-step failure: emit_output is
+            #    fail-loud, so a successful gh PATCH followed by a
+            #    failed $GITHUB_OUTPUT write produces step
+            #    outcome=failure with did_push="" — the ref may or
+            #    may not have moved. We can't tell from the step
+            #    output, so we flag it as possible-split and point
+            #    at the runbook. Most push failures will be before
+            #    the API call (so no split), but the runbook check
+            #    is cheap and the cost of missing a real split is
+            #    much higher than a false alarm.
             if [[ "$BS_DID_PUSH" == "true" && "$LML_DID_PUSH" != "true" ]]; then
               echo ":rotating_light: **Split promotion**: BS prod advanced but LML did not. Manually fast-forward LML prod to its current main SHA, or roll BS prod back. See runbook (wiki#81)."
               echo ""
@@ -321,6 +333,14 @@ jobs:
               # gating (LML can't push if BS didn't), but flag it if
               # it does — the gate's correctness depends on this.
               echo ":rotating_light: **Split promotion (inverted)**: LML prod advanced but BS did not. This violates the gate's ordering invariant; investigate the workflow."
+              echo ""
+            elif [[ "$BS_OUTCOME" == "failure" && "$LML_OUTCOME" != "success" ]]; then
+              # BS push step failed (gh error OR emit_output write
+              # error after a successful PATCH). The ref MAY have
+              # moved on the BS side; LML definitely didn't push.
+              # Verify before deciding whether to retry the gate
+              # or recover manually.
+              echo ":warning: **Possible split promotion**: BS push step failed; the API PATCH may have landed before the failure. Check Backend-Service \`prod\` HEAD against \`${bs_new:0:12}\` directly via the GitHub API. If advanced, follow the split-promotion section of the runbook (wiki#81)."
               echo ""
             fi
             # Only print the bypass footer if the audit step actually

--- a/README.md
+++ b/README.md
@@ -583,6 +583,53 @@ npm run generate:python      # Python models (datamodel-codegen)
 
 See [e2e/README.md](./e2e/README.md) for details on running E2E tests.
 
+## Staging gate (bs-lml-gate)
+
+`.github/workflows/bs-lml-gate.yml` coordinates Backend-Service + library-metadata-lookup prod promotion. The shape: a PR merges to `main` in either repo → that repo's staging deploy fires → on healthy, the deploy job sends a `repository_dispatch` here → this workflow re-resolves the *current* `main` SHA of both repos, polls both staging `/health` endpoints, verifies each staging build's `/version` matches its `main` SHA, runs the wxyc-shared E2E suite + `wxyc-canary check --suite=smoke` against staging, and on all-pass fast-forwards each repo's `prod` branch to its `main` SHA. The existing prod auto-deploys in each repo then fire on `push: prod`.
+
+The gate is intentionally coupled — BS and LML promote together, and a broken BS staging holds LML hotfixes hostage. That's the trade-off for catching schema drift between the two pre-prod. There's a documented bypass path (see below).
+
+### Trigger
+
+```
+repository_dispatch:
+  types: [bs-staging-deployed, lml-staging-deployed]
+```
+
+`client_payload.source_sha` is informational only. The gate always re-queries `main` via the GitHub API after acquiring the concurrency lock, so a stale dispatch arriving after a newer merge cannot regress `prod`.
+
+### Concurrency
+
+`group: bs-lml-gate`, `cancel-in-progress: false`. A new dispatch queues behind a running gate; cancellation mid-push could leave one repo's `prod` advanced and the other not. Each dequeue uses whatever `main` SHA is current at that moment — we always promote the latest green pair.
+
+### Bypass
+
+`workflow_dispatch` with `skip_gate: true` and a non-empty `justification`. The bypass path still resolves both `main` SHAs and is still a no-op if `prod == main` already; it only skips the health/version/E2E/canary checks. A comment is appended to the pinned tracker issue (`vars.GATE_BYPASS_ISSUE_NUMBER`) *before* any prod push — if the audit append fails, the workflow exits non-zero before touching prod. There are no silent bypasses.
+
+### Setup checklist
+
+This workflow assumes the following one-time setup is done in the wxyc-shared repo:
+
+1. **Fine-grained PATs**: `PROD_PUSH_TOKEN_BS` and `PROD_PUSH_TOKEN_LML`, each scoped to `Contents: write` on the `prod` branch of *only* their respective repo. Store as repo secrets.
+2. **Staging URLs** as repo *variables* (not secrets — staging hostnames aren't sensitive): `BS_STAGING_BASE_URL`, `BS_STAGING_AUTH_URL`, `LML_STAGING_BASE_URL`.
+3. **Bypass tracker issue**: a pinned issue in this repo. Set `vars.GATE_BYPASS_ISSUE_NUMBER` to its number.
+4. **Staging API key**: `LML_API_KEY_STAGING` (added by phase 3).
+5. **E2E credentials**: already present (`E2E_TEST_DJ_EMAIL`, `E2E_TEST_DJ_PASSWORD`).
+
+Once the dispatchers in BS (phase 4) and LML (phase 3) are live, the gate fires automatically.
+
+### Helpers
+
+The workflow keeps logic in shell helpers at `scripts/bs-lml-gate/` (not the top-level `scripts/` dir, so the gate's blast radius is one directory listing). Each helper takes input via env vars, writes outputs to `$GITHUB_OUTPUT`, and has bats tests at `scripts/__tests__/bs-lml-gate/`:
+
+- `resolve-shas.sh` — fetches both repos' main + prod SHAs via `gh api`
+- `poll-staging-health.sh` — polls a URL until 200 or timeout
+- `verify-version.sh` — compares a service's `/version` to an expected SHA
+- `push-prod.sh` — advances a repo's `prod` ref via the GitHub refs API
+- `log-bypass.sh` — appends an audit comment to the tracker issue
+
+Run helper tests with `npm run test:bs-lml-gate`.
+
 ## Railway Deployment
 
 See [`railway/`](./railway/) for the Railway service topology, environment variable reference, and setup instructions for replicating the deployment environment.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:e2e:contracts": "vitest run --config vitest.e2e.config.ts tests/e2e-contracts.test.ts",
     "test:setup-script": "bats scripts/__tests__/setup-dev-environment.test.sh",
     "test:drift-guard": "bats scripts/__tests__/check-corpus-drift.test.sh",
+    "test:bs-lml-gate": "bats scripts/__tests__/bs-lml-gate/*.test.sh",
     "lint": "tsc --noEmit --declaration false --declarationMap false",
     "clean": "rm -rf dist",
     "generate": "npm run generate:typescript && npm run generate:python && npm run generate:swift && npm run generate:kotlin",

--- a/scripts/__tests__/bs-lml-gate/log-bypass.test.sh
+++ b/scripts/__tests__/bs-lml-gate/log-bypass.test.sh
@@ -114,10 +114,53 @@ GH_EOF
     [ "$status" -eq 2 ]
 }
 
+@test "error message names the exact env-var the operator must set" {
+    install_fake_gh_success
+    unset BYPASS_ISSUE_NUMBER
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    # Must say BYPASS_ISSUE_NUMBER, not BYPASS_ISSUE (the earlier name
+    # was confusing — operator would grep for the wrong var).
+    [[ "$output" == *"BYPASS_ISSUE_NUMBER"* ]]
+    [[ "$output" != *"BYPASS_ISSUE is"* ]]
+}
+
 @test "defaults BYPASS_WHEN to current UTC time when unset" {
     install_fake_gh_success
     unset BYPASS_WHEN
     run "$SCRIPT_PATH"
     [ "$status" -eq 0 ]
     grep -qE '20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' "$GH_BODY_LOG"
+}
+
+@test "wraps justification in a fenced code block so markdown is neutralized" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION='Approved by @wxyc/oncall — see https://evil.example/spoof'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    # The body should contain a fence line, AND the justification text
+    # should appear after the fence (not as inline markdown).
+    grep -qE '^```$' "$GH_BODY_LOG" || grep -qE '^~~~$' "$GH_BODY_LOG"
+    grep -q 'Approved by @wxyc/oncall' "$GH_BODY_LOG"
+}
+
+@test "falls back to ~~~ fence if justification contains backtick fence" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION=$'try this:\n```rm -rf /```'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    # Outer fence must be ~~~ since the body contains ```
+    grep -qE '^~~~$' "$GH_BODY_LOG"
+}
+
+@test "neutralizes embedded fence sequence that matches the chosen delimiter" {
+    install_fake_gh_success
+    # Plain backtick-fenced justification — outer fence is ```, so an
+    # interior ``` would escape the block. Verify it gets broken up.
+    export BYPASS_JUSTIFICATION=$'plain text with embedded ``` fence'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    # Outer fence is ~~~ (since input has ```), so escape isn't a concern,
+    # but verify the input ``` was disarmed too as belt-and-suspenders.
+    ! grep -qE '^```$' "$GH_BODY_LOG" || true
 }

--- a/scripts/__tests__/bs-lml-gate/log-bypass.test.sh
+++ b/scripts/__tests__/bs-lml-gate/log-bypass.test.sh
@@ -53,14 +53,23 @@ teardown() {
 install_fake_gh_success() {
     cat >"$FAKE_BIN/gh" <<GH_EOF
 #!/usr/bin/env bash
+# Mirror real \`gh api\` flag semantics: only -F (--field) treats
+# @<path> as a file reference; -f (--raw-field) sends it as a literal
+# string. Capturing both behaviors lets the test distinguish them so
+# a swap of -F → -f doesn't silently pass.
 printf '%s\n' "\$*" >>"$GH_CALL_LOG"
-# Capture the body sent via -F body=@... if present
-for ((i=1; i<=\$#; i++)); do
-    arg="\${!i}"
-    if [[ "\$arg" == "body=@"* ]]; then
-        path="\${arg#body=@}"
-        cat "\$path" >>"$GH_BODY_LOG"
+prev=""
+for arg in "\$@"; do
+    if [[ "\$arg" == "body="* ]]; then
+        value="\${arg#body=}"
+        if [[ "\$value" == "@"* && ( "\$prev" == "-F" || "\$prev" == "--field" ) ]]; then
+            cat "\${value#@}" >>"\$GH_BODY_LOG"
+        else
+            # -f or no flag context: body is the literal string value
+            printf '%s\n' "\$value" >>"\$GH_BODY_LOG"
+        fi
     fi
+    prev="\$arg"
 done
 exit 0
 GH_EOF
@@ -105,6 +114,31 @@ GH_EOF
     run "$SCRIPT_PATH"
     [ "$status" -eq 2 ]
     [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "exits 2 when justification is whitespace-only (no silent bypass via blank)" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION=$'   \n\t  \n'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "handles justification line equal to 'EOF' (heredoc-injection defense)" {
+    install_fake_gh_success
+    # If the body were built with an unquoted heredoc <<EOF, this line
+    # would terminate the heredoc early. The script must build the
+    # body via a delimiter-free mechanism so this is just text.
+    export BYPASS_JUSTIFICATION=$'before\nEOF\nafter'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    # Body must contain all three lines verbatim plus the closing fence.
+    grep -q '^before$' "$GH_BODY_LOG"
+    grep -q '^EOF$' "$GH_BODY_LOG"
+    grep -q '^after$' "$GH_BODY_LOG"
+    # And the body must end with the closing fence (either ``` or ~~~);
+    # if heredoc-EOF had terminated early, the closing fence would be missing.
+    tail -1 "$GH_BODY_LOG" | grep -qE '^(```|~~~)$'
 }
 
 @test "exits 2 when any required field is missing" {
@@ -153,14 +187,39 @@ GH_EOF
     grep -qE '^~~~$' "$GH_BODY_LOG"
 }
 
-@test "neutralizes embedded fence sequence that matches the chosen delimiter" {
+@test "disarms input fence that matches the chosen outer fence" {
     install_fake_gh_success
-    # Plain backtick-fenced justification — outer fence is ```, so an
-    # interior ``` would escape the block. Verify it gets broken up.
-    export BYPASS_JUSTIFICATION=$'plain text with embedded ``` fence'
+    # Outer fence is chosen based on input: ``` is the default; if
+    # input contains ```, outer flips to ~~~. The remaining defense:
+    # if the chosen outer fence sequence appears in the input, it
+    # must be broken up so it can't close the outer block early.
+    #
+    # Input contains BOTH ``` and ~~~. Outer fence becomes ~~~
+    # (input has ```). The script must disarm the standalone ~~~
+    # line in the input so it doesn't close the outer ~~~ block.
+    export BYPASS_JUSTIFICATION=$'has ``` and\n~~~\nstandalone'
     run "$SCRIPT_PATH"
     [ "$status" -eq 0 ]
-    # Outer fence is ~~~ (since input has ```), so escape isn't a concern,
-    # but verify the input ``` was disarmed too as belt-and-suspenders.
-    ! grep -qE '^```$' "$GH_BODY_LOG" || true
+    # Body must not contain a standalone ~~~ line in positions where
+    # it would close the outer block. The opening and closing fences
+    # are the only legitimate ~~~ lines; the middle of the body
+    # (inside the fence) must not have ~~~ alone on a line.
+    # Count standalone ~~~ lines: should be exactly 2 (open + close).
+    count=$(grep -cE '^~~~$' "$GH_BODY_LOG")
+    [ "$count" -eq 2 ]
+}
+
+@test "posts the rendered body via -F (not -f), so audit content reaches the issue" {
+    # Regression test for the iter-2 swap of -F → -f that silently
+    # broke the audit body: gh api -f body=@path sends the LITERAL
+    # string '@path', not the file content. The fake gh distinguishes
+    # the two flags, so this asserts the script uses -F.
+    install_fake_gh_success
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -qE '(^| )-F( |$)' "$GH_CALL_LOG"
+    # And the body that landed must be the rendered markdown, not
+    # the literal '@/tmp/...' string the -f path would produce.
+    [ -s "$GH_BODY_LOG" ]
+    ! grep -qE '^@/' "$GH_BODY_LOG"
 }

--- a/scripts/__tests__/bs-lml-gate/log-bypass.test.sh
+++ b/scripts/__tests__/bs-lml-gate/log-bypass.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/bs-lml-gate/log-bypass.sh.
+#
+# log-bypass.sh appends a comment to a long-lived "gate-bypasses"
+# tracker issue with who/when/justification/SHAs. Called by the
+# workflow on the bypass path before any prod push. If the append
+# fails, log-bypass exits non-zero so the workflow bails out before
+# advancing prod — bypass-with-no-audit is forbidden.
+#
+# Env:
+#   BYPASS_REPO            — required, e.g. WXYC/wxyc-shared
+#   BYPASS_ISSUE_NUMBER    — required, integer
+#   BYPASS_ACTOR           — required (github.actor)
+#   BYPASS_JUSTIFICATION   — required, non-empty
+#   BYPASS_BS_SHA          — required
+#   BYPASS_LML_SHA         — required
+#   BYPASS_RUN_URL         — required, link back to the GHA run
+#   BYPASS_WHEN            — optional, ISO timestamp. Defaults to `date -u +%Y-%m-%dT%H:%M:%SZ`
+#
+# Exit:
+#   0 — comment posted
+#   1 — gh api failed
+#   2 — usage error
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../bs-lml-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/log-bypass.sh"
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+    export FAKE_BIN="$TEST_TEMP_DIR/bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+    export GH_CALL_LOG="$TEST_TEMP_DIR/gh-calls.log"
+    export GH_BODY_LOG="$TEST_TEMP_DIR/gh-body.log"
+    : >"$GH_CALL_LOG"
+    : >"$GH_BODY_LOG"
+
+    export BYPASS_REPO='WXYC/wxyc-shared'
+    export BYPASS_ISSUE_NUMBER='42'
+    export BYPASS_ACTOR='jakebromberg'
+    export BYPASS_JUSTIFICATION='LML staging wedged on stale Discogs cache; promoting BS hotfix #BS-1318 manually'
+    export BYPASS_BS_SHA='a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9'
+    export BYPASS_LML_SHA='ffeeddccbbaa99887766554433221100ffeeddcc'
+    export BYPASS_RUN_URL='https://github.com/WXYC/wxyc-shared/actions/runs/123456'
+    export BYPASS_WHEN='2026-06-04T22:00:00Z'
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+install_fake_gh_success() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+# Capture the body sent via -F body=@... if present
+for ((i=1; i<=\$#; i++)); do
+    arg="\${!i}"
+    if [[ "\$arg" == "body=@"* ]]; then
+        path="\${arg#body=@}"
+        cat "\$path" >>"$GH_BODY_LOG"
+    fi
+done
+exit 0
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+install_fake_gh_failure() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+echo "fake gh: simulated failure" >&2
+exit 1
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+@test "posts a comment containing actor, justification, both SHAs, when, and run URL" {
+    install_fake_gh_success
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+
+    grep -q "POST" "$GH_CALL_LOG"
+    grep -q "repos/WXYC/wxyc-shared/issues/42/comments" "$GH_CALL_LOG"
+
+    grep -q 'jakebromberg' "$GH_BODY_LOG"
+    grep -q 'LML staging wedged' "$GH_BODY_LOG"
+    grep -q 'a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9' "$GH_BODY_LOG"
+    grep -q 'ffeeddccbbaa99887766554433221100ffeeddcc' "$GH_BODY_LOG"
+    grep -q '2026-06-04T22:00:00Z' "$GH_BODY_LOG"
+    grep -q 'actions/runs/123456' "$GH_BODY_LOG"
+}
+
+@test "exits 1 when gh fails — workflow must abort before pushing prod" {
+    install_fake_gh_failure
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+}
+
+@test "exits 2 when justification is empty (defends invariant: no silent bypass)" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION=''
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "exits 2 when any required field is missing" {
+    install_fake_gh_success
+    unset BYPASS_ACTOR
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+}
+
+@test "defaults BYPASS_WHEN to current UTC time when unset" {
+    install_fake_gh_success
+    unset BYPASS_WHEN
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -qE '20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' "$GH_BODY_LOG"
+}

--- a/scripts/__tests__/bs-lml-gate/poll-staging-health.test.sh
+++ b/scripts/__tests__/bs-lml-gate/poll-staging-health.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/bs-lml-gate/poll-staging-health.sh.
+#
+# poll-staging-health.sh polls one URL until it returns HTTP 200 or the
+# timeout elapses. Multiple URLs are polled in series — the gate calls
+# this once per service. Polling-multiple-in-parallel is the workflow's
+# concern, not the helper's.
+#
+# Inputs (env):
+#   POLL_URL          — required, URL to GET
+#   POLL_TIMEOUT_SECS — optional, default 300
+#   POLL_INTERVAL_SECS— optional, default 5
+#
+# Exit:
+#   0 on first 200
+#   1 on timeout or DNS failure
+#   2 on usage error
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../bs-lml-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/poll-staging-health.sh"
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    # SERVER_PID is written to a file (not exported) because start_*
+    # runs inside a $(...) subshell, so a plain variable assignment
+    # there would not propagate back here.
+    if [[ -f "$TEST_TEMP_DIR/server.pid" ]]; then
+        local pid
+        pid="$(cat "$TEST_TEMP_DIR/server.pid")"
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    fi
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+# Spin up a Python HTTP server that returns the response codes listed in
+# $TEST_TEMP_DIR/sequence.txt, one per request, falling through to the last
+# value once exhausted. Returns the chosen port on stdout.
+start_sequenced_server() {
+    local seq_file="$TEST_TEMP_DIR/sequence.txt"
+    local port_file="$TEST_TEMP_DIR/server.port"
+    cat >"$TEST_TEMP_DIR/server.py" <<'PY_EOF'
+import http.server, socketserver, sys, threading
+seq_path = sys.argv[1]
+port_path = sys.argv[2]
+with open(seq_path) as f:
+    seq = [int(line.strip()) for line in f if line.strip()]
+i = [0]
+lock = threading.Lock()
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        with lock:
+            code = seq[i[0]] if i[0] < len(seq) else seq[-1]
+            i[0] += 1
+        self.send_response(code)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+    def log_message(self, *a, **k):
+        pass
+with socketserver.TCPServer(("127.0.0.1", 0), H) as s:
+    with open(port_path, "w") as f:
+        f.write(str(s.server_address[1]))
+    s.serve_forever()
+PY_EOF
+    python3 "$TEST_TEMP_DIR/server.py" "$seq_file" "$port_file" >/dev/null 2>&1 &
+    echo $! >"$TEST_TEMP_DIR/server.pid"
+    # wait for port_file to be written
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if [[ -s "$port_file" ]]; then break; fi
+        sleep 0.1
+    done
+    cat "$port_file"
+}
+
+@test "exits 0 immediately when server returns 200" {
+    echo "200" >"$TEST_TEMP_DIR/sequence.txt"
+    port=$(start_sequenced_server)
+    export POLL_URL="http://127.0.0.1:${port}/health"
+    export POLL_TIMEOUT_SECS=10
+    export POLL_INTERVAL_SECS=1
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+}
+
+@test "polls until 200 after several 503s" {
+    printf '503\n503\n503\n200\n' >"$TEST_TEMP_DIR/sequence.txt"
+    port=$(start_sequenced_server)
+    export POLL_URL="http://127.0.0.1:${port}/health"
+    export POLL_TIMEOUT_SECS=30
+    export POLL_INTERVAL_SECS=1
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+}
+
+@test "exits 1 when timeout elapses without a 200" {
+    echo "503" >"$TEST_TEMP_DIR/sequence.txt"
+    port=$(start_sequenced_server)
+    export POLL_URL="http://127.0.0.1:${port}/health"
+    export POLL_TIMEOUT_SECS=3
+    export POLL_INTERVAL_SECS=1
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"timeout"* || "$output" == *"timed out"* ]]
+}
+
+@test "exits 1 when DNS / connection fails (server not listening)" {
+    # Pick a port that is almost certainly closed.
+    export POLL_URL="http://127.0.0.1:1/health"
+    export POLL_TIMEOUT_SECS=3
+    export POLL_INTERVAL_SECS=1
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+}
+
+@test "exits 2 when POLL_URL is missing" {
+    unset POLL_URL || true
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"POLL_URL"* ]]
+}
+
+@test "exits 2 when POLL_URL is not http(s)" {
+    export POLL_URL="file:///etc/passwd"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+}

--- a/scripts/__tests__/bs-lml-gate/push-prod.test.sh
+++ b/scripts/__tests__/bs-lml-gate/push-prod.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/bs-lml-gate/push-prod.sh.
+#
+# push-prod.sh advances a single repo's `prod` branch to a target SHA
+# via the GitHub API (no local clone — the gate runs on a self-hosted
+# runner that we don't want to pollute with per-repo clones).
+#
+# Env:
+#   PUSH_REPO       — required, e.g. WXYC/Backend-Service
+#   PUSH_TARGET_SHA — required, 40-char hex
+#   PUSH_CURRENT_SHA— required, "" means seed (create branch)
+#   PUSH_PAT        — required, fine-grained PAT for the target repo's `prod` ref
+#   PUSH_DRY_RUN    — optional, "1" prints the gh call(s) instead of running them
+#
+# Exit:
+#   0 — push succeeded OR no-op (target == current)
+#   1 — push failed
+#   2 — usage error
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../bs-lml-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/push-prod.sh"
+
+EXPECTED='a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9'
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+    export FAKE_BIN="$TEST_TEMP_DIR/bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+    export GH_CALL_LOG="$TEST_TEMP_DIR/gh-calls.log"
+    : >"$GH_CALL_LOG"
+    # Common required env
+    export PUSH_REPO='WXYC/Backend-Service'
+    export PUSH_TARGET_SHA="$EXPECTED"
+    export PUSH_CURRENT_SHA=""
+    export PUSH_PAT='ghp_fake'
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+install_fake_gh_success() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+exit 0
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+install_fake_gh_failure() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+echo "fake gh: simulated failure" >&2
+exit 1
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+@test "no-op when PUSH_TARGET_SHA == PUSH_CURRENT_SHA (skips gh entirely)" {
+    install_fake_gh_failure   # would fail if it were called
+    export PUSH_CURRENT_SHA="$EXPECTED"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no-op"* || "$output" == *"already"* ]]
+    [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "fast-forward updates an existing prod ref via PATCH" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q 'PATCH' "$GH_CALL_LOG"
+    grep -q "refs/heads/prod" "$GH_CALL_LOG"
+    grep -q "$EXPECTED" "$GH_CALL_LOG"
+}
+
+@test "seed (PUSH_CURRENT_SHA empty) POSTs a new ref" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA=""
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q 'POST' "$GH_CALL_LOG"
+    grep -q "refs/heads/prod" "$GH_CALL_LOG"
+    grep -q "$EXPECTED" "$GH_CALL_LOG"
+}
+
+@test "exits 1 if gh fails" {
+    install_fake_gh_failure
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+}
+
+@test "dry-run does not invoke gh" {
+    install_fake_gh_failure   # would fail if invoked
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    export PUSH_DRY_RUN='1'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [ ! -s "$GH_CALL_LOG" ]
+    [[ "$output" == *"$EXPECTED"* ]]
+    [[ "$output" == *"$PUSH_REPO"* ]]
+}
+
+@test "exits 2 if required env is missing" {
+    unset PUSH_TARGET_SHA
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+}
+
+@test "rejects PUSH_TARGET_SHA that is not 40-char hex" {
+    install_fake_gh_failure
+    export PUSH_TARGET_SHA='not-a-sha'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "does not leak PAT to stdout/stderr or the call log" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    export PUSH_PAT='ghp_secretsecretsecretsecretsecret'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"ghp_secret"* ]]
+    ! grep -q 'ghp_secret' "$GH_CALL_LOG"
+}

--- a/scripts/__tests__/bs-lml-gate/push-prod.test.sh
+++ b/scripts/__tests__/bs-lml-gate/push-prod.test.sh
@@ -129,6 +129,17 @@ GH_EOF
     [ ! -s "$GH_CALL_LOG" ]
 }
 
+@test "exits non-zero if \$GITHUB_OUTPUT write fails (no silent did_push loss)" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    # Point GITHUB_OUTPUT at a directory (not a file) so the append
+    # fails predictably without needing root or fs manipulation.
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR"
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GITHUB_OUTPUT"* ]]
+}
+
 @test "does not leak PAT to stdout/stderr or the call log" {
     install_fake_gh_success
     export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'

--- a/scripts/__tests__/bs-lml-gate/push-prod.test.sh
+++ b/scripts/__tests__/bs-lml-gate/push-prod.test.sh
@@ -30,6 +30,8 @@ setup() {
     export PATH="$FAKE_BIN:$PATH"
     export GH_CALL_LOG="$TEST_TEMP_DIR/gh-calls.log"
     : >"$GH_CALL_LOG"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github_output"
+    : >"$GITHUB_OUTPUT"
     # Common required env
     export PUSH_REPO='WXYC/Backend-Service'
     export PUSH_TARGET_SHA="$EXPECTED"
@@ -60,16 +62,17 @@ GH_EOF
     chmod +x "$FAKE_BIN/gh"
 }
 
-@test "no-op when PUSH_TARGET_SHA == PUSH_CURRENT_SHA (skips gh entirely)" {
+@test "no-op when PUSH_TARGET_SHA == PUSH_CURRENT_SHA (skips gh entirely, did_push=false)" {
     install_fake_gh_failure   # would fail if it were called
     export PUSH_CURRENT_SHA="$EXPECTED"
     run "$SCRIPT_PATH"
     [ "$status" -eq 0 ]
     [[ "$output" == *"no-op"* || "$output" == *"already"* ]]
     [ ! -s "$GH_CALL_LOG" ]
+    grep -q '^did_push=false$' "$GITHUB_OUTPUT"
 }
 
-@test "fast-forward updates an existing prod ref via PATCH" {
+@test "fast-forward updates an existing prod ref via PATCH (did_push=true)" {
     install_fake_gh_success
     export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
     run "$SCRIPT_PATH"
@@ -77,9 +80,10 @@ GH_EOF
     grep -q 'PATCH' "$GH_CALL_LOG"
     grep -q "refs/heads/prod" "$GH_CALL_LOG"
     grep -q "$EXPECTED" "$GH_CALL_LOG"
+    grep -q '^did_push=true$' "$GITHUB_OUTPUT"
 }
 
-@test "seed (PUSH_CURRENT_SHA empty) POSTs a new ref" {
+@test "seed (PUSH_CURRENT_SHA empty) POSTs a new ref (did_push=true)" {
     install_fake_gh_success
     export PUSH_CURRENT_SHA=""
     run "$SCRIPT_PATH"
@@ -87,13 +91,17 @@ GH_EOF
     grep -q 'POST' "$GH_CALL_LOG"
     grep -q "refs/heads/prod" "$GH_CALL_LOG"
     grep -q "$EXPECTED" "$GH_CALL_LOG"
+    grep -q '^did_push=true$' "$GITHUB_OUTPUT"
 }
 
-@test "exits 1 if gh fails" {
+@test "exits 1 if gh fails (and does NOT claim did_push=true)" {
     install_fake_gh_failure
     export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
     run "$SCRIPT_PATH"
     [ "$status" -eq 1 ]
+    # On gh failure, we don't know if the ref moved; the summary
+    # logic depends on did_push staying unset rather than 'true'.
+    ! grep -q '^did_push=true$' "$GITHUB_OUTPUT"
 }
 
 @test "dry-run does not invoke gh" {

--- a/scripts/__tests__/bs-lml-gate/resolve-shas.test.sh
+++ b/scripts/__tests__/bs-lml-gate/resolve-shas.test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/bs-lml-gate/resolve-shas.sh
+#
+# resolve-shas.sh fetches current main + prod SHAs for BS and LML via
+# `gh api`, writes them to $GITHUB_OUTPUT, and exits non-zero if any
+# fetch fails (so a transient API blip blocks promotion rather than
+# silently using a stale SHA).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../bs-lml-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/resolve-shas.sh"
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github_output"
+    : >"$GITHUB_OUTPUT"
+    export FAKE_BIN="$TEST_TEMP_DIR/bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+# Install a fake `gh` that emits canned JSON keyed by the path it was called with.
+install_fake_gh() {
+    local fixture_dir="$TEST_TEMP_DIR/gh-fixtures"
+    mkdir -p "$fixture_dir"
+    export GH_FIXTURE_DIR="$fixture_dir"
+    cat >"$FAKE_BIN/gh" <<'GH_EOF'
+#!/usr/bin/env bash
+# Expects: gh api <path>
+# Returns body for $GH_FIXTURE_DIR/<sanitized-path>.json or exits 22.
+if [[ "$1" != "api" ]]; then
+    echo "fake gh: unexpected first arg '$1'" >&2
+    exit 99
+fi
+path="$2"
+sanitized="${path//\//_}"
+fixture="$GH_FIXTURE_DIR/${sanitized}.json"
+if [[ ! -f "$fixture" ]]; then
+    echo "fake gh: no fixture for '$path' (looked at $fixture)" >&2
+    exit 22
+fi
+cat "$fixture"
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+set_fixture() {
+    local path="$1" body="$2"
+    local sanitized="${path//\//_}"
+    echo "$body" >"$GH_FIXTURE_DIR/${sanitized}.json"
+}
+
+# Test SHAs: hex-only, exactly 40 chars. Leading letter + 38 zeros + tag.
+BS_MAIN='b000000000000000000000000000000000000001'
+BS_PROD='b000000000000000000000000000000000000002'
+LML_MAIN='c000000000000000000000000000000000000001'
+LML_PROD='c000000000000000000000000000000000000002'
+
+@test "writes bs_main_sha, lml_main_sha, bs_prod_sha, lml_prod_sha to GITHUB_OUTPUT" {
+    install_fake_gh
+    set_fixture "repos/WXYC/Backend-Service/branches/main"           "{\"commit\":{\"sha\":\"$BS_MAIN\"}}"
+    set_fixture "repos/WXYC/Backend-Service/branches/prod"           "{\"commit\":{\"sha\":\"$BS_PROD\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/main"   "{\"commit\":{\"sha\":\"$LML_MAIN\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/prod"   "{\"commit\":{\"sha\":\"$LML_PROD\"}}"
+
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+
+    grep -qE "^bs_main_sha=${BS_MAIN}\$"   "$GITHUB_OUTPUT"
+    grep -qE "^bs_prod_sha=${BS_PROD}\$"   "$GITHUB_OUTPUT"
+    grep -qE "^lml_main_sha=${LML_MAIN}\$" "$GITHUB_OUTPUT"
+    grep -qE "^lml_prod_sha=${LML_PROD}\$" "$GITHUB_OUTPUT"
+}
+
+@test "treats missing prod branch (404) as empty SHA so the seed flow works" {
+    install_fake_gh
+    set_fixture "repos/WXYC/Backend-Service/branches/main"           "{\"commit\":{\"sha\":\"$BS_MAIN\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/main"   "{\"commit\":{\"sha\":\"$LML_MAIN\"}}"
+    # prod fixtures intentionally absent -> fake gh exits 22 (Not Found-ish)
+
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q '^bs_prod_sha=$'  "$GITHUB_OUTPUT"
+    grep -q '^lml_prod_sha=$' "$GITHUB_OUTPUT"
+}
+
+@test "fails if main resolve fails (do NOT proceed with empty main)" {
+    install_fake_gh
+    # No main fixtures -> fake gh exits 22 for main lookups
+    set_fixture "repos/WXYC/Backend-Service/branches/prod"           "{\"commit\":{\"sha\":\"$BS_PROD\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/prod"   "{\"commit\":{\"sha\":\"$LML_PROD\"}}"
+
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+}
+
+@test "fails if GITHUB_OUTPUT is unset" {
+    install_fake_gh
+    unset GITHUB_OUTPUT
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GITHUB_OUTPUT"* ]]
+}
+
+@test "rejects SHAs that are not 40-char hex (defense against fixture/API drift)" {
+    install_fake_gh
+    set_fixture "repos/WXYC/Backend-Service/branches/main"           '{"commit":{"sha":"not-a-sha"}}'
+    set_fixture "repos/WXYC/Backend-Service/branches/prod"           "{\"commit\":{\"sha\":\"$BS_PROD\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/main"   "{\"commit\":{\"sha\":\"$LML_MAIN\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/prod"   "{\"commit\":{\"sha\":\"$LML_PROD\"}}"
+
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"sha"* || "$output" == *"SHA"* ]]
+}

--- a/scripts/__tests__/bs-lml-gate/resolve-shas.test.sh
+++ b/scripts/__tests__/bs-lml-gate/resolve-shas.test.sh
@@ -23,15 +23,17 @@ teardown() {
     rm -rf "$TEST_TEMP_DIR"
 }
 
-# Install a fake `gh` that emits canned JSON keyed by the path it was called with.
+# Install a fake `gh` that emits canned JSON keyed by the path it was
+# called with. Missing fixture defaults to a 404-style stderr so the
+# script's 404→empty path is exercised (the production gh emits e.g.
+# `gh: Not Found (HTTP 404)`). Tests that want a non-404 failure write
+# a fixture-suffixed file `<path>.500` or `<path>.401`.
 install_fake_gh() {
     local fixture_dir="$TEST_TEMP_DIR/gh-fixtures"
     mkdir -p "$fixture_dir"
     export GH_FIXTURE_DIR="$fixture_dir"
     cat >"$FAKE_BIN/gh" <<'GH_EOF'
 #!/usr/bin/env bash
-# Expects: gh api <path>
-# Returns body for $GH_FIXTURE_DIR/<sanitized-path>.json or exits 22.
 if [[ "$1" != "api" ]]; then
     echo "fake gh: unexpected first arg '$1'" >&2
     exit 99
@@ -39,13 +41,27 @@ fi
 path="$2"
 sanitized="${path//\//_}"
 fixture="$GH_FIXTURE_DIR/${sanitized}.json"
+# Non-404 failure fixture support: presence of <sanitized>.HTTP_xxx
+# means simulate that status code with a matching stderr.
+for code in 401 403 429 500 503; do
+    if [[ -f "$GH_FIXTURE_DIR/${sanitized}.HTTP_${code}" ]]; then
+        echo "gh: HTTP ${code}: simulated (https://api.github.com/${path})" >&2
+        exit 1
+    fi
+done
 if [[ ! -f "$fixture" ]]; then
-    echo "fake gh: no fixture for '$path' (looked at $fixture)" >&2
-    exit 22
+    echo "gh: Not Found (HTTP 404)" >&2
+    exit 1
 fi
 cat "$fixture"
 GH_EOF
     chmod +x "$FAKE_BIN/gh"
+}
+
+simulate_http() {
+    # simulate_http <path> <status>
+    local sanitized="${1//\//_}"
+    : >"$GH_FIXTURE_DIR/${sanitized}.HTTP_${2}"
 }
 
 set_fixture() {
@@ -116,4 +132,29 @@ LML_PROD='c000000000000000000000000000000000000002'
     run "$SCRIPT_PATH"
     [ "$status" -ne 0 ]
     [[ "$output" == *"sha"* || "$output" == *"SHA"* ]]
+}
+
+@test "fails fast on transient 5xx for prod lookup (does NOT collapse to seed path)" {
+    install_fake_gh
+    set_fixture "repos/WXYC/Backend-Service/branches/main"           "{\"commit\":{\"sha\":\"$BS_MAIN\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/main"   "{\"commit\":{\"sha\":\"$LML_MAIN\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/prod"   "{\"commit\":{\"sha\":\"$LML_PROD\"}}"
+    # BS prod returns 503 — must surface as a failure, not as 'seed needed'
+    simulate_http "repos/WXYC/Backend-Service/branches/prod" 503
+
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"503"* ]]
+}
+
+@test "fails fast on 401 for any lookup (expired PAT, do NOT silently bypass)" {
+    install_fake_gh
+    set_fixture "repos/WXYC/Backend-Service/branches/main"           "{\"commit\":{\"sha\":\"$BS_MAIN\"}}"
+    set_fixture "repos/WXYC/library-metadata-lookup/branches/main"   "{\"commit\":{\"sha\":\"$LML_MAIN\"}}"
+    set_fixture "repos/WXYC/Backend-Service/branches/prod"           "{\"commit\":{\"sha\":\"$BS_PROD\"}}"
+    simulate_http "repos/WXYC/library-metadata-lookup/branches/prod" 401
+
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"401"* ]]
 }

--- a/scripts/__tests__/bs-lml-gate/verify-version.test.sh
+++ b/scripts/__tests__/bs-lml-gate/verify-version.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/bs-lml-gate/verify-version.sh.
+#
+# Checks that a service's /version endpoint reports the SHA we expect.
+# Used to detect "staging deployed an older build than the dispatcher's
+# commit" — usually means a newer push has landed and we should wait
+# for its dispatch to arrive instead of promoting against stale state.
+#
+# Env:
+#   VERIFY_URL          — required
+#   EXPECTED_SHA        — required (40-char hex)
+#   VERIFY_JQ_PATH      — optional, default '.sha' (some services may use '.version' etc)
+#
+# Exit:
+#   0 — match
+#   1 — mismatch, non-200, or unparseable response
+#   2 — usage error
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../bs-lml-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/verify-version.sh"
+
+EXPECTED='a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9'
+OTHER='ffeeddccbbaa99887766554433221100ffeeddcc'
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    # SERVER_PID lives in a file because start_version_server runs in
+    # a $(...) subshell — plain variable assignment there would not
+    # propagate.
+    if [[ -f "$TEST_TEMP_DIR/server.pid" ]]; then
+        local pid
+        pid="$(cat "$TEST_TEMP_DIR/server.pid")"
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    fi
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+# Start an HTTP server that returns the given (status, body) for /version.
+# Status and body are passed via argv to keep the heredoc quoted (so Python's
+# !r and bash's ${} can't collide).
+start_version_server() {
+    local status="$1" body="$2"
+    local port_file="$TEST_TEMP_DIR/server.port"
+    local body_file="$TEST_TEMP_DIR/server.body"
+    printf '%s' "$body" >"$body_file"
+    cat >"$TEST_TEMP_DIR/server.py" <<'PY_EOF'
+import http.server, socketserver, sys
+status = int(sys.argv[1])
+with open(sys.argv[2], "rb") as f:
+    body = f.read()
+port_path = sys.argv[3]
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a, **k):
+        pass
+with socketserver.TCPServer(("127.0.0.1", 0), H) as s:
+    with open(port_path, "w") as f:
+        f.write(str(s.server_address[1]))
+    s.serve_forever()
+PY_EOF
+    python3 "$TEST_TEMP_DIR/server.py" "$status" "$body_file" "$port_file" >/dev/null 2>&1 &
+    echo $! >"$TEST_TEMP_DIR/server.pid"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if [[ -s "$port_file" ]]; then break; fi
+        sleep 0.1
+    done
+    cat "$port_file"
+}
+
+@test "exit 0 when /version sha matches EXPECTED_SHA" {
+    port=$(start_version_server 200 "{\"sha\":\"$EXPECTED\"}")
+    export VERIFY_URL="http://127.0.0.1:${port}/version"
+    export EXPECTED_SHA="$EXPECTED"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 1 with both SHAs in stderr when /version sha mismatches" {
+    port=$(start_version_server 200 "{\"sha\":\"$OTHER\"}")
+    export VERIFY_URL="http://127.0.0.1:${port}/version"
+    export EXPECTED_SHA="$EXPECTED"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"$EXPECTED"* ]]
+    [[ "$output" == *"$OTHER"* ]]
+}
+
+@test "exit 1 on empty body" {
+    port=$(start_version_server 200 '')
+    export VERIFY_URL="http://127.0.0.1:${port}/version"
+    export EXPECTED_SHA="$EXPECTED"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+}
+
+@test "exit 1 on non-200 response" {
+    port=$(start_version_server 500 "{\"sha\":\"$EXPECTED\"}")
+    export VERIFY_URL="http://127.0.0.1:${port}/version"
+    export EXPECTED_SHA="$EXPECTED"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+}
+
+@test "exit 1 on unparseable JSON" {
+    port=$(start_version_server 200 'not-json{')
+    export VERIFY_URL="http://127.0.0.1:${port}/version"
+    export EXPECTED_SHA="$EXPECTED"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+}
+
+@test "honours VERIFY_JQ_PATH override for services that nest the sha" {
+    port=$(start_version_server 200 "{\"build\":{\"commit\":\"$EXPECTED\"}}")
+    export VERIFY_URL="http://127.0.0.1:${port}/version"
+    export EXPECTED_SHA="$EXPECTED"
+    export VERIFY_JQ_PATH='.build.commit'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 2 when VERIFY_URL or EXPECTED_SHA is missing" {
+    unset VERIFY_URL EXPECTED_SHA || true
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+}

--- a/scripts/bs-lml-gate/log-bypass.sh
+++ b/scripts/bs-lml-gate/log-bypass.sh
@@ -36,6 +36,14 @@ for var in BYPASS_REPO BYPASS_ISSUE_NUMBER BYPASS_ACTOR \
     fi
 done
 
+# Whitespace-only justification is a silent-bypass-by-content. `-z`
+# above catches truly empty strings; this catches space/tab/newline-only
+# payloads that would pass the length check but contribute no content.
+if [[ -z "${BYPASS_JUSTIFICATION//[[:space:]]/}" ]]; then
+    echo "log-bypass: BYPASS_JUSTIFICATION is whitespace-only (no silent bypasses)" >&2
+    exit 2
+fi
+
 body_file="$(mktemp)"
 trap 'rm -f "$body_file"' EXIT
 
@@ -57,23 +65,30 @@ else
     sanitized="${BYPASS_JUSTIFICATION//\`\`\`/\`\` \`}"
 fi
 
-cat >"$body_file" <<EOF
-## Gate bypass — ${WHEN}
+# Build the body via printf (not heredoc) so a justification line of
+# exactly `EOF` can't terminate the heredoc early and corrupt the
+# audit comment. printf doesn't have a delimiter to inject.
+printf '%s\n' \
+    "## Gate bypass — ${WHEN}" \
+    "" \
+    "- **Actor:** @${BYPASS_ACTOR}" \
+    "- **Run:** ${BYPASS_RUN_URL}" \
+    "- **Backend-Service SHA promoted:** \`${BYPASS_BS_SHA}\`" \
+    "- **library-metadata-lookup SHA promoted:** \`${BYPASS_LML_SHA}\`" \
+    "" \
+    "**Justification**" \
+    "" \
+    "${fence}" \
+    "${sanitized}" \
+    "${fence}" \
+    >"$body_file"
 
-- **Actor:** @${BYPASS_ACTOR}
-- **Run:** ${BYPASS_RUN_URL}
-- **Backend-Service SHA promoted:** \`${BYPASS_BS_SHA}\`
-- **library-metadata-lookup SHA promoted:** \`${BYPASS_LML_SHA}\`
-
-**Justification**
-
-${fence}
-${sanitized}
-${fence}
-EOF
-
+# NB: `-F` (--field) is required here, NOT `-f` (--raw-field). Per
+# `gh api --help`: only `-F` supports the `@<path>` syntax to read
+# the value from a file. `-f body=@path` posts the literal seven-char
+# string `@<path>` — destroying the audit trail without erroring.
 if ! gh api -X POST "repos/${BYPASS_REPO}/issues/${BYPASS_ISSUE_NUMBER}/comments" \
-    -f "body=@${body_file}" --silent; then
+    -F "body=@${body_file}" --silent; then
     echo "log-bypass: failed to append comment to ${BYPASS_REPO}#${BYPASS_ISSUE_NUMBER}" >&2
     exit 1
 fi

--- a/scripts/bs-lml-gate/log-bypass.sh
+++ b/scripts/bs-lml-gate/log-bypass.sh
@@ -24,18 +24,14 @@
 
 set -uo pipefail
 
-REPO="${BYPASS_REPO:-}"
-ISSUE="${BYPASS_ISSUE_NUMBER:-}"
-ACTOR="${BYPASS_ACTOR:-}"
-JUSTIFICATION="${BYPASS_JUSTIFICATION:-}"
-BS_SHA="${BYPASS_BS_SHA:-}"
-LML_SHA="${BYPASS_LML_SHA:-}"
-RUN_URL="${BYPASS_RUN_URL:-}"
 WHEN="${BYPASS_WHEN:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
-for var in REPO ISSUE ACTOR JUSTIFICATION BS_SHA LML_SHA RUN_URL; do
-    if [[ -z "${!var}" ]]; then
-        echo "log-bypass: BYPASS_${var} is required (no silent bypasses)" >&2
+# Loop iterates over the ACTUAL env-var names so error messages match
+# what an operator needs to set — not the local script aliases.
+for var in BYPASS_REPO BYPASS_ISSUE_NUMBER BYPASS_ACTOR \
+           BYPASS_JUSTIFICATION BYPASS_BS_SHA BYPASS_LML_SHA BYPASS_RUN_URL; do
+    if [[ -z "${!var:-}" ]]; then
+        echo "log-bypass: ${var} is required (no silent bypasses)" >&2
         exit 2
     fi
 done
@@ -43,26 +39,44 @@ done
 body_file="$(mktemp)"
 trap 'rm -f "$body_file"' EXIT
 
-# Plain markdown — the tracker issue is a long-lived pinned issue so
-# comments append naturally. Keep this format stable; runbook may grep it.
+# Justification is user input; render it inside a fenced code block so
+# markdown (@-mentions, links, headings) is neutralized in the audit
+# comment. The fence label is empty so the block doesn't get a language
+# tag. Anyone reading the source can still see the text verbatim, but
+# they can't be social-engineered by a fake "Approved by" link.
+#
+# Defense against fence-escape: if the justification itself contains
+# ``` we fall back to ~~~ (CommonMark allows either, and code fences
+# must match the opening sequence). Belt-and-suspenders: we also strip
+# any embedded fence sequence that matches the chosen delimiter.
+if [[ "$BYPASS_JUSTIFICATION" == *'```'* ]]; then
+    fence='~~~'
+    sanitized="${BYPASS_JUSTIFICATION//\~\~\~/\~\~ \~}"
+else
+    fence='```'
+    sanitized="${BYPASS_JUSTIFICATION//\`\`\`/\`\` \`}"
+fi
+
 cat >"$body_file" <<EOF
 ## Gate bypass — ${WHEN}
 
-- **Actor:** @${ACTOR}
-- **Run:** ${RUN_URL}
-- **Backend-Service SHA promoted:** \`${BS_SHA}\`
-- **library-metadata-lookup SHA promoted:** \`${LML_SHA}\`
+- **Actor:** @${BYPASS_ACTOR}
+- **Run:** ${BYPASS_RUN_URL}
+- **Backend-Service SHA promoted:** \`${BYPASS_BS_SHA}\`
+- **library-metadata-lookup SHA promoted:** \`${BYPASS_LML_SHA}\`
 
 **Justification**
 
-${JUSTIFICATION}
+${fence}
+${sanitized}
+${fence}
 EOF
 
-if ! gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" \
-    -F "body=@${body_file}" --silent; then
-    echo "log-bypass: failed to append comment to ${REPO}#${ISSUE}" >&2
+if ! gh api -X POST "repos/${BYPASS_REPO}/issues/${BYPASS_ISSUE_NUMBER}/comments" \
+    -f "body=@${body_file}" --silent; then
+    echo "log-bypass: failed to append comment to ${BYPASS_REPO}#${BYPASS_ISSUE_NUMBER}" >&2
     exit 1
 fi
 
-echo "log-bypass: appended bypass audit to ${REPO}#${ISSUE}"
+echo "log-bypass: appended bypass audit to ${BYPASS_REPO}#${BYPASS_ISSUE_NUMBER}"
 exit 0

--- a/scripts/bs-lml-gate/log-bypass.sh
+++ b/scripts/bs-lml-gate/log-bypass.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# log-bypass.sh — append an audit comment to the gate-bypasses tracker
+# issue.
+#
+# Invariant: the workflow MUST NOT advance prod via the bypass path if
+# this script fails. The audit append is the only record of a manual
+# promotion, so failing-open here would be a silent bypass.
+#
+# Env (all required unless noted):
+#   BYPASS_REPO           — e.g. WXYC/wxyc-shared
+#   BYPASS_ISSUE_NUMBER   — integer
+#   BYPASS_ACTOR          — github.actor
+#   BYPASS_JUSTIFICATION  — non-empty
+#   BYPASS_BS_SHA         — Backend-Service main SHA being promoted
+#   BYPASS_LML_SHA        — library-metadata-lookup main SHA being promoted
+#   BYPASS_RUN_URL        — link to the GHA run
+#   BYPASS_WHEN           — optional ISO timestamp; defaults to now (UTC)
+#
+# Exit:
+#   0 — comment posted
+#   1 — gh api failed
+#   2 — usage error
+
+set -uo pipefail
+
+REPO="${BYPASS_REPO:-}"
+ISSUE="${BYPASS_ISSUE_NUMBER:-}"
+ACTOR="${BYPASS_ACTOR:-}"
+JUSTIFICATION="${BYPASS_JUSTIFICATION:-}"
+BS_SHA="${BYPASS_BS_SHA:-}"
+LML_SHA="${BYPASS_LML_SHA:-}"
+RUN_URL="${BYPASS_RUN_URL:-}"
+WHEN="${BYPASS_WHEN:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+for var in REPO ISSUE ACTOR JUSTIFICATION BS_SHA LML_SHA RUN_URL; do
+    if [[ -z "${!var}" ]]; then
+        echo "log-bypass: BYPASS_${var} is required (no silent bypasses)" >&2
+        exit 2
+    fi
+done
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+# Plain markdown — the tracker issue is a long-lived pinned issue so
+# comments append naturally. Keep this format stable; runbook may grep it.
+cat >"$body_file" <<EOF
+## Gate bypass — ${WHEN}
+
+- **Actor:** @${ACTOR}
+- **Run:** ${RUN_URL}
+- **Backend-Service SHA promoted:** \`${BS_SHA}\`
+- **library-metadata-lookup SHA promoted:** \`${LML_SHA}\`
+
+**Justification**
+
+${JUSTIFICATION}
+EOF
+
+if ! gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" \
+    -F "body=@${body_file}" --silent; then
+    echo "log-bypass: failed to append comment to ${REPO}#${ISSUE}" >&2
+    exit 1
+fi
+
+echo "log-bypass: appended bypass audit to ${REPO}#${ISSUE}"
+exit 0

--- a/scripts/bs-lml-gate/poll-staging-health.sh
+++ b/scripts/bs-lml-gate/poll-staging-health.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# poll-staging-health.sh — poll a URL until 200 OK or timeout.
+#
+# Used by .github/workflows/bs-lml-gate.yml to wait for staging /health
+# endpoints. Returns fast on success so the gate doesn't pay polling
+# latency unnecessarily.
+#
+# Env:
+#   POLL_URL          — required, must be http(s)://
+#   POLL_TIMEOUT_SECS — optional, default 300 (5 minutes)
+#   POLL_INTERVAL_SECS— optional, default 5
+#
+# Exit:
+#   0 — got a 200
+#   1 — timed out / connection failed throughout
+#   2 — usage error (missing/invalid POLL_URL)
+#
+# Requires: curl, bash 4+.
+
+set -uo pipefail
+
+URL="${POLL_URL:-}"
+TIMEOUT_SECS="${POLL_TIMEOUT_SECS:-300}"
+INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
+
+if [[ -z "$URL" ]]; then
+    echo "poll-staging-health: POLL_URL is required" >&2
+    exit 2
+fi
+if [[ "$URL" != http://* && "$URL" != https://* ]]; then
+    echo "poll-staging-health: POLL_URL must be http:// or https:// (got: '$URL')" >&2
+    exit 2
+fi
+
+# SECONDS resets each subshell — safe in this single-script context.
+SECONDS=0
+last_status=""
+while (( SECONDS < TIMEOUT_SECS )); do
+    # -s silent, -o /dev/null discard body, -w "%{http_code}" emit status
+    # -m caps per-request time so a hung connection doesn't eat the whole budget
+    last_status="$(curl -s -o /dev/null -w '%{http_code}' -m 10 "$URL" || echo "000")"
+    if [[ "$last_status" == "200" ]]; then
+        echo "poll-staging-health: $URL ready (elapsed ${SECONDS}s)"
+        exit 0
+    fi
+    sleep "$INTERVAL_SECS"
+done
+
+echo "poll-staging-health: timed out after ${TIMEOUT_SECS}s polling $URL (last status: ${last_status})" >&2
+exit 1

--- a/scripts/bs-lml-gate/push-prod.sh
+++ b/scripts/bs-lml-gate/push-prod.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# push-prod.sh — advance a repo's `prod` branch to a target SHA.
+#
+# Uses the GitHub API (refs PATCH / POST) rather than a local clone so
+# the self-hosted runner stays clean. Authentication is via a
+# fine-grained PAT scoped to `Contents: write` on the `prod` ref of
+# the target repo only.
+#
+# Env:
+#   PUSH_REPO        — required, e.g. WXYC/Backend-Service
+#   PUSH_TARGET_SHA  — required, 40-char hex
+#   PUSH_CURRENT_SHA — required, "" means seed (no prod branch yet)
+#   PUSH_PAT         — required, fine-grained PAT
+#   PUSH_DRY_RUN     — optional, "1" prints the planned API call
+#
+# Exit:
+#   0 — push succeeded OR no-op (target == current)
+#   1 — push failed
+#   2 — usage error
+#
+# Requires: gh.
+
+set -uo pipefail
+
+REPO="${PUSH_REPO:-}"
+TARGET="${PUSH_TARGET_SHA:-}"
+CURRENT="${PUSH_CURRENT_SHA-__UNSET__}"
+PAT="${PUSH_PAT:-}"
+DRY_RUN="${PUSH_DRY_RUN:-0}"
+
+if [[ -z "$REPO" || -z "$TARGET" || "$CURRENT" == "__UNSET__" || -z "$PAT" ]]; then
+    echo "push-prod: PUSH_REPO, PUSH_TARGET_SHA, PUSH_CURRENT_SHA, PUSH_PAT are required" >&2
+    exit 2
+fi
+
+if ! [[ "$TARGET" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "push-prod: PUSH_TARGET_SHA is not a 40-char hex sha: '$TARGET'" >&2
+    exit 2
+fi
+
+if [[ -n "$CURRENT" ]] && ! [[ "$CURRENT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "push-prod: PUSH_CURRENT_SHA is not a 40-char hex sha: '$CURRENT'" >&2
+    exit 2
+fi
+
+if [[ "$TARGET" == "$CURRENT" ]]; then
+    echo "push-prod: $REPO prod already at $TARGET (no-op)"
+    exit 0
+fi
+
+# Decide PATCH vs POST. Seed (no prod yet) = POST /git/refs with ref=refs/heads/prod.
+# Fast-forward = PATCH /git/refs/heads/prod with sha=TARGET.
+if [[ -z "$CURRENT" ]]; then
+    method="POST"
+    path="repos/${REPO}/git/refs"
+    fields=( -f "ref=refs/heads/prod" -f "sha=${TARGET}" )
+else
+    method="PATCH"
+    path="repos/${REPO}/git/refs/heads/prod"
+    fields=( -f "sha=${TARGET}" )
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "push-prod: DRY_RUN $method $path sha=$TARGET (repo=$REPO from=${CURRENT:-<seed>})"
+    exit 0
+fi
+
+# Pass the PAT via env to gh so it never appears on argv (would otherwise
+# show in `ps`). `gh` reads $GH_TOKEN before $GITHUB_TOKEN.
+if ! GH_TOKEN="$PAT" gh api -X "$method" "$path" "${fields[@]}" --silent; then
+    echo "push-prod: $method $path failed" >&2
+    exit 1
+fi
+
+echo "push-prod: $REPO prod -> $TARGET (${method})"
+exit 0

--- a/scripts/bs-lml-gate/push-prod.sh
+++ b/scripts/bs-lml-gate/push-prod.sh
@@ -50,8 +50,15 @@ fi
 
 emit_output() {
     # Write key=value to $GITHUB_OUTPUT when in GHA; no-op locally.
+    # Fail loud on write error — the workflow's split-promotion detector
+    # tests `did_push == "true"` exactly, so a silent emit-failure after
+    # a real push would mask the actual state and could even trigger a
+    # spurious inverted-split warning.
     if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-        printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
+        if ! printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"; then
+            echo "push-prod: failed to write $1=$2 to \$GITHUB_OUTPUT ($GITHUB_OUTPUT)" >&2
+            exit 1
+        fi
     fi
 }
 

--- a/scripts/bs-lml-gate/push-prod.sh
+++ b/scripts/bs-lml-gate/push-prod.sh
@@ -14,6 +14,10 @@
 #   PUSH_PAT         — required, fine-grained PAT
 #   PUSH_DRY_RUN     — optional, "1" prints the planned API call
 #
+# Outputs (to $GITHUB_OUTPUT if set):
+#   did_push=true    — a PATCH/POST landed against the GitHub API
+#   did_push=false   — short-circuited at target==current (no API call)
+#
 # Exit:
 #   0 — push succeeded OR no-op (target == current)
 #   1 — push failed
@@ -44,8 +48,16 @@ if [[ -n "$CURRENT" ]] && ! [[ "$CURRENT" =~ ^[0-9a-f]{40}$ ]]; then
     exit 2
 fi
 
+emit_output() {
+    # Write key=value to $GITHUB_OUTPUT when in GHA; no-op locally.
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
+    fi
+}
+
 if [[ "$TARGET" == "$CURRENT" ]]; then
     echo "push-prod: $REPO prod already at $TARGET (no-op)"
+    emit_output did_push false
     exit 0
 fi
 
@@ -63,6 +75,7 @@ fi
 
 if [[ "$DRY_RUN" == "1" ]]; then
     echo "push-prod: DRY_RUN $method $path sha=$TARGET (repo=$REPO from=${CURRENT:-<seed>})"
+    emit_output did_push false
     exit 0
 fi
 
@@ -70,8 +83,12 @@ fi
 # show in `ps`). `gh` reads $GH_TOKEN before $GITHUB_TOKEN.
 if ! GH_TOKEN="$PAT" gh api -X "$method" "$path" "${fields[@]}" --silent; then
     echo "push-prod: $method $path failed" >&2
+    # Even on failure, the request reached the API — but we don't
+    # know whether the ref moved. Don't claim did_push=true; leave
+    # the output unset so the workflow falls back to step outcome.
     exit 1
 fi
 
 echo "push-prod: $REPO prod -> $TARGET (${method})"
+emit_output did_push true
 exit 0

--- a/scripts/bs-lml-gate/resolve-shas.sh
+++ b/scripts/bs-lml-gate/resolve-shas.sh
@@ -50,9 +50,14 @@ fetch_branch_sha() {
         return 0
     fi
 
-    # gh's 404 stderr looks like `gh: Not Found (HTTP 404)`. Be liberal
-    # in what we accept here so a gh version bump doesn't surprise us.
-    if grep -qiE 'HTTP 404|Not Found' "$err_file"; then
+    # gh's 404 stderr always includes the literal `HTTP 404`. We anchor
+    # on that exact substring (no `-i`, no 'Not Found' alternation) to
+    # avoid false-matching on errors like `host not found` (DNS),
+    # `token not found` (auth), or upstream proxy messages that happen
+    # to contain the phrase. A false 404 match drives push-prod.sh into
+    # the seed/POST path on an existing branch, which then 422s loudly
+    # but mis-attributes the cause.
+    if grep -q 'HTTP 404' "$err_file"; then
         rm -f "$err_file"
         echo ""
         return 0

--- a/scripts/bs-lml-gate/resolve-shas.sh
+++ b/scripts/bs-lml-gate/resolve-shas.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# resolve-shas.sh — fetch current main + prod SHAs for both repos.
+#
+# Used by .github/workflows/bs-lml-gate.yml. Always re-queries the GitHub
+# API so a stale repository_dispatch payload cannot regress prod: whatever
+# commit is at HEAD of main at *this* moment is the one that gets promoted.
+#
+# Outputs (to $GITHUB_OUTPUT):
+#   bs_main_sha   — Backend-Service:main HEAD
+#   bs_prod_sha   — Backend-Service:prod HEAD ("" if branch doesn't exist yet)
+#   lml_main_sha  — library-metadata-lookup:main HEAD
+#   lml_prod_sha  — library-metadata-lookup:prod HEAD ("")
+#
+# Exits non-zero if a main SHA cannot be resolved (we never proceed with
+# a guessed/empty main). A missing prod branch is treated as "needs seed"
+# and resolves to empty string.
+#
+# Requires: gh, jq.
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+    echo "resolve-shas: GITHUB_OUTPUT is not set; refusing to run outside GHA" >&2
+    exit 2
+fi
+
+# Fetch the `commit.sha` for a branch; on any gh failure, echo empty.
+fetch_branch_sha() {
+    local repo="$1" branch="$2"
+    local body sha
+    if ! body="$(gh api "repos/${repo}/branches/${branch}" 2>/dev/null)"; then
+        echo ""
+        return 0
+    fi
+    sha="$(printf '%s' "$body" | jq -r '.commit.sha // ""')"
+    echo "$sha"
+}
+
+validate_sha() {
+    local label="$1" sha="$2"
+    if [[ -z "$sha" ]]; then
+        return 0
+    fi
+    if ! [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "resolve-shas: ${label} is not a 40-char hex sha: '${sha}'" >&2
+        return 1
+    fi
+}
+
+BS_MAIN_SHA="$(fetch_branch_sha WXYC/Backend-Service main)"
+LML_MAIN_SHA="$(fetch_branch_sha WXYC/library-metadata-lookup main)"
+BS_PROD_SHA="$(fetch_branch_sha WXYC/Backend-Service prod)"
+LML_PROD_SHA="$(fetch_branch_sha WXYC/library-metadata-lookup prod)"
+
+if [[ -z "$BS_MAIN_SHA" ]]; then
+    echo "resolve-shas: failed to resolve Backend-Service:main" >&2
+    exit 1
+fi
+if [[ -z "$LML_MAIN_SHA" ]]; then
+    echo "resolve-shas: failed to resolve library-metadata-lookup:main" >&2
+    exit 1
+fi
+
+validate_sha "Backend-Service:main"       "$BS_MAIN_SHA"
+validate_sha "library-metadata-lookup:main" "$LML_MAIN_SHA"
+validate_sha "Backend-Service:prod"       "$BS_PROD_SHA"
+validate_sha "library-metadata-lookup:prod" "$LML_PROD_SHA"
+
+{
+    echo "bs_main_sha=${BS_MAIN_SHA}"
+    echo "bs_prod_sha=${BS_PROD_SHA}"
+    echo "lml_main_sha=${LML_MAIN_SHA}"
+    echo "lml_prod_sha=${LML_PROD_SHA}"
+} >>"$GITHUB_OUTPUT"

--- a/scripts/bs-lml-gate/resolve-shas.sh
+++ b/scripts/bs-lml-gate/resolve-shas.sh
@@ -25,16 +25,45 @@ if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
     exit 2
 fi
 
-# Fetch the `commit.sha` for a branch; on any gh failure, echo empty.
+# Fetch the `commit.sha` for a branch.
+#
+# Exit semantics — we distinguish 404 (branch missing → seed path) from
+# every other gh failure (transient 5xx, expired PAT, rate-limit). The
+# old behavior of collapsing all failures into "empty" would let a 503
+# on a `prod` lookup mis-trigger the seed/POST path on an existing
+# branch and corrupt the audit trail.
+#
+# Returns: prints SHA on stdout (empty if branch is genuinely missing).
+# Exits the script on any non-404 failure (set -e propagates).
 fetch_branch_sha() {
     local repo="$1" branch="$2"
-    local body sha
-    if ! body="$(gh api "repos/${repo}/branches/${branch}" 2>/dev/null)"; then
+    local body="" err_file rc=0
+    err_file="$(mktemp)"
+
+    # NB: `if body="$(cmd)"; then` would clobber $? to 0 in the else
+    # branch (bash if-statement quirk). `|| rc=$?` keeps the real code.
+    body="$(gh api "repos/${repo}/branches/${branch}" 2>"$err_file")" || rc=$?
+
+    if (( rc == 0 )); then
+        rm -f "$err_file"
+        printf '%s' "$body" | jq -r '.commit.sha // ""'
+        return 0
+    fi
+
+    # gh's 404 stderr looks like `gh: Not Found (HTTP 404)`. Be liberal
+    # in what we accept here so a gh version bump doesn't surprise us.
+    if grep -qiE 'HTTP 404|Not Found' "$err_file"; then
+        rm -f "$err_file"
         echo ""
         return 0
     fi
-    sha="$(printf '%s' "$body" | jq -r '.commit.sha // ""')"
-    echo "$sha"
+
+    # Anything else: surface the error and propagate. set -e in main
+    # will fail the script.
+    echo "resolve-shas: gh api repos/${repo}/branches/${branch} failed (rc=$rc):" >&2
+    cat "$err_file" >&2
+    rm -f "$err_file"
+    return "$rc"
 }
 
 validate_sha() {

--- a/scripts/bs-lml-gate/verify-version.sh
+++ b/scripts/bs-lml-gate/verify-version.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# verify-version.sh — confirm a service's /version endpoint reports the
+# SHA we are about to promote.
+#
+# Used by .github/workflows/bs-lml-gate.yml after staging /health is
+# green but before we run E2E. If the staging build doesn't match
+# main, a newer push is mid-flight and the gate should fail — the
+# next dispatch (from that newer push) will re-run with the latest
+# pair.
+#
+# Env:
+#   VERIFY_URL    — required, http(s) URL of the /version endpoint
+#   EXPECTED_SHA  — required, the 40-char hex SHA we want to see
+#   VERIFY_JQ_PATH— optional, default '.sha'. Some services nest the SHA.
+#
+# Exit:
+#   0 — match
+#   1 — mismatch, non-200, or unparseable response
+#   2 — usage error
+#
+# Requires: curl, jq.
+
+set -uo pipefail
+
+URL="${VERIFY_URL:-}"
+EXPECTED="${EXPECTED_SHA:-}"
+JQ_PATH="${VERIFY_JQ_PATH:-.sha}"
+
+if [[ -z "$URL" || -z "$EXPECTED" ]]; then
+    echo "verify-version: VERIFY_URL and EXPECTED_SHA are required" >&2
+    exit 2
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+status="$(curl -s -o "$tmp" -w '%{http_code}' -m 10 "$URL" || echo "000")"
+if [[ "$status" != "200" ]]; then
+    echo "verify-version: $URL returned HTTP $status (expected 200)" >&2
+    exit 1
+fi
+
+if [[ ! -s "$tmp" ]]; then
+    echo "verify-version: $URL returned empty body" >&2
+    exit 1
+fi
+
+actual="$(jq -r "$JQ_PATH // \"\"" <"$tmp" 2>/dev/null || true)"
+if [[ -z "$actual" || "$actual" == "null" ]]; then
+    echo "verify-version: could not extract sha at $JQ_PATH from response" >&2
+    exit 1
+fi
+
+if [[ "$actual" != "$EXPECTED" ]]; then
+    echo "verify-version: $URL reports sha '$actual' but expected '$EXPECTED'" >&2
+    exit 1
+fi
+
+echo "verify-version: $URL matches expected sha $EXPECTED"
+exit 0


### PR DESCRIPTION
Closes #166. Part of [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80) phase 5.

## Summary

Adds `.github/workflows/bs-lml-gate.yml` — the coordinator that promotes Backend-Service and library-metadata-lookup `prod` branches together after their staging deploys + E2E + canary smoke all pass. Phase 5a ([wxyc-canary#43](https://github.com/WXYC/wxyc-canary/pull/43)) merged the CLI shim this gate calls, so this PR is the next domino.

Helpers live at `scripts/bs-lml-gate/` (not the top-level `scripts/` dir) so the gate's blast radius is one directory listing. Each helper takes inputs via env vars, writes outputs to `\$GITHUB_OUTPUT`, and has bats tests in `scripts/__tests__/bs-lml-gate/` (31 tests):

- `resolve-shas.sh` — fetches both repos' main + prod SHAs via `gh api`
- `poll-staging-health.sh` — polls a URL until 200 or timeout (default 5min)
- `verify-version.sh` — compares a service's `/version` to an expected SHA
- `push-prod.sh` — advances a repo's `prod` ref via the GitHub refs API (no local clone — keeps the self-hosted runner clean)
- `log-bypass.sh` — appends an audit comment to the tracker issue

Plus `.github/actionlint.yaml` declaring the `e2e-runner` self-hosted label (also used by [e2e-runner-bootstrap](https://github.com/WXYC/wxyc-shared/tree/e2e-runner-bootstrap)) so future actionlint runs don't flag it.

## Design decisions

- **Re-query main on every run.** `client_payload.source_sha` is informational only. The gate always re-resolves both `main` SHAs after acquiring the concurrency lock, so a stale dispatch arriving after a newer merge cannot regress `prod`.
- **`cancel-in-progress: false`.** A cancellation mid-push would leave one repo's `prod` advanced and the other not — splits the staging-gate invariant.
- **Fine-grained PATs, not GITHUB_TOKEN.** Per-repo PATs (`PROD_PUSH_TOKEN_BS`, `PROD_PUSH_TOKEN_LML`) scoped to `Contents: write` on `prod` only. The audit log shows the promoter identity rather than the generic GHA bot.
- **Bypass cannot be silent.** `workflow_dispatch` with `skip_gate: true` requires a non-empty `justification` and posts an audit comment to the pinned tracker issue *before* any prod push. If the audit append fails, the workflow exits non-zero before touching prod.
- **Half-success is recoverable, not prevented.** If BS push succeeds and LML push fails, the operator manually fast-forwards the laggard (runbook in [wiki#81](https://github.com/WXYC/wiki/issues/81)). Preventing this requires a two-phase commit pattern not justified for our volume.

## Blocked operationally by (but not blocked for merge)

This workflow is the orchestrator — the dispatchers and staging envs come from peer phases:
- [wxyc-shared#165](https://github.com/WXYC/wxyc-shared/issues/165) — e2e-runner provisioning
- [library-metadata-lookup#496](https://github.com/WXYC/library-metadata-lookup/issues/496) — LML staging env + dispatch
- [Backend-Service#1335](https://github.com/WXYC/Backend-Service/issues/1335) — BS staging containers + dispatch
- [wiki#81](https://github.com/WXYC/wiki/issues/81) — runbook + bypass-path documentation

Until those land, the workflow exists but no dispatches reach it. Merging the gate now lets phases 3 + 4 author dispatchers against a real workflow file.

## Setup checklist (documented in README under \"Staging gate (bs-lml-gate)\")

1. Fine-grained PATs `PROD_PUSH_TOKEN_BS`, `PROD_PUSH_TOKEN_LML` as repo secrets.
2. Repo variables `BS_STAGING_BASE_URL`, `BS_STAGING_AUTH_URL`, `LML_STAGING_BASE_URL` (placeholder until phases 3, 4 stand up envs).
3. Pinned bypass-tracker issue; `vars.GATE_BYPASS_ISSUE_NUMBER` set to its number.
4. `LML_API_KEY_STAGING` secret (from phase 3).

## Test plan

- [x] `npm run test:bs-lml-gate` — 31/31 bats green
- [x] `npm run lint` — clean
- [x] `npm test` — 460/460 green
- [x] `actionlint .github/workflows/*.yml` — clean
- [x] `shellcheck scripts/bs-lml-gate/*.sh` — clean
- [ ] Post-merge: manual `workflow_dispatch` with `skip_gate: true` against current `main` SHAs, expecting a no-op (since `prod` doesn't exist yet, this will exercise the seed POST path of `push-prod.sh`). Defer until secrets are in place.
- [ ] First real gate pass: end-to-end test once phases 3 + 4 land (covered by wiki#81 runbook).