### PR TITLE
feat(api): add DiscogsReleaseMetadata.not_found tombstone marker (1.12.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.11.0
+  version: 1.12.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3180,6 +3180,24 @@ components:
             uses this to distinguish bulk-loader gaps (which it back-fills)
             from genuinely-imageless releases (which it does not refetch).
             See WXYC/discogs-etl#239 + WXYC/library-metadata-lookup#423.
+        not_found:
+          type: boolean
+          default: false
+          description: |
+            Tombstone marker for Discogs 404s on `get_release`. `true` means
+            LML hit the live Discogs API for this release id and Discogs
+            returned 404; subsequent reads short-circuit on this flag rather
+            than re-burning the rate-limit budget. The tombstone row carries
+            `title = ""` and `artist = ""` as identifier sentinels;
+            consumers must guard against rendering those empty strings as
+            real values. `release_url` is identifier-derived
+            (`https://www.discogs.com/release/{release_id}`) and remains
+            valid even on a tombstone. LML's public boundary translates
+            `not_found = true` back to `None` for direct callers; this flag
+            is observable only by consumers that read the cache row
+            directly (none of which exist in LML's public API today, but
+            the contract is exposed here for future cross-service readers).
+            See WXYC/library-metadata-lookup#510.
         release_url:
           type: string
         cached:


### PR DESCRIPTION
## Summary

- Adds `not_found: boolean (default false)` to `DiscogsReleaseMetadata`. `true` means LML hit Discogs and got a 404 for this release id, so the row is a tombstone — `title = ""` and `artist = ""` are identifier sentinels rather than real values.
- LML's public boundary translates the tombstone back to `None` for direct callers (the `T | None` contract is unchanged for the LML API surface); this flag is exposed in the schema for future cross-service readers (Backend-Service, dj-site, iOS) so they can read the cache row directly without re-deriving the 404 state.
- Bumps `info.version` 1.11.0 → 1.12.0. Additive only — every existing consumer that doesn't read the flag continues to behave exactly as it did pre-1.12.

## Land order

After `WXYC/discogs-etl` ships the alembic migration adding `release.not_found` to the cache schema. Then `WXYC/library-metadata-lookup#510` pins this release and regenerates `generated/api_models.py`.

## Test plan

- [x] `npm run test` — 460 passed (no schema-shape contract regressions).
- [x] `npm run lint` — clean.
- [x] `npm run check:breaking` — no breaking changes.
- [x] `npm run generate:typescript` succeeds.

## Related

- WXYC/library-metadata-lookup#510 — the consumer issue + LML companion PR.
- `release.not_found` schema migration ships in WXYC/discogs-etl.