### PR TITLE
feat: add GET /library/catalog + CatalogExportRow to the api.yaml SSOT

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1127,6 +1127,91 @@ components:
             artist/album hits. Backward-compatible — existing consumers
             ignore the field.
 
+    CatalogExportRow:
+      type: object
+      description: >
+        One row of the WXYC library catalog as served by GET /library/catalog
+        for offline cloning (BS#1468, Epic F #1466). A query-independent snapshot
+        of the core catalog row. Deliberately NOT AlbumSearchResult: it drops the
+        search-only decoration (matched_via, matched_via_alias, album_dist,
+        artist_dist) and the fields the export omits (add_date, label_id,
+        rotation_id, album_artist, date_lost, date_found), and instead ships
+        rotation RAW (rotation_bin + rotation_kill_date) so the client evaluates
+        rotation expiry against its own clock. See the rotation_bin description
+        for the load-bearing semantic difference from AlbumSearchResult.
+      required:
+        - id
+        - artist_name
+        - album_title
+        - code_letters
+        - code_number
+        - code_artist_number
+        - genre_name
+        - format_name
+      properties:
+        id:
+          type: integer
+        artist_name:
+          type: string
+          description: >
+            Authoritative artist name. The server COALESCEs the denormalized
+            library.artist_name to artists.artist_name (NOT NULL), so this never
+            ships as null even before the denormalization backfill completes.
+        album_title:
+          type: string
+        code_letters:
+          type: string
+          description: Shelf call-number letters (e.g. "AU").
+        code_number:
+          type: integer
+          description: Shelf call-number release number.
+        code_artist_number:
+          type: integer
+          description: Shelf call-number artist number (genre-scoped).
+        label:
+          type: string
+          nullable: true
+        genre_name:
+          type: string
+        format_name:
+          type: string
+        on_streaming:
+          type: boolean
+          nullable: true
+          description: True if on >=1 streaming service; false if physical-only; null if unknown.
+        plays:
+          type: integer
+          nullable: true
+        artwork_url:
+          type: string
+          nullable: true
+          description: Album cover URL from Discogs; null if not yet fetched.
+        rotation_bin:
+          type: string
+          nullable: true
+          description: >
+            RAW current-rotation bin — the most-recently-ADDED rotation record
+            for this album — NOT the CURRENT_DATE-filtered value AlbumSearchResult
+            returns. Nominal values are H/M/L/S (see RotationBin) but it is typed
+            as a free string, NOT the RotationBin enum, so a value outside those
+            cohorts (e.g. 'N', a current server-enum member — NOT legacy) cannot
+            break a strict-enum decoder. Evaluate live rotation
+            client-side together with rotation_kill_date:
+              in rotation  ==  rotation_bin != null
+                              AND (rotation_kill_date == null
+                                   OR rotation_kill_date > today-in-client-tz)
+            The daily kill-date expiry is a clock event no DB trigger can observe,
+            which is why this endpoint ships raw and defers expiry to the client.
+        rotation_kill_date:
+          type: string
+          format: date
+          nullable: true
+          description: >
+            Date (YYYY-MM-DD; server ::text cast) the current rotation record
+            expires, or null if it has none. Used with rotation_bin to evaluate
+            live rotation client-side. Absent from AlbumSearchResult — a client
+            that reuses AlbumSearchResult for this endpoint silently loses it.
+
     AddAlbumRequest:
       type: object
       required:
@@ -4704,7 +4789,9 @@ paths:
   /library:
     get:
       summary: Search for album
-      security: []
+      # routes enforce requirePermissions({ catalog: ['read'] }) (library.route.ts)
+      security:
+        - BearerAuth: []
       parameters:
         - name: artist_name
           in: query
@@ -4759,7 +4846,9 @@ paths:
         with exact-match via double quotes). Combines parsed conditions with
         optional catalog filters (`on_streaming`, `genre`, `format`) via `AND`.
         Returns a paginated envelope.
-      security: []
+      # routes enforce requirePermissions({ catalog: ['read'] }) (library.route.ts)
+      security:
+        - BearerAuth: []
       parameters:
         - name: q
           in: query
