### PR TITLE
feat(api): add apple_music_album to ReleaseIdentitySource enum

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2933,6 +2933,7 @@ components:
         - discogs_release
         - discogs_master
         - bandcamp
+        - apple_music_album
 
     ReleaseIdentityResolveRequest:
       type: object
@@ -2961,7 +2962,9 @@ components:
             URL-canonicalises before mint so trailing-slash and
             equivalent variants converge on one identity row. Non-album
             Bandcamp URLs (track URLs, bare subdomain) are rejected with
-            422.
+            422. For `apple_music_album` it is the numeric Apple Music
+            album ID as a string (e.g. `1234567890`); zero, negative,
+            and non-numeric values are rejected with 422.
       example:
         kind: release
         source: discogs_release


### PR DESCRIPTION
Closes #179.

## Summary

Adds ``apple_music_album`` to the ``ReleaseIdentitySource`` enum in ``api.yaml`` and extends the ``external_id`` field description to document the Apple Music shape (positive decimal integer string; zero/negative/non-numeric rejected with 422).

This unblocks the public ``POST /api/v1/identity/resolve`` endpoint in LML for ``source=apple_music_album``. The internal mint path already works (LML#572 wired it through ``identity/release_validation``); this completes the public surface.

## Diff

```diff
@@ -2933,6 +2933,7 @@ components:
         - discogs_release
         - discogs_master
         - bandcamp
+        - apple_music_album
@@ -2961,7 +2962,9 @@ components:
             URL-canonicalises before mint so trailing-slash and
             equivalent variants converge on one identity row. Non-album
             Bandcamp URLs (track URLs, bare subdomain) are rejected with
-            422.
+            422. For ``apple_music_album`` it is the numeric Apple Music
+            album ID as a string (e.g. ``1234567890``); zero, negative,
+            and non-numeric values are rejected with 422.
```

4 additions, 1 deletion to ``api.yaml``. Additive — non-breaking for existing clients.

## Test plan

- [x] ``oasdiff`` confirms no breaking changes (CI gate).
- [ ] Downstream codegen refreshes:
  - ``WXYC/library-metadata-lookup`` — ``scripts/generate_api_models.sh`` produces the new enum value in ``generated/api_models.py``. After merge here + bump, LML cleans up the ``_INTERNAL_ONLY_SOURCES`` allow-list and the deferral notes (drift invariant at ``tests/unit/test_release_validation.py::test_release_source_column_keys_match_pydantic_enum`` will fail until that cleanup lands).
  - ``WXYC/Backend-Service``, ``WXYC/dj-site``, ``WXYC/wxyc-ios-64``, ``WXYC/WXYC-Android`` — none of these mint identities today via the public endpoint, but each consumer's codegen check will still need to regenerate.

## Related

- WXYC/library-metadata-lookup#572 (LML-side wiring — merged via PR WXYC/library-metadata-lookup#580)
- WXYC/library-metadata-lookup#570 (parent feature — persistent Apple Music URL cache + post-process)