### PR TITLE
feat(api): surface Discogs master_id on DiscogsMatchResult + DiscogsReleaseMetadata

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2375,6 +2375,17 @@ components:
             Discogs release ID. `> 0` is a real release identity; `0` is the
             streaming-only sentinel (paired with `release_url == ""`, BS#1185)
             and is not a linkable Discogs release.
+        master_id:
+          type: integer
+          nullable: true
+          description: >
+            Discogs master ID for the release, when the release belongs to a
+            master. `null` when Discogs has no master for this release
+            (one-offs, self-released) or for the streaming-only sentinel
+            (`release_id == 0`). Lets a caller collapse multiple
+            pressings/formats of one logical album into a single record keyed
+            on the master. Populated from the resolved release's
+            `master_id` field on `/lookup` (single and bulk).
         release_url:
           type: string
           description: >
@@ -3565,6 +3576,14 @@ components:
       properties:
         release_id:
           type: integer
+        master_id:
+          type: integer
+          nullable: true
+          description: >
+            Discogs master ID for this release, when the release belongs to a
+            master. `null` when Discogs has no master (one-offs,
+            self-released). Lets a caller collapse multiple pressings/formats
+            of one logical album into a single record keyed on the master.
         title:
           type: string
         artist:

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -764,6 +764,40 @@ describe('OpenAPI Specification', () => {
         '#/components/schemas/DiscogsResolvedToken',
       );
     });
+
+    it('should attach master_id to DiscogsMatchResult as an optional nullable integer', () => {
+      // Phase-2 catalog popularity (WXYC/Backend-Service#1486, WXYC/library-metadata-lookup#688):
+      // the release's Discogs master id, so a caller can collapse multiple
+      // pressings/formats of one logical album into a single record keyed on
+      // the master. Optional + nullable so the additive contract doesn't break
+      // existing LML/BS/iOS/Android consumers; null when Discogs has no master.
+      const schema = spec.components.schemas.DiscogsMatchResult as {
+        properties: Record<string, SchemaProp>;
+        required?: string[];
+      };
+
+      const prop = schema.properties.master_id;
+      expect(prop).toBeDefined();
+      expect(prop.type).toBe('integer');
+      expect(prop.nullable).toBe(true);
+      expect(schema.required ?? []).not.toContain('master_id');
+    });
+
+    it('should attach master_id to DiscogsReleaseMetadata as an optional nullable integer', () => {
+      // Same Phase-2 master-collapse signal on the full release-metadata schema
+      // (WXYC/library-metadata-lookup#688). Optional + nullable; null when Discogs
+      // has no master for the release.
+      const schema = spec.components.schemas.DiscogsReleaseMetadata as {
+        properties: Record<string, SchemaProp>;
+        required?: string[];
+      };
+
+      const prop = schema.properties.master_id;
+      expect(prop).toBeDefined();
+      expect(prop.type).toBe('integer');
+      expect(prop.nullable).toBe(true);
+      expect(schema.required ?? []).not.toContain('master_id');
+    });
   });
 
   describe('Lookup Hard Cap (LML#370)', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -786,4 +786,38 @@ describe('Generated TypeScript Types', () => {
       expect(nulled.profile_tokens).toBeNull();
     });
   });
+
+  describe('DiscogsMatchResult master_id (Phase-2 catalog popularity, LML#688)', () => {
+    // Pin the consumer-facing contract: master_id is optional + nullable, so a
+    // caller can collapse pressings/formats of one logical album by the
+    // Discogs master id. WXYC/Backend-Service#1486.
+    it('accepts a result with master_id populated', () => {
+      const withMaster: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        master_id: 67890,
+      };
+
+      expect(withMaster.master_id).toBe(67890);
+    });
+
+    it('accepts a result with master_id null (release has no master)', () => {
+      const noMaster: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        master_id: null,
+      };
+
+      expect(noMaster.master_id).toBeNull();
+    });
+
+    it('accepts a result that omits master_id entirely', () => {
+      const baseline: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+      };
+
+      expect(baseline.master_id).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds a nullable `master_id: integer` field to `DiscogsMatchResult` and `DiscogsReleaseMetadata` in `api.yaml`, the cross-repo OpenAPI SSOT. This is the contract half of Phase-2 Track 0: surfacing the Discogs master id so a caller can collapse multiple pressings/formats of one logical album into a single record keyed on the master.

## Why

WXYC/Backend-Service#1486 (attribution-corrected catalog popularity) needs a master-level "logical album" key. `DiscogsMatchResult` already carries `release_id`, but a release is per-pressing — two pressings of the same album get distinct ids. The master id is the missing collapse key. WXYC/library-metadata-lookup#688 reads this field's value out of the resolved Discogs release and threads it onto every `/lookup` result (single and bulk).

## Scope

`api.yaml` (+ the two parity tests that guard it). No codegen is vendored here — each consumer regenerates from this spec.

## Merge ordering

Merge this first. WXYC/library-metadata-lookup#688's committed `generated/api_models.py` is the regeneration of this spec; its codegen-drift CI check runs against this repo's `main`, so it stays red until `master_id` is present here.

## Related

- Consumer: WXYC/library-metadata-lookup#688
- Epic: WXYC/Backend-Service#1486