@@ -4828,10 +4917,76 @@ paths:
               schema:
                 $ref: '#/components/schemas/LibraryQueryResponse'
 
+  /library/catalog:
+    get:
+      summary: Bulk catalog export for offline cloning (gzipped NDJSON)
+      description: |
+        Stream the entire WXYC library catalog as one gzipped, newline-delimited
+        JSON (NDJSON) body — one CatalogExportRow per line — so a client (the
+        iOS Spotlight clone; BS#1468 / Epic F #1466) can mirror the catalog
+        on-device in a single request instead of paging /library/query.
+
+        Conditional GET: the response carries Last-Modified, set from the
+        library_watermark (advanced by a DB statement trigger, so the discogs-etl
+        daily sync moves it too). The client echoes it back via If-Modified-Since
+        (or ?since=) and gets a cheap 304 until the catalog actually changes
+        (~daily); otherwise a 200 with the full body. Same conditionalGet
+        middleware as the flowsheet export (BS#902).
+
+        Transport (not expressible in the element schema): the body is NDJSON —
+        split on newlines and decode per line; it is NOT a JSON array. It is
+        gzip-encoded (Content-Encoding: gzip; most HTTP clients, incl. URLSession,
+        decompress transparently). See catalog-export.service.ts
+        (serializeCatalogNdjson).
+      security:
+        - BearerAuth: []   # routes enforce requirePermissions({ catalog: ['read'] })
+      parameters:
+        - name: If-Modified-Since
+          in: header
+          required: false
+          schema:
+            type: string
+          description: >
+            HTTP-date previously returned in Last-Modified. Yields 304 if the
+            catalog has not changed since. Echo the server's string verbatim; do
+            not round-trip it through a local date type.
+        - name: since
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Header-free alternative to If-Modified-Since (same semantics).
+      responses:
+        '200':
+          description: Full catalog as gzipped NDJSON (one CatalogExportRow per line).
+          headers:
+            Last-Modified:
+              schema:
+                type: string
+              description: Catalog watermark as an HTTP-date; echo back as If-Modified-Since.
+            Content-Encoding:
+              schema:
+                type: string
+              description: '"gzip" on the gzip-accepting path.'
+          content:
+            application/x-ndjson:
+              # NOTE: the body is newline-delimited CatalogExportRow objects (one
+              # per line), NOT a single object or a JSON array. OpenAPI can't
+              # model NDJSON framing; this schema describes ONE line. See the
+              # path description.
+              schema:
+                $ref: '#/components/schemas/CatalogExportRow'
+        '304':
+          description: >
+            Not Modified — catalog unchanged since the client's
+            If-Modified-Since / since watermark. No body.
+
   /library/rotation:
     get:
       summary: Get rotation list
-      security: []
+      # routes enforce requirePermissions({ catalog: ['read'] }) (library.route.ts)
+      security:
+        - BearerAuth: []
       responses:
         '200':
           description: List of rotations

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -292,6 +292,128 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  // GET /library/catalog (the gzipped-NDJSON bulk export) and its row shape
+  // shipped in Backend-Service#1468 (Epic F, parent #1466) but were never
+  // propagated to this cross-repo SSOT — only to BS's local Swagger-only
+  // app.yaml. These tests pin the reconciliation: the export row is its own
+  // schema (NOT a superset of AlbumSearchResult), rotation is raw, and all four
+  // catalog GET reads share the `catalog:read` auth the routes enforce.
+  describe('Catalog Export (BS#1468 / Epic F #1466)', () => {
+    type Schema = {
+      required?: string[];
+      properties?: Record<string, Record<string, unknown>>;
+      allOf?: unknown;
+    };
+
+    // The 14-field projection: catalog-export.service.ts:33-48 (CatalogExportRow).
+    const EXPORT_FIELDS = [
+      'id',
+      'artist_name',
+      'album_title',
+      'code_letters',
+      'code_number',
+      'code_artist_number',
+      'label',
+      'genre_name',
+      'format_name',
+      'on_streaming',
+      'plays',
+      'artwork_url',
+      'rotation_bin',
+      'rotation_kill_date',
+    ];
+
+    it('defines CatalogExportRow with exactly the 14 shipped fields', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+      expect(schema).toBeDefined();
+      expect(Object.keys(schema.properties ?? {}).sort()).toEqual([...EXPORT_FIELDS].sort());
+    });
+
+    it('marks the 8 non-null fields required (deliberate leniency: the nullable keys are omitted)', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+      expect((schema.required ?? []).sort()).toEqual(
+        [
+          'id',
+          'artist_name',
+          'album_title',
+          'code_letters',
+          'code_number',
+          'code_artist_number',
+          'genre_name',
+          'format_name',
+        ].sort()
+      );
+    });
+
+    it('types rotation_bin as a raw nullable string, NOT the RotationBin enum (admits N; decision 1)', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+      const rotationBin = schema.properties?.rotation_bin;
+      expect(rotationBin).toBeDefined();
+      expect(rotationBin!.type).toBe('string');
+      expect(rotationBin!.nullable).toBe(true);
+      // A $ref to RotationBin ([H,M,L,S]) would make a strict decoder reject 'N'.
+      expect(rotationBin!.$ref).toBeUndefined();
+    });
+
+    it('ships rotation_kill_date as a nullable date, and keeps it off AlbumSearchResult (decision 2)', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+      const killDate = schema.properties?.rotation_kill_date;
+      expect(killDate).toBeDefined();
+      expect(killDate!.type).toBe('string');
+      expect(killDate!.format).toBe('date');
+      expect(killDate!.nullable).toBe(true);
+
+      const search = spec.components.schemas.AlbumSearchResult as Schema;
+      expect(search.properties?.rotation_kill_date).toBeUndefined();
+    });
+
+    it('keeps CatalogExportRow a distinct flat schema, not a superset of AlbumSearchResult (decision 3)', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+      expect(schema.allOf).toBeUndefined();
+      // It drops the search-only decoration AlbumSearchResult carries.
+      for (const searchOnly of ['add_date', 'matched_via', 'matched_via_alias', 'album_dist', 'artist_dist']) {
+        expect(schema.properties?.[searchOnly]).toBeUndefined();
+      }
+    });
+
+    it('declares GET /library/catalog (BearerAuth; If-Modified-Since + ?since=; NDJSON 200 + 304)', () => {
+      const path = spec.paths['/library/catalog'] as {
+        get?: {
+          security?: Array<Record<string, unknown[]>>;
+          parameters?: Array<{ name: string; in: string }>;
+          responses?: Record<
+            string,
+            { headers?: Record<string, unknown>; content?: Record<string, { schema?: { $ref?: string } }> }
+          >;
+        };
+      };
+      expect(path?.get).toBeDefined();
+      expect(path.get!.security).toEqual([{ BearerAuth: [] }]);
+
+      const ifModifiedSince = path.get!.parameters?.find((p) => p.name === 'If-Modified-Since');
+      expect(ifModifiedSince?.in).toBe('header');
+      const since = path.get!.parameters?.find((p) => p.name === 'since');
+      expect(since?.in).toBe('query');
+
+      const ok = path.get!.responses?.['200'];
+      expect(ok).toBeDefined();
+      // One NDJSON line is one CatalogExportRow (the framing itself isn't expressible in OpenAPI).
+      expect(ok!.content?.['application/x-ndjson']?.schema?.$ref).toBe('#/components/schemas/CatalogExportRow');
+      expect(ok!.headers?.['Last-Modified']).toBeDefined();
+      expect(ok!.headers?.['Content-Encoding']).toBeDefined();
+      expect(path.get!.responses?.['304']).toBeDefined();
+    });
+
+    it('requires BearerAuth on all four catalog GET reads — no half-fixed SSOT (decision 4)', () => {
+      const reads = ['/library', '/library/query', '/library/rotation', '/library/catalog'];
+      for (const route of reads) {
+        const path = spec.paths[route] as { get?: { security?: unknown[] } };
+        expect(path?.get, route).toBeDefined();
+        expect(path!.get!.security, route).toEqual([{ BearerAuth: [] }]);
+      }
+    });
+  });
+
   describe('Rotation Schemas', () => {
     it('should define RotationEntry', () => {
       expect(spec.components.schemas.RotationEntry).toBeDefined();

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -351,8 +351,10 @@ describe('OpenAPI Specification', () => {
       expect(rotationBin).toBeDefined();
       expect(rotationBin!.type).toBe('string');
       expect(rotationBin!.nullable).toBe(true);
-      // A $ref to RotationBin ([H,M,L,S]) would make a strict decoder reject 'N'.
+      // Either a $ref to RotationBin ([H,M,L,S]) OR an inline enum would make a
+      // strict decoder reject 'N' — both forms must stay off rotation_bin.
       expect(rotationBin!.$ref).toBeUndefined();
+      expect(rotationBin!.enum).toBeUndefined();
     });
 
     it('ships rotation_kill_date as a nullable date, and keeps it off AlbumSearchResult (decision 2)', () => {


### PR DESCRIPTION
Closes #186.

Reconciles the shipped `GET /library/catalog` bulk-export wire shape (`Backend-Service#1468`, Epic F `#1466`) into the cross-repo SSOT (`api.yaml`) that feeds iOS / Kotlin / dj-site codegen. The endpoint and its row shape previously lived only in Backend-Service's local Swagger-only `app.yaml`, so consumers that mirror the SSOT had nothing to generate from — and the two specs drifted on rotation. Unblocks `WXYC/wxyc-dj-ios#19`.

## What changed

- **`CatalogExportRow` schema** — the 14-field projection from [`catalog-export.service.ts:33-48`](https://github.com/WXYC/Backend-Service/blob/main/apps/backend/services/catalog-export.service.ts#L33), added near `AlbumSearchResult`. A **distinct flat schema**, not a superset, so a consumer knows from the type alone whether rotation is `CURRENT_DATE`-filtered (search) or raw (export).
- **`GET /library/catalog` path** — `BearerAuth`; `If-Modified-Since` header + `?since=` conditional-GET; `200` (gzipped NDJSON with `Last-Modified` + `Content-Encoding`) and `304`; plus the NDJSON-is-not-a-JSON-array transport note.
- **Security drift fix (decision 4)** — the three existing catalog GET reads (`/library`, `/library/query`, `/library/rotation`) flipped from `security: []` to `BearerAuth`, so the SSOT isn't left half-fixed. All four routes enforce `requirePermissions({ catalog: ['read'] })` ([`library.route.ts`](https://github.com/WXYC/Backend-Service/blob/main/apps/backend/routes/library.route.ts)).

## Decisions ratified

1. **`rotation_bin` raw nullable string**, not the `RotationBin` `[H,M,L,S]` enum — the export ships rotation raw, and `N` is a current server-enum member, so a strict `[H,M,L,S]` decoder must not reject it.
2. **`rotation_kill_date` export-only** — not added to `AlbumSearchResult` (search is already server-side `CURRENT_DATE`-filtered).
3. **Two flat schemas** (no shared `allOf` base) — keeps `AlbumSearchResult`'s generated output bit-identical (verified) rather than risk a codegen change.
5. **Out of scope here.** `AlbumSearchResult` is untouched; the `N`-safety fix for the live read surfaces is the ratified fast-follow in #191 (blocked-by this PR).

## Verification

- New TDD tests in `tests/api-spec.test.ts` pin the schema fields, the raw-string `rotation_bin`, the export-only `rotation_kill_date`, the distinct-schema shape, the full `/library/catalog` path contract, and `BearerAuth` on all four catalog GET reads.
- Local checks all green: `generate:typescript`, `build` (ESM + DTS), `lint`, `npm test` (467 passing), `check:breaking` (no breaking changes). Regenerated `CatalogExportRow` TS matches the shipped `catalog-export.service.ts` type field-for-field; `AlbumSearchResult` generated output is unchanged.

## Follow-ups (Backend-Service, out of scope here)

- **G1** — TS↔SSOT parity test for `CatalogExportRow`.
- **G3** — "new endpoint ⇒ `api.yaml` schema first" rule in BS's PR checklist.
- **G4** — retire/realign BS's `app.yaml` `CatalogExportRow` duplicate.
