### PR TITLE
feat(#195): add /auth/device/* (RFC 8628 device-authorization) to api.yaml

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1903,6 +1903,259 @@ components:
           type: string
           format: date-time
 
+    # ===================
+    # Device Authorization (RFC 8628) — issue #195
+    # Mirrors the better-auth device-authorization plugin (1.6.20 — the version
+    # WXYC's auth-service runs, per Backend-Service#1495) PLUS WXYC's BS hooks.
+    # Wire shapes verified against
+    # node_modules/better-auth/dist/plugins/device-authorization/routes.mjs.
+    # Error enums mirror RUNTIME behavior (a superset of the plugin's declared
+    # zod enums). Casing is intentionally asymmetric: code/token/verify use
+    # snake_case; approve/deny request bodies use camelCase `userCode`.
+    # ===================
+
+    DeviceAuthCodeRequest:
+      type: object
+      required:
+        - client_id
+      properties:
+        client_id:
+          type: string
+          description: The client ID of the application requesting authorization.
+        scope:
+          type: string
+          description: Optional space-separated list of OAuth scopes.
+        user_id:
+          type: string
+          description: >
+            Optional. The user ID to which the device code should be pre-bound
+            (a better-auth 1.6.20+ plugin field). WXYC's shared-computer QR flow
+            does not send this — the DJ is identified later at
+            /auth/device/approve — but it is mirrored here for runtime fidelity.
+
+    DeviceAuthCodeResponse:
+      type: object
+      required:
+        - device_code
+        - user_code
+        - verification_uri
+        - verification_uri_complete
+        - expires_in
+        - interval
+      properties:
+        device_code:
+          type: string
+          description: The device verification code, polled at /auth/device/token.
+        user_code:
+          type: string
+          description: The short code shown to the user / encoded in the QR.
+        verification_uri:
+          type: string
+          format: uri
+          description: URL where the user verifies the code.
+        verification_uri_complete:
+          type: string
+          format: uri
+          description: verification_uri with user_code pre-filled as a query parameter.
+        expires_in:
+          type: integer
+          description: 'Lifetime of the device/user code in seconds (WXYC config: 300 = 5min).'
+        interval:
+          type: integer
+          description: 'Minimum polling interval in seconds (WXYC config: 5).'
+
+    DeviceAuthTokenRequest:
+      type: object
+      required:
+        - grant_type
+        - device_code
+        - client_id
+      properties:
+        grant_type:
+          type: string
+          enum:
+            - 'urn:ietf:params:oauth:grant-type:device_code'
+          description: RFC 8628 device-flow grant type (fixed value).
+        device_code:
+          type: string
+          description: The device_code returned by /auth/device/code.
+        client_id:
+          type: string
+          description: The client ID of the application.
+
+    DeviceAuthTokenResponse:
+      type: object
+      required:
+        - access_token
+        - token_type
+        - expires_in
+        - scope
+      properties:
+        access_token:
+          type: string
+          description: The session bearer token for the browser.
+        token_type:
+          type: string
+          enum:
+            - Bearer
+        expires_in:
+          type: integer
+          description: >
+            Token lifetime in seconds. WXYC's auth-service (Backend-Service#1495,
+            hooks.after on /device/token) rewrites the plugin's session-derived
+            value to a fixed 43200 (12h). The vanilla-plugin value would otherwise
+            be the global ~7-day session TTL.
+        scope:
+          type: string
+          description: Granted scopes (empty string when none were requested).
+
+    DeviceAuthStatus:
+      type: string
+      description: Current status of a device authorization (GET /auth/device).
+      enum:
+        - pending
+        - approved
+        - denied
+
+    DeviceAuthVerifyResponse:
+      type: object
+      required:
+        - user_code
+        - status
+      properties:
+        user_code:
+          type: string
+        status:
+          $ref: '#/components/schemas/DeviceAuthStatus'
+
+    DeviceAuthApproveRequest:
+      type: object
+      required:
+        - userCode
+      properties:
+        userCode:
+          type: string
+          description: >
+            The user code to approve. NOTE: camelCase on the wire — the plugin's
+            approve/deny bodies differ from the snake_case code/token bodies.
+
+    DeviceAuthDenyRequest:
+      type: object
+      required:
+        - userCode
+      properties:
+        userCode:
+          type: string
+          description: >
+            The user code to deny. NOTE: camelCase on the wire (see
+            DeviceAuthApproveRequest).
+
+    DeviceAuthActionResponse:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+          description: Always true on success. Shared by /approve and /deny.
+
+    # --- Per-endpoint error envelopes. The shape { error, error_description } is
+    # --- modeled once per endpoint; the `error` enum is constrained per path to
+    # --- the RUNTIME superset — it includes codes the plugin emits but omits from
+    # --- its declared zod (server_error, expired_token) and excludes a declared-
+    # --- but-never-emitted code (device_code_already_processed). One enum per
+    # --- endpoint, listing every code it can emit across all its HTTP statuses,
+    # --- so a polling client switches over a single exhaustive type.
+
+    DeviceAuthCodeErrorCode:
+      type: string
+      description: Error codes for POST /auth/device/code.
+      enum:
+        - invalid_request
+        - invalid_client
+
+    DeviceAuthCodeError:
+      type: object
+      required:
+        - error
+        - error_description
+      properties:
+        error:
+          $ref: '#/components/schemas/DeviceAuthCodeErrorCode'
+        error_description:
+          type: string
+
+    DeviceAuthTokenErrorCode:
+      type: string
+      description: >
+        Error codes for POST /auth/device/token — the RFC 8628 polling vocabulary
+        the browser switches on. `server_error` is emitted at runtime (HTTP 500)
+        though it is absent from the plugin's declared zod enum.
+      enum:
+        - authorization_pending
+        - slow_down
+        - expired_token
+        - access_denied
+        - invalid_request
+        - invalid_grant
+        - server_error
+
+    DeviceAuthTokenError:
+      type: object
+      required:
+        - error
+        - error_description
+      properties:
+        error:
+          $ref: '#/components/schemas/DeviceAuthTokenErrorCode'
+        error_description:
+          type: string
+
+    DeviceAuthVerifyErrorCode:
+      type: string
+      description: >
+        Error codes for GET /auth/device. `expired_token` is emitted at runtime
+        (HTTP 400) though the plugin's declared zod enum lists only invalid_request.
+      enum:
+        - invalid_request
+        - expired_token
+
+    DeviceAuthVerifyError:
+      type: object
+      required:
+        - error
+        - error_description
+      properties:
+        error:
+          $ref: '#/components/schemas/DeviceAuthVerifyErrorCode'
+        error_description:
+          type: string
+
+    DeviceAuthActionErrorCode:
+      type: string
+      description: >
+        Error codes for POST /auth/device/approve and POST /auth/device/deny
+        (shared — both routes emit the same set). `device_code_already_processed`
+        is declared in the plugin's approve zod enum but is NEVER emitted on the
+        wire — the already-processed branch throws `invalid_request` — so it is
+        intentionally omitted here (mirror runtime).
+      enum:
+        - invalid_request
+        - expired_token
+        - unauthorized
+        - access_denied
+
+    DeviceAuthActionError:
+      type: object
+      required:
+        - error
+        - error_description
+      properties:
+        error:
+          $ref: '#/components/schemas/DeviceAuthActionErrorCode'
+        error_description:
+          type: string
+
     RateLimitInfo:
       type: object
       required:
