### PR TITLE
feat(api): add radio_hour to FlowsheetV2BreakpointEntry

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -791,6 +791,18 @@ components:
             entry_type:
               type: string
               enum: [breakpoint]
+            radio_hour:
+              type: string
+              format: date-time
+              nullable: true
+              description: >-
+                Exact top-of-hour this breakpoint marks (ISO 8601), sourced from
+                tubafrenzy's RADIO_HOUR. Distinct from `add_time`, which is the
+                row's logging instant (~1 min before the hour). Optional and
+                nullable: absent on servers predating the producer rollout, null
+                for breakpoint rows not yet backfilled. Clients use `radio_hour`
+                for the hour-marker label when present and fall back to `add_time`
+                otherwise.
             message:
               type: string
               nullable: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -212,8 +212,11 @@ export const testV2TalksetEntry: FlowsheetV2TalksetEntry = {
 export const testV2BreakpointEntry: FlowsheetV2BreakpointEntry = {
   id: 106,
   show_id: 1,
+  // add_time is the logging instant (~1 min before the hour); radio_hour is the
+  // exact top-of-hour the breakpoint marks — the field clients read for the label.
   play_order: 100,
-  add_time: testV2AddTime,
+  add_time: '2024-06-15T14:58:42.000Z',
+  radio_hour: '2024-06-15T15:00:00.000Z',
   entry_type: 'breakpoint',
   message: 'Breakpoint - 3:00 PM',
 };


### PR DESCRIPTION
## What

Adds a required `radio_hour` (ISO 8601 `date-time`) to the `FlowsheetV2BreakpointEntry` variant in `api.yaml`, carrying the exact top-of-hour a breakpoint marks (sourced from tubafrenzy's `RADIO_HOUR`).

## Why

A breakpoint's `add_time` is the row's *logging instant* — ~1 minute before the top of the hour. Clients that derive the hour-marker chip from `add_time` and format `"h a"` floor it back across the boundary and render the hour **one early** (e.g. a breakpoint marking 12:00 PM is logged at 11:58 → "11 AM"). The authoritative hour was being dropped by the service; this field carries it through so clients read `radio_hour` for the label instead of guessing/rounding.

Only the breakpoint variant changes (idiomatic for the `oneOf` + `discriminator: entry_type` union — parallel to how `message` is variant-specific). `radio_hour` is **not** added to `FlowsheetV2Base`.

## Changes

- `api.yaml`: `radio_hour` (date-time) added + required on `FlowsheetV2BreakpointEntry`.
- `src/test-utils/fixtures.ts`: `testV2BreakpointEntry` sets `radio_hour` (top-of-hour) and an `add_time` ~1 min prior, to model the real distinction.
- Version bump 1.11.0 → 1.12.0.
- Generated types (`src/generated/**`, gitignored) verified locally to include `radio_hour: string`.

## Verification

- `npm run lint` (tsc), `npm run test` (vitest, 460 pass), `npm run build` (tsup), `npm run check:breaking` (no breaking changes) all pass locally.
- Additive, response-only field → non-breaking for external consumers (breakpoints are never client-constructed).

Closes #183
Parent epic: WXYC/Backend-Service#1447