### PR TITLE
feat(catalog-export): add popularity to CatalogExportRow SSOT (BS#1486 Phase-2 Track 3)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1190,13 +1190,17 @@ components:
           type: integer
           nullable: true
           description: >
-            Attribution-corrected, master-collapsed popularity (BS#1486 Phase-2
-            Track 3). Collapses every pressing/format of one logical album under
-            its Discogs master AND folds in the ~43% of free-text/unlinked plays
-            that `plays` cannot see, so consumers can rank releases by real
-            listening. null when the album_popularity signal has no row for this
-            row's logical key (e.g. unresolved-and-unplayed). Distinct from
-            `plays`, which stays the per-pressing linked count.
+            Attribution-corrected popularity (BS#1486 Phase-2 Track 3): a play
+            count for this row's LOGICAL album rather than this single pressing.
+            Pressings that resolve to the same Discogs master (~90% of RESOLVED
+            library rows) collapse into one count; release-only and unresolved
+            rows keep a per-release or per-library key, with no cross-pressing
+            collapse. It also adds the free-text/unlinked plays Track 1 has
+            resolved to the same release/master (the ~43% free-text tail is the
+            ceiling, not all of it — only the resolved subset counts), which the
+            linked-only `plays` cannot see. Rank releases by `popularity`. null
+            when the album_popularity signal has no row for this row's logical
+            key. Distinct from `plays`, which stays the per-pressing linked count.
         artwork_url:
           type: string
           nullable: true

--- a/api.yaml
+++ b/api.yaml
@@ -1182,6 +1182,21 @@ components:
         plays:
           type: integer
           nullable: true
+          description: >
+            Per-pressing LINKED play count for THIS catalog row (from album_plays).
+            The honest per-release number; to rank by real popularity across all
+            pressings of a logical album, use `popularity` instead.
+        popularity:
+          type: integer
+          nullable: true
+          description: >
+            Attribution-corrected, master-collapsed popularity (BS#1486 Phase-2
+            Track 3). Collapses every pressing/format of one logical album under
+            its Discogs master AND folds in the ~43% of free-text/unlinked plays
+            that `plays` cannot see, so consumers can rank releases by real
+            listening. null when the album_popularity signal has no row for this
+            row's logical key (e.g. unresolved-and-unplayed). Distinct from
+            `plays`, which stays the per-pressing linked count.
         artwork_url:
           type: string
           nullable: true

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -305,7 +305,7 @@ describe('OpenAPI Specification', () => {
       allOf?: unknown;
     };
 
-    // The 14-field projection: catalog-export.service.ts:33-48 (CatalogExportRow).
+    // The 15-field projection: catalog-export.service.ts:33-48 (CatalogExportRow).
     const EXPORT_FIELDS = [
       'id',
       'artist_name',
@@ -318,12 +318,13 @@ describe('OpenAPI Specification', () => {
       'format_name',
       'on_streaming',
       'plays',
+      'popularity',
       'artwork_url',
       'rotation_bin',
       'rotation_kill_date',
     ];
 
-    it('defines CatalogExportRow with exactly the 14 shipped fields', () => {
+    it('defines CatalogExportRow with exactly the 15 shipped fields', () => {
       const schema = spec.components.schemas.CatalogExportRow as Schema;
       expect(schema).toBeDefined();
       expect(Object.keys(schema.properties ?? {}).sort()).toEqual([...EXPORT_FIELDS].sort());
@@ -343,6 +344,19 @@ describe('OpenAPI Specification', () => {
           'format_name',
         ].sort()
       );
+    });
+
+    it('ships popularity as a nullable integer, distinct from plays (BS#1486 Phase-2 Track 3)', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+      const popularity = schema.properties?.popularity;
+      expect(popularity).toBeDefined();
+      expect(popularity!.type).toBe('integer');
+      expect(popularity!.nullable).toBe(true);
+      // popularity is the corrected logical signal, NOT a rename of the
+      // per-pressing linked `plays`: both ship, and popularity stays nullable
+      // (omitted from required) so a decoder predating it keeps working.
+      expect(schema.properties?.plays).toBeDefined();
+      expect(schema.required ?? []).not.toContain('popularity');
     });
 
     it('types rotation_bin as a raw nullable string, NOT the RotationBin enum (admits N; decision 1)', () => {

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -305,7 +305,10 @@ describe('OpenAPI Specification', () => {
       allOf?: unknown;
     };
 
-    // The 15-field projection: catalog-export.service.ts:33-48 (CatalogExportRow).
+    // The catalog-export projection (Backend-Service catalog-export.service.ts,
+    // CatalogExportRow). The SSOT leads the consumer: this list is 15 fields,
+    // one ahead of that private type until Backend Track 3 (#1493) adds the
+    // 15th, `popularity`.
     const EXPORT_FIELDS = [
       'id',
       'artist_name',
@@ -346,16 +349,20 @@ describe('OpenAPI Specification', () => {
       );
     });
 
-    it('ships popularity as a nullable integer, distinct from plays (BS#1486 Phase-2 Track 3)', () => {
+    it('ships popularity as a nullable integer alongside plays, not as a replacement (BS#1486 Phase-2 Track 3)', () => {
       const schema = spec.components.schemas.CatalogExportRow as Schema;
       const popularity = schema.properties?.popularity;
       expect(popularity).toBeDefined();
       expect(popularity!.type).toBe('integer');
       expect(popularity!.nullable).toBe(true);
       // popularity is the corrected logical signal, NOT a rename of the
-      // per-pressing linked `plays`: both ship, and popularity stays nullable
-      // (omitted from required) so a decoder predating it keeps working.
-      expect(schema.properties?.plays).toBeDefined();
+      // per-pressing linked `plays`: BOTH ship as distinct nullable-int fields,
+      // and popularity stays out of `required` so a decoder predating it keeps
+      // working.
+      const plays = schema.properties?.plays;
+      expect(plays).toBeDefined();
+      expect(plays!.type).toBe('integer');
+      expect(plays!.nullable).toBe(true);
       expect(schema.required ?? []).not.toContain('popularity');
     });
 


### PR DESCRIPTION
## What

Adds `popularity` (nullable integer) to the `CatalogExportRow` schema in the cross-repo SSOT (`api.yaml`) — the attribution-corrected, master-collapsed catalog popularity signal from BS#1486 Phase-2. Track 2 (WXYC/Backend-Service#1492) built the `album_popularity` table; Backend-Service Track 3 (WXYC/Backend-Service#1493) is the consumer that projects this field from that table.

## Field semantics

- **`popularity`** — collapses every pressing/format of one logical album under its Discogs master AND folds in the ~43% of free-text/unlinked plays the per-pressing `plays` count can't see, so consumers can rank releases by real listening. Nullable; `null` when the `album_popularity` signal has no row for the export row's logical key (e.g. unresolved-and-unplayed).
- **`plays`** stays the honest per-pressing LINKED count (now given a description so the distinction is explicit). Both ship; `popularity` is additive and nullable, so existing generated iOS / Kotlin / TS decoders keep working until they regenerate.

## Tests

`tests/api-spec.test.ts`: the field-set guard now expects **15** fields (was 14), plus a new case pinning `popularity` as a nullable integer that is NOT required and is distinct from `plays`. Full suite green (491 tests), lint clean, build + TS codegen emit `popularity?: number | null`.

## Sequencing

SSOT-first per the org rule. Generated code isn't committed here (built at release, matching the #186 `CatalogExportRow` precedent). Once this merges and a new `@wxyc/shared` cuts, Backend-Service #1493 bumps the dep and projects `popularity` via a LEFT JOIN to `album_popularity`.

Part of WXYC/Backend-Service#1486 (Phase-2) / #1493 (Track 3). Unblocks the deferred ranked-bundle seed in WXYC/wxyc-dj-ios#44.