@@ -6012,3 +6265,195 @@ paths:
                   and `subscription` envelope events.
                 oneOf:
                   - $ref: '#/components/schemas/LiveFsEvent'
+
+  # ===================
+  # Device Authorization (RFC 8628) — issue #195. Schemas live under
+  # components/schemas/DeviceAuth*. /device/code + /device/token are PUBLIC;
+  # /device/approve + /device/deny require a Better Auth session (BearerAuth);
+  # GET /device accepts an optional session (used only to claim the code).
+  # Mirrors better-auth 1.6.20 + Backend-Service#1495.
+  # ===================
+
+  /auth/device/code:
+    post:
+      summary: Request a device + user code (RFC 8628 §3.2)
+      description: >
+        Starts the QR sign-in flow. The browser POSTs this, renders
+        verification_uri_complete as a QR plus the user_code, then polls
+        /auth/device/token. Public (no session required).
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceAuthCodeRequest'
+      responses:
+        '200':
+          description: Device and user codes issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthCodeResponse'
+        '400':
+          description: 'invalid_request (malformed body) or invalid_client.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthCodeError'
+
+  /auth/device/token:
+    post:
+      summary: Exchange a device_code for a session token (RFC 8628 §3.4)
+      description: >
+        The browser polls this until the DJ approves. Public (no session
+        required). RFC 8628 polling states (authorization_pending, slow_down)
+        are returned as 400 errors, not 2xx. Deliberately not rate-limited by
+        the auth-service — the plugin enforces the polling interval server-side.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceAuthTokenRequest'
+      responses:
+        '200':
+          description: Authorization granted; session token issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthTokenResponse'
+        '400':
+          description: >
+            RFC 8628 polling state or bad request: authorization_pending,
+            slow_down, expired_token, access_denied, invalid_request, invalid_grant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthTokenError'
+        '500':
+          description: 'server_error — user lookup or session creation failed.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthTokenError'
+
+  /auth/device:
+    get:
+      summary: Look up a device authorization by user_code
+      description: >
+        Returns the current status of a device authorization. A session is
+        optional: anonymous callers get the status; a signed-in DJ additionally
+        claims a pending code for their account.
+      security:
+        - {}
+        - BearerAuth: []
+      parameters:
+        - name: user_code
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The user code to look up.
+      responses:
+        '200':
+          description: Current device authorization status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthVerifyResponse'
+        '400':
+          description: 'invalid_request (unknown user_code) or expired_token.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthVerifyError'
+
+  /auth/device/approve:
+    post:
+      summary: Approve a device authorization (iOS scanner)
+      description: >
+        Called by the iOS app carrying the DJ's session. Flips the device code
+        to approved so the polling browser receives a session. The auth-service
+        gates this to roles >= dj; a member is rejected with access_denied (403).
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceAuthApproveRequest'
+      responses:
+        '200':
+          description: Device authorization approved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionResponse'
+        '400':
+          description: >
+            invalid_request (unknown / unclaimed / already-processed code) or
+            expired_token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionError'
+        '401':
+          description: 'unauthorized — no valid session.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionError'
+        '403':
+          description: >
+            access_denied — caller is not the claiming user, or lacks the dj
+            role (auth-service gate).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionError'
+
+  /auth/device/deny:
+    post:
+      summary: Deny a device authorization (iOS scanner)
+      description: >
+        Called by the iOS app carrying the DJ's session to reject a scanned QR.
+        Requires a Better Auth session. Not role-gated by the auth-service — the
+        plugin's own userId check already prevents denying someone else's code.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceAuthDenyRequest'
+      responses:
+        '200':
+          description: Device authorization denied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionResponse'
+        '400':
+          description: >
+            invalid_request (unknown / unclaimed / already-processed code) or
+            expired_token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionError'
+        '401':
+          description: 'unauthorized — no valid session.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionError'
+        '403':
+          description: 'access_denied — caller is not the claiming user.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthActionError'

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "^25.9.3",
         "@vitest/coverage-v8": "^4.1.9",
         "bats": "^1.11.0",
-        "better-auth": "^1.6.18",
+        "better-auth": "^1.6.20",
         "openapi-typescript": "^7.13.0",
         "tsup": "^8.4.0",
         "typescript": "^5.6.2 || ^6.0.0",
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.18.tgz",
-      "integrity": "sha512-mlPZBKHY6gZdJtuY6LiuKjN2r8AWu0LCss7CEnI0xMbE9D7Sw6WofwPPwiMm+0Hi0QBKIaZGYRmR7/WasbOs+Q==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.20.tgz",
+      "integrity": "sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -118,8 +118,8 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.4.1",
-        "@better-fetch/fetch": "1.3.0",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
         "better-call": "1.3.6",
@@ -137,14 +137,14 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.18.tgz",
-      "integrity": "sha512-VFcW2YMLZt0YAD0hy6BcMkjPh4Rh9khV71jnV2uL3udqz599Z1P4PiuWO6XZLELTvb/bbAUnxS5ZnyXQwFDAPQ==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.20.tgz",
+      "integrity": "sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.18",
-        "@better-auth/utils": "0.4.1",
+        "@better-auth/core": "^1.6.20",
+        "@better-auth/utils": "0.4.2",
         "drizzle-orm": "^0.45.2"
       },
       "peerDependenciesMeta": {
@@ -154,14 +154,14 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.18.tgz",
-      "integrity": "sha512-7Q9+LYWiVD8t3nrxN/fPqZOgUQFcVh+KUo95CDj2+Hfnf4GCb6/ZsQrEnBXBgplwBQbUOYN58Lp/uevb6ugwFQ==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.20.tgz",
+      "integrity": "sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.18",
-        "@better-auth/utils": "0.4.1",
+        "@better-auth/core": "^1.6.20",
+        "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
       "peerDependenciesMeta": {
@@ -171,25 +171,25 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.18.tgz",
-      "integrity": "sha512-jHulNRsA0OGKAACmsCNfAbH2z0NEoLQCLdZTU6Pvqn/Cd+xh7aFz0oys69KyKZp2r30QUjuEG9FrrqS8ASWDiw==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.20.tgz",
+      "integrity": "sha512-J5Ni0LlFijbzXlwu2rFHaD8zEFocmajyzWkRnHsq8LhV/Dk4iWQwwnqzLrPoDQEj8roECAUF03hrIeMzqWRqJQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.18",
-        "@better-auth/utils": "0.4.1"
+        "@better-auth/core": "^1.6.20",
+        "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.18.tgz",
-      "integrity": "sha512-A6aD3sKsptQl5sBq2wFoLGckEIM5Pa93T//R1DR+erAZOMejZGyaqYaPXWwRk7ZejFOyrftMm98OP0IJsz52gg==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.20.tgz",
+      "integrity": "sha512-ClDBJf6h4g85WJswxwQwxLaiyRU67Gmz/uaIf19tY1gqlLJDykSGjmqRNSBMG5rWABNzcNqbO4KG31rYUldbIw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.18",
-        "@better-auth/utils": "0.4.1",
+        "@better-auth/core": "^1.6.20",
+        "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
@@ -199,14 +199,14 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.18.tgz",
-      "integrity": "sha512-9hJrDYDqGpb53o8BUuB8uunkkeY+nACzYpZr06R8+22zTFS/NL/jLwgUlK3Xf+1VjhBoXAoEBKJ3ghVUGu6jFw==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.20.tgz",
+      "integrity": "sha512-WhYdhSGuVSfu1peCSf2snmmVzfWjRaEvbSrsNCusiwGE9l94HlES4mjSPM48fed24hL7yg4j1dYK/yjEt87FpQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.18",
-        "@better-auth/utils": "0.4.1",
+        "@better-auth/core": "^1.6.20",
+        "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
@@ -220,21 +220,21 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.18.tgz",
-      "integrity": "sha512-C/sWZzDAFrtb8bFs+yLHLYYfk1Yffw2GnKXerxTGO3rHI7qV2Ktf359nAf3IdZr+cC/404fFk4hkDCnQiGCkZA==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.20.tgz",
+      "integrity": "sha512-3BhbY3naQDERvdJvJ7fGszVY6rpsVfc6c9uyBVZlC1coVEF/rkM0rIcjtMVI1GUH7vWy1wjR6qF5vQnMun3XNQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.18",
-        "@better-auth/utils": "0.4.1",
-        "@better-fetch/fetch": "1.3.0"
+        "@better-auth/core": "^1.6.20",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.1.tgz",
-      "integrity": "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+      "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.0.tgz",
-      "integrity": "sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+      "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2207,21 +2207,21 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.18.tgz",
-      "integrity": "sha512-6jONqD0gNjE0S6ehhSZhZ7We0rBwjAzbqnQMJQg/zY0387M+agak7VsOAuE78r7Z0Qv7C/KBRKhHSuyJDQ4iLw==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.20.tgz",
+      "integrity": "sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.6.18",
-        "@better-auth/drizzle-adapter": "1.6.18",
-        "@better-auth/kysely-adapter": "1.6.18",
-        "@better-auth/memory-adapter": "1.6.18",
-        "@better-auth/mongo-adapter": "1.6.18",
-        "@better-auth/prisma-adapter": "1.6.18",
-        "@better-auth/telemetry": "1.6.18",
-        "@better-auth/utils": "0.4.1",
-        "@better-fetch/fetch": "1.3.0",
+        "@better-auth/core": "1.6.20",
+        "@better-auth/drizzle-adapter": "1.6.20",
+        "@better-auth/kysely-adapter": "1.6.20",
+        "@better-auth/memory-adapter": "1.6.20",
+        "@better-auth/mongo-adapter": "1.6.20",
+        "@better-auth/prisma-adapter": "1.6.20",
+        "@better-auth/telemetry": "1.6.20",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
         "better-call": "1.3.6",
@@ -4678,9 +4678,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
       "dev": true,
       "license": "MIT"
     },

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -1293,6 +1293,38 @@ describe('OpenAPI Specification', () => {
       }
     });
 
+    it('models /device/code and GET /device errors as 400-only, each its own error envelope', () => {
+      const codeR = (spec.paths['/auth/device/code'] as { post: Operation }).post.responses!;
+      expect(Object.keys(codeR).sort()).toEqual(['200', '400']);
+      expect(codeR['400'].content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/DeviceAuthCodeError'
+      );
+      const verifyR = (spec.paths['/auth/device'] as { get: Operation }).get.responses!;
+      expect(Object.keys(verifyR).sort()).toEqual(['200', '400']);
+      expect(verifyR['400'].content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/DeviceAuthVerifyError'
+      );
+    });
+
+    it('wires each endpoint 200 success response to its own response schema', () => {
+      const okRef = (op: Operation) => op.responses!['200'].content?.['application/json']?.schema?.$ref;
+      expect(okRef((spec.paths['/auth/device/code'] as { post: Operation }).post)).toBe(
+        '#/components/schemas/DeviceAuthCodeResponse'
+      );
+      expect(okRef((spec.paths['/auth/device/token'] as { post: Operation }).post)).toBe(
+        '#/components/schemas/DeviceAuthTokenResponse'
+      );
+      expect(okRef((spec.paths['/auth/device'] as { get: Operation }).get)).toBe(
+        '#/components/schemas/DeviceAuthVerifyResponse'
+      );
+      expect(okRef((spec.paths['/auth/device/approve'] as { post: Operation }).post)).toBe(
+        '#/components/schemas/DeviceAuthActionResponse'
+      );
+      expect(okRef((spec.paths['/auth/device/deny'] as { post: Operation }).post)).toBe(
+        '#/components/schemas/DeviceAuthActionResponse'
+      );
+    });
+
     it('GET /auth/device takes a required user_code query param', () => {
       const op = (spec.paths['/auth/device'] as { get: Operation }).get;
       const userCode = op.parameters?.find((p) => p.name === 'user_code');

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -1143,4 +1143,175 @@ describe('OpenAPI Specification', () => {
       expect(services?.additionalProperties?.enum).toEqual(['ok', 'unavailable', 'timeout']);
     });
   });
+
+  describe('Device Authorization (RFC 8628) — #195', () => {
+    // Field-list / enum snapshot against api.yaml (the #186 CatalogExportRow house
+    // style — NOT a live runtime diff; the plugin's per-route zod schemas are
+    // module-internal and unexported). The contract mirrors better-auth 1.6.20 +
+    // Backend-Service#1495. Error enums are the RUNTIME superset of the declared zod.
+    type Schema = {
+      type?: string;
+      required?: string[];
+      properties?: Record<string, Record<string, unknown>>;
+      enum?: string[];
+    };
+    type Operation = {
+      security?: Array<Record<string, unknown[]>>;
+      parameters?: Array<{ name: string; in: string; required?: boolean }>;
+      responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }>;
+    };
+    const getSchema = (name: string) => spec.components.schemas[name] as Schema;
+    const props = (name: string) => Object.keys(getSchema(name).properties ?? {}).sort();
+
+    it('declares all five /auth/device/* paths with the right methods', () => {
+      expect((spec.paths['/auth/device/code'] as Record<string, unknown>)?.post).toBeDefined();
+      expect((spec.paths['/auth/device/token'] as Record<string, unknown>)?.post).toBeDefined();
+      expect((spec.paths['/auth/device'] as Record<string, unknown>)?.get).toBeDefined();
+      expect((spec.paths['/auth/device/approve'] as Record<string, unknown>)?.post).toBeDefined();
+      expect((spec.paths['/auth/device/deny'] as Record<string, unknown>)?.post).toBeDefined();
+    });
+
+    // ---- Request/response field lists (snapshot vs the verified plugin wire shapes) ----
+
+    it('DeviceAuthCodeRequest = { client_id (req), scope?, user_id? } — user_id is the 1.6.20 pre-bind field', () => {
+      expect(props('DeviceAuthCodeRequest')).toEqual(['client_id', 'scope', 'user_id'].sort());
+      expect(getSchema('DeviceAuthCodeRequest').required).toEqual(['client_id']);
+    });
+
+    it('DeviceAuthCodeResponse carries all six RFC 8628 fields, all required', () => {
+      const fields = [
+        'device_code',
+        'user_code',
+        'verification_uri',
+        'verification_uri_complete',
+        'expires_in',
+        'interval',
+      ];
+      expect(props('DeviceAuthCodeResponse')).toEqual([...fields].sort());
+      expect((getSchema('DeviceAuthCodeResponse').required ?? []).sort()).toEqual([...fields].sort());
+    });
+
+    it('DeviceAuthTokenRequest preserves snake_case + a fixed grant_type literal', () => {
+      expect(props('DeviceAuthTokenRequest')).toEqual(['client_id', 'device_code', 'grant_type'].sort());
+      expect(getSchema('DeviceAuthTokenRequest').properties?.grant_type?.enum).toEqual([
+        'urn:ietf:params:oauth:grant-type:device_code',
+      ]);
+    });
+
+    it('DeviceAuthTokenResponse carries all four runtime fields INCLUDING scope (token_type fixed to Bearer)', () => {
+      const fields = ['access_token', 'token_type', 'expires_in', 'scope'];
+      expect(props('DeviceAuthTokenResponse')).toEqual([...fields].sort());
+      expect((getSchema('DeviceAuthTokenResponse').required ?? []).sort()).toEqual([...fields].sort());
+      expect(getSchema('DeviceAuthTokenResponse').properties?.token_type?.enum).toEqual(['Bearer']);
+      // expires_in stays a plain integer — BS clamps the VALUE to 43200, not the type.
+      expect(getSchema('DeviceAuthTokenResponse').properties?.expires_in?.type).toBe('integer');
+    });
+
+    it('DeviceAuthVerifyResponse = { user_code, status } with status the [pending,approved,denied] enum', () => {
+      expect(props('DeviceAuthVerifyResponse')).toEqual(['status', 'user_code']);
+      expect(getSchema('DeviceAuthVerifyResponse').properties?.status?.$ref).toBe(
+        '#/components/schemas/DeviceAuthStatus'
+      );
+      expect(getSchema('DeviceAuthStatus').enum).toEqual(['pending', 'approved', 'denied']);
+    });
+
+    it('approve + deny request bodies use camelCase userCode (NOT snake_case)', () => {
+      for (const name of ['DeviceAuthApproveRequest', 'DeviceAuthDenyRequest']) {
+        expect(props(name), name).toEqual(['userCode']);
+        expect(getSchema(name).required, name).toEqual(['userCode']);
+        expect(getSchema(name).properties?.user_code, name).toBeUndefined();
+      }
+    });
+
+    it('DeviceAuthActionResponse is a plain { success: boolean }', () => {
+      expect(props('DeviceAuthActionResponse')).toEqual(['success']);
+      expect(getSchema('DeviceAuthActionResponse').properties?.success?.type).toBe('boolean');
+    });
+
+    // ---- Per-endpoint error enums mirror RUNTIME (a superset of the declared zod) ----
+
+    it('pins each per-endpoint error enum to the runtime vocabulary', () => {
+      expect(getSchema('DeviceAuthCodeErrorCode').enum).toEqual(['invalid_request', 'invalid_client']);
+      expect(getSchema('DeviceAuthTokenErrorCode').enum).toEqual([
+        'authorization_pending',
+        'slow_down',
+        'expired_token',
+        'access_denied',
+        'invalid_request',
+        'invalid_grant',
+        'server_error',
+      ]);
+      expect(getSchema('DeviceAuthVerifyErrorCode').enum).toEqual(['invalid_request', 'expired_token']);
+      expect(getSchema('DeviceAuthActionErrorCode').enum).toEqual([
+        'invalid_request',
+        'expired_token',
+        'unauthorized',
+        'access_denied',
+      ]);
+    });
+
+    it('includes runtime-only codes the declared zod omits (server_error on token, expired_token on verify)', () => {
+      expect(getSchema('DeviceAuthTokenErrorCode').enum).toContain('server_error');
+      expect(getSchema('DeviceAuthVerifyErrorCode').enum).toContain('expired_token');
+    });
+
+    it('drops device_code_already_processed — declared in approve zod but never a wire error', () => {
+      expect(getSchema('DeviceAuthActionErrorCode').enum).not.toContain('device_code_already_processed');
+    });
+
+    // ---- security per endpoint ----
+
+    it('makes code/token public; approve/deny require BearerAuth; GET /device accepts an optional session', () => {
+      expect((spec.paths['/auth/device/code'] as { post: Operation }).post.security).toEqual([]);
+      expect((spec.paths['/auth/device/token'] as { post: Operation }).post.security).toEqual([]);
+      expect((spec.paths['/auth/device/approve'] as { post: Operation }).post.security).toEqual([
+        { BearerAuth: [] },
+      ]);
+      expect((spec.paths['/auth/device/deny'] as { post: Operation }).post.security).toEqual([{ BearerAuth: [] }]);
+      // GET /device works unauthenticated (200 + status); a session only claims the code.
+      expect((spec.paths['/auth/device'] as { get: Operation }).get.security).toEqual([{}, { BearerAuth: [] }]);
+    });
+
+    // ---- per-status error blocks reference the right envelope ----
+
+    it('models /device/token errors per status (400 + 500), both DeviceAuthTokenError', () => {
+      const r = (spec.paths['/auth/device/token'] as { post: Operation }).post.responses!;
+      expect(Object.keys(r).sort()).toEqual(['200', '400', '500']);
+      expect(r['400'].content?.['application/json']?.schema?.$ref).toBe('#/components/schemas/DeviceAuthTokenError');
+      expect(r['500'].content?.['application/json']?.schema?.$ref).toBe('#/components/schemas/DeviceAuthTokenError');
+    });
+
+    it('models approve/deny errors per status (400 + 401 + 403), all DeviceAuthActionError', () => {
+      for (const route of ['/auth/device/approve', '/auth/device/deny']) {
+        const r = (spec.paths[route] as { post: Operation }).post.responses!;
+        expect(Object.keys(r).sort(), route).toEqual(['200', '400', '401', '403']);
+        for (const code of ['400', '401', '403']) {
+          expect(r[code].content?.['application/json']?.schema?.$ref, `${route} ${code}`).toBe(
+            '#/components/schemas/DeviceAuthActionError'
+          );
+        }
+      }
+    });
+
+    it('GET /auth/device takes a required user_code query param', () => {
+      const op = (spec.paths['/auth/device'] as { get: Operation }).get;
+      const userCode = op.parameters?.find((p) => p.name === 'user_code');
+      expect(userCode?.in).toBe('query');
+      expect(userCode?.required).toBe(true);
+    });
+
+    // ---- version forcing-function ----
+
+    it('pins the verified better-auth version so a bump forces a conscious re-verification', () => {
+      // The contract above mirrors better-auth 1.6.20 (the version Backend-Service#1495
+      // runs; 1.6.20 added the /device/code `user_id` field over 1.6.18/.19). If this
+      // fails after a bump, re-verify routes.mjs against the new version, update the
+      // enums/fields above, then bump this string. (package.json keeps the ^1.6.18
+      // caret per the issue; package-lock.json resolves it to 1.6.20.)
+      const ba = JSON.parse(
+        readFileSync(join(__dirname, '..', 'node_modules', 'better-auth', 'package.json'), 'utf-8')
+      ) as { version: string };
+      expect(ba.version).toBe('1.6.20');
+    });
+  });
 });


### PR DESCRIPTION
Mirrors the five QR-sign-in endpoints from [WXYC/Backend-Service#1495](https://github.com/WXYC/Backend-Service/pull/1495) into the cross-repo SSOT (`api.yaml`) so dj-site and `wxyc-dj-tool-ios` can `import { DeviceAuthCodeResponse, DeviceAuthTokenResponse, DeviceAuthTokenErrorCode } from '@wxyc/shared'` instead of hand-typing the RFC 8628 polling vocabulary.

## What's added

- **5 paths** — `POST /auth/device/code`, `POST /auth/device/token`, `GET /auth/device`, `POST /auth/device/approve`, `POST /auth/device/deny`.
- **17 `DeviceAuth*` component schemas** — requests, responses, the `pending`/`approved`/`denied` status enum, and one per-endpoint error-code enum + envelope each. The `DeviceAuth*` prefix avoids colliding with the existing push-notification `DeviceToken`/`DeviceRegistration` schemas.

## Faithful to runtime, not the declared zod

`api.yaml` = the plugin's **runtime** behavior + WXYC's BS hooks (the two diverge from the declared zod schemas):

- `/device/token` error enum includes **`server_error`** (HTTP 500, absent from the declared enum); response carries the fourth field **`scope`**; `expires_in` is documented as clamped to **43200** (12h) by the BS `hooks.after` override.
- `GET /device` error enum includes **`expired_token`** (runtime-only; declared enum lists only `invalid_request`).
- `/device/approve` **drops `device_code_already_processed`** — declared in the plugin's zod enum but never a wire `error` (the branch throws `invalid_request`).
- Request-body casing preserved exactly: snake_case for code/token + the `user_code` query; **camelCase `userCode`** for approve/deny.

## Modeling decisions (resolved during planning)

- **Errors per HTTP status** (token 400 + 500; approve/deny 400 + 401 + 403), each status referencing the endpoint's single error envelope → a polling client switches over one exhaustive enum. (Swift codegen is models-only, so the status split is invisible to Swift and exists for HTTP/TS/Python fidelity.)
- **Security per endpoint:** code/token public; approve/deny require `BearerAuth`; `GET /device` accepts an **optional** session (`[{}, {BearerAuth: []}]`) — verified to return `200` + status unauthenticated, with a session used only to claim the code (no `401` path), which corrected the original "BearerAuth-required" assumption.
- `status` modeled as an enum; `DeviceAuthActionResponse.success` as `boolean`.

## Version

Verified against **better-auth 1.6.20** — the version BS runs. The lockfile moves `1.6.18 → 1.6.20` (package.json keeps the `^1.6.18` caret); **1.6.20 added the optional `/device/code` `user_id` pre-bind field**, now mirrored. A guard test snapshots the field lists, per-endpoint error enums, security, and casing, and **asserts the installed better-auth version** so a future bump forces a conscious re-verification.

## Verification

- `npm run check:breaking` — no breaking changes (purely additive).
- `npm test` — 488 passed (incl. the new `Device Authorization (RFC 8628)` block).
- `npm run lint`, `npm run build` — clean.
- All four generators run clean: TS const-object enums, Python pydantic `StrEnum`/`BaseModel`, Kotlin, and Swift (switchable `enum DeviceAuthTokenErrorCode: String, Codable, CaseIterable`). Generated output is gitignored / writes to consumer repos, so the committed diff is `api.yaml` + the guard test + the lockfile bump only.

## Out of scope (follow-ups in consumer repos)

Swift/Kotlin checked-in types and dj-site / `wxyc-dj-tool-ios` dropping hand-typed shapes land in their own repos once this merges. The stale `generate:swift` output path (`../wxyc-ios-64-copy`, vs the actual consumer `wxyc-dj-tool-ios`) is noted for separate cleanup.

Closes #195