### PR TITLE
feat(api): add genres/styles to FlowsheetV2TrackEntry

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -684,6 +684,18 @@ components:
               description: Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.
             metadata_status:
               $ref: '#/components/schemas/MetadataStatus'
+            genres:
+              type: array
+              nullable: true
+              items:
+                type: string
+              description: Discogs genre tags surfaced on the Playcut Detail card.
+            styles:
+              type: array
+              nullable: true
+              items:
+                type: string
+              description: Discogs style tags (finer-grained than genres).
 
     FlowsheetV2ShowStartEntry:
       description: V2 show start event - when a show begins


### PR DESCRIPTION
## What

Adds `genres` and `styles` (nullable arrays of strings) to the `FlowsheetV2TrackEntry` schema in `api.yaml`, so the V2 flowsheet payload can carry Discogs genre/style tags inline. This is the contract leading edge of a chain that restores genre/style capsules on the iOS Playcut Detail card without an extra metadata round-trip.

## Why

Genre/style tags only ever lived on the live LML/proxy response; the cache-first `album_metadata` read path sheds them on cache-hit, and the iOS detail view short-circuits past the proxy when streaming is inline. Carrying them inline in the flowsheet is the durable fix. The contract has to declare the fields before the backend (WXYC/Backend-Service#1441) projects them and iOS (WXYC/wxyc-ios-64#402) decodes them.

## Changes

- `api.yaml` — `FlowsheetV2TrackEntry` gains `genres`/`styles`, matching the existing `DiscogsMatchResult` array-of-string style (`nullable: true`, block-form `items:`).

Generated artifacts are gitignored in this repo (regenerated, never tracked), so only `api.yaml` is committed. Consumers regenerate on their next `@wxyc/shared` bump.

## Verification

- `npm run generate` — all four generators (TS/Python/Swift/Kotlin) ran clean; the regenerated flowsheet track entry carries `genres?: string[] | null` / `styles?: string[] | null`.
- `npm run check:breaking` — **no breaking changes** (purely additive optional fields).

## Related

- Closes #181
- WXYC/Backend-Service#1336 — foundation: persists genres/styles on `album_metadata`.
- WXYC/Backend-Service#1441 — consumes this contract (projects the fields into the V2 flowsheet response).
- WXYC/wxyc-ios-64#402 — decodes the inline fields and renders capsules.
