### PR TITLE
feat(api): cache-refresh-for-identities schemas + path (1.14.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.13.0
+  version: 1.14.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3144,6 +3144,156 @@ components:
           $ref: '#/components/schemas/CacheStats'
 
     # ====================================
+    # Cache refresh for identities (LML#525)
+    # ====================================
+    # `POST /api/v1/cache/refresh-for-identities` is the source-agnostic
+    # cache-warmer that Backend's rotation-artist-backfill cron consumes
+    # (WXYC/Backend-Service#1381). The cron passes `entity.release_identity.id`
+    # values; LML maps each to its per-source `(source, external_id)` pairs
+    # and dispatches the per-source release-cache refresh. After each
+    # refreshed Discogs release, LML walks the release's artist credits and
+    # refreshes the per-artist cache too — applying the LML#525 sentinel
+    # guard at the walk site so VA compilations with `artist_id = 0` don't
+    # leak through. Today only the Discogs leg is wired; other sources
+    # return `release_outcome = "not_implemented"`.
+
+    CacheRefreshSourceOutcome:
+      type: string
+      description: >
+        Per-source release-leg outcome. `success` covers both cache hits and
+        fresh fetches AND tombstones (Discogs 404s — the cache state is
+        still current). `error` is transport / 5xx / parse failure. The
+        leg did not complete. `not_implemented` is for sources whose cache
+        layer doesn't exist yet (discogs_master pre-`MasterRelease.artists`,
+        musicbrainz_release pre-LML#217, etc.). Consumers that need to
+        distinguish "warm-real" from "warm-tombstone" should read the cache
+        row's `not_found` flag directly, not infer from this enum.
+      enum:
+        - success
+        - error
+        - not_implemented
+
+    CacheRefreshItemStatus:
+      type: string
+      description: >
+        Per-identity rollup of the per-source outcomes. Release-leg-gated:
+        any source `success` → `warmed` (artist failures inside a release
+        walk are partial value, not a retry trigger). Only `not_implemented`
+        sources → `not_implemented`. All sources errored → `error`. Row
+        absent in `entity.release_identity` → `not_found` (with `sources`
+        as null). Only `error` is a retry signal.
+      enum:
+        - warmed
+        - not_found
+        - not_implemented
+        - error
+
+    CacheRefreshArtistOutcome:
+      type: object
+      description: >
+        Per-artist outcome inside the walk-to-artists step of a per-source
+        release refresh. `external_id` is string-typed for future
+        source-agnosticism — Discogs IDs serialize as decimal strings.
+      required:
+        - external_id
+        - outcome
+      properties:
+        external_id:
+          type: string
+        outcome:
+          $ref: '#/components/schemas/CacheRefreshSourceOutcome'
+        message:
+          type: string
+          nullable: true
+          description: >
+            Exception class name when `outcome != success`. Bare `str()` of
+            the exception is intentionally NOT serialized — it may carry
+            upstream error bodies, SQL fragments, or file paths. Full
+            traceback lands in Sentry.
+
+    CacheRefreshSourceResult:
+      type: object
+      description: >
+        Per-source outcome for one identity. `artists` is the walk-to-artists
+        fan-out result for the Discogs release leg — empty list on
+        tombstone-success (no artists to walk) and on legs that don't do a
+        walk (every non-Discogs source today).
+      required:
+        - release_outcome
+      properties:
+        release_outcome:
+          $ref: '#/components/schemas/CacheRefreshSourceOutcome'
+        artists:
+          type: array
+          default: []
+          items:
+            $ref: '#/components/schemas/CacheRefreshArtistOutcome'
+        message:
+          type: string
+          nullable: true
+
+    CacheRefreshResultItem:
+      type: object
+      description: >
+        Per-identity verdict. `sources` is null when `status == not_found`
+        (no row to dispatch against). Otherwise it is keyed by source
+        vocabulary (`discogs_release`, `discogs_master`, …); see
+        `RELEASE_SOURCE_COLUMN` on the LML side for the canonical set.
+      required:
+        - identity_id
+        - status
+      properties:
+        identity_id:
+          type: integer
+        status:
+          $ref: '#/components/schemas/CacheRefreshItemStatus'
+        sources:
+          type: object
+          nullable: true
+          additionalProperties:
+            $ref: '#/components/schemas/CacheRefreshSourceResult'
+        message:
+          type: string
+          nullable: true
+
+    BulkCacheRefreshRequest:
+      type: object
+      description: >
+        Request body. The 50-id batch cap is enforced server-side with
+        HTTP 400 on overflow (not 422 — LML's `/api/v1/lookup/bulk`
+        precedent). Downstream callers should encode 50 as a hard
+        constant or assert at startup, not expose it as an env knob —
+        the cap is bounded by Discogs rate-limit × cold-cache fan-out ≤
+        Railway's request-timeout ceiling, and recalibration must land
+        alongside any ingress change. Empty `identity_ids` returns 422
+        (Pydantic `min_length=1`). Duplicate identity_ids are allowed;
+        each runs independently and shows up as a separate result.
+      required:
+        - identity_ids
+      properties:
+        identity_ids:
+          type: array
+          minItems: 1
+          items:
+            type: integer
+      example:
+        identity_ids: [42, 99, 12345]
+
+    BulkCacheRefreshResponse:
+      type: object
+      description: >
+        Per-identity verdicts in input order. No top-level counters —
+        callers derive them via `Counter(r.status for r in results)`,
+        matching the `BulkLookupResultItem` precedent.
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CacheRefreshResultItem'
+
+    # ====================================
     # LML Discogs & Metadata Service Types
     # ====================================
 
@@ -5251,6 +5401,75 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
         '422':
           description: Validation error (per-input field validation failed).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
+  /api/v1/cache/refresh-for-identities:
+    post:
+      summary: Warm LML's cache for a batch of release identity_ids
+      description: >
+        Source-agnostic cache warmer (LML#525). For each `identity_id` in
+        the request, resolves the per-source external IDs via
+        `entity.release_identity` and fans out the per-source release-cache
+        refresh. For each refreshed Discogs release, walks
+        `release.artists[*].artist_id` (skipping `artist_id <= 0` — the LML#525
+        sentinel guard) and refreshes the per-artist cache.
+
+        Multiplexes onto LML's fallthrough seam (LML#503's `fetched_at`
+        discriminator) — won't re-hit Discogs if the cache is already warm.
+        "Refresh" means "ensure freshness," not "bypass cache." A future
+        `force: true` flag could carry true-bypass semantics post-Discogs-
+        reshuffle invalidation.
+
+        Today only the Discogs release leg is wired. `discogs_master`,
+        `musicbrainz_release`, `spotify_album`, `apple_music_album`, and
+        `bandcamp` return `release_outcome = not_implemented`. See LML#525's
+        out-of-scope list for the unblocking dependencies on each.
+      security:
+        - LMLBearerAuth: []
+      tags:
+        - cache
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkCacheRefreshRequest'
+      responses:
+        '200':
+          description: Per-identity verdicts in input order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkCacheRefreshResponse'
+        '400':
+          description: Malformed body or batch above the 50-id cap.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '401':
+          description: Missing or invalid `LML_API_KEY` bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '422':
+          description: Empty `identity_ids` (Pydantic min_length=1).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '499':
+          description: Client closed connection before the batch finished.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Entity store or Discogs service not available.
           content:
             application/json:
               schema:

--- a/api.yaml
+++ b/api.yaml
@@ -3292,6 +3292,34 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CacheRefreshResultItem'
+      example:
+        results:
+          - identity_id: 42
+            status: warmed
+            sources:
+              discogs_release:
+                release_outcome: success
+                artists:
+                  - external_id: "999"
+                    outcome: success
+                  - external_id: "1001"
+                    outcome: success
+          - identity_id: 99
+            status: not_found
+            sources: null
+          - identity_id: 12345
+            status: not_implemented
+            sources:
+              discogs_master:
+                release_outcome: not_implemented
+                artists: []
+          - identity_id: 7
+            status: error
+            sources:
+              discogs_release:
+                release_outcome: error
+                artists: []
+                message: ConnectError
 
     # ====================================
     # LML Discogs & Metadata Service Types

--- a/api.yaml
+++ b/api.yaml
@@ -3277,7 +3277,7 @@ components:
           items:
             type: integer
       example:
-        identity_ids: [42, 99, 12345]
+        identity_ids: [42, 99, 12345, 7]
 
     BulkCacheRefreshResponse:
       type: object


### PR DESCRIPTION
## Summary

Codifies the API contract for `POST /api/v1/cache/refresh-for-identities` — the LML#525 source-agnostic cache-warmer that Backend-Service's rotation-artist-backfill cron consumes via WXYC/Backend-Service#1381.

Implementation already shipped to LML's `main` in three stacked PRs:

- WXYC/library-metadata-lookup#557 — concurrency primitives hoist
- WXYC/library-metadata-lookup#558 — `EntityStore.get_release_identity_provenance_bulk`
- WXYC/library-metadata-lookup#559 — the endpoint itself

The LML side ships internal Pydantic models in `cache/models.py` that match this schema exactly. This PR codifies the contract so BS-side codegen (and any other consumer) can track the response shape directly rather than reading it out of LML's source.

## What's added

**5 component schemas + 1 request + 1 response:**

- `CacheRefreshSourceOutcome` — enum (`success | error | not_implemented`). Tombstones (Discogs 404 → fallthrough seam returns None) count as `success` because the cache state is current.
- `CacheRefreshItemStatus` — per-id rollup enum (`warmed | not_found | not_implemented | error`). Release-leg-gated: artist failures inside a release walk don't promote per-id to `error`.
- `CacheRefreshArtistOutcome` — per-artist outcome inside the walk-to-artists step. `external_id` is string-typed for future source-agnosticism.
- `CacheRefreshSourceResult` — per-source outcome including the artists list from the walk-to-artists step.
- `CacheRefreshResultItem` — per-id verdict. `sources` is null when `status == not_found`.
- `BulkCacheRefreshRequest` — `identity_ids: list[int]`, `minItems: 1`. The 50-id batch cap is enforced server-side with HTTP 400 (LML's `/api/v1/lookup/bulk` precedent — not 422). The cap is documented inline as a hard contract, not an env knob.
- `BulkCacheRefreshResponse` — per-identity verdicts in input order. No top-level counters — callers derive them via `Counter(r.status for r in results)`.

**1 new path:**

- `POST /api/v1/cache/refresh-for-identities` — secured by `LMLBearerAuth`, tag `cache`, full 200/400/401/422/499/503 response set documented.

## Compatibility

Additive only — no existing schemas or paths change. Bumps minor to **1.14.0**.

## Lint

Same error count as baseline `origin/main` (10 errors — all pre-existing `nullable-type-sibling` / `security-defined` patterns in unrelated schemas). Adds one `operation-operationId` warning consistent with every other endpoint in the file.

## Test plan

- [x] YAML parse (`python3 -c "import yaml; yaml.safe_load(open('api.yaml'))"`) clean
- [x] Redocly lint diff against baseline — no new errors
- [ ] CI

Closes WXYC/library-metadata-lookup#525 contract-side.