### PR TITLE
fix(#197): repoint Swift/Kotlin codegen output to in-repo generated/{swift,kotlin}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,14 +99,30 @@ The `.github/workflows/publish.yml` workflow handles the rest.
 
 DTOs are generated from `api.yaml`. TypeScript uses `openapi-typescript` (pure Node.js); Swift and Kotlin use the Java-based `openapi-generator-cli`:
 ```bash
-npm run generate:typescript  # TypeScript types (openapi-typescript, no JVM)
-npm run generate:swift       # iOS types (openapi-generator-cli, requires Java)
-npm run generate:kotlin      # Android types (openapi-generator-cli, requires Java)
+npm run generate:typescript  # TypeScript types (openapi-typescript, no JVM)  -> src/generated/
+npm run generate:python      # Python pydantic models (datamodel-codegen)     -> generated/python/
+npm run generate:swift       # Swift types (openapi-generator-cli, requires Java)  -> generated/swift/
+npm run generate:kotlin      # Kotlin types (openapi-generator-cli, requires Java) -> generated/kotlin/
 ```
 
-The codegen script (`scripts/generate-models.js`) produces:
+The TypeScript codegen script (`scripts/generate-models.js`) produces:
 - `src/generated/openapi-types.d.ts` -- raw openapi-typescript output
 - `src/generated/models/index.ts` -- re-export layer with const objects for enums
+
+All four output trees are **in-repo and gitignored** (`src/generated/`, `generated/`) — they're regenerated artifacts, never committed here. TypeScript is the only output consumed by this package's own build (it ships the DTOs); Python/Swift/Kotlin are produced for downstream consumers.
+
+### Output locations and consumers
+
+| Script | Output (gitignored) | Consumer(s) | How the consumer uses it today |
+|---|---|---|---|
+| `generate:typescript` | `src/generated/` | Backend-Service, dj-site (via `@wxyc/shared/dtos`) | Imported from the published package |
+| `generate:python` | `generated/python/` | request-o-matic, library-metadata-lookup | Pydantic models |
+| `generate:swift` | `generated/swift/` | wxyc-dj-ios (DJ tool / device-auth), wxyc-ios-64 (listener) | **Hand-maintained** — reference/diff aid only |
+| `generate:kotlin` | `generated/kotlin/` | WXYC-Android | **Hand-maintained** — reference/diff aid only |
+
+The Swift/Kotlin consumers **do not yet consume the generated output** — they hand-author types that mirror `api.yaml` (e.g. `wxyc-dj-ios`'s `Packages/WXYCAPI/Sources/WXYCAPI/DTOs/`). So `generated/swift` and `generated/kotlin` are a local reference a maintainer regenerates and diffs against when hand-updating a consumer after an `api.yaml` change — not a tree any consumer checks in. (`library-scanner`, formerly a Swift consumer, is now an archived/read-only repo.)
+
+Migrating each consumer onto the generated output is tracked separately, blocked by this output-path fix (#197): WXYC/wxyc-dj-ios#75, WXYC/WXYC-Android#25, WXYC/wxyc-ios-64#412 — all sub-issues of the codegen umbrella #106. Once a consumer migrates, its `-o` path (or its own build step) should point at wherever that repo checks the generated client in; until then these stay in-repo.
 
 Run `npm run check:breaking` before changing `api.yaml` to detect breaking changes.
 

--- a/openapi-config/kotlin.yaml
+++ b/openapi-config/kotlin.yaml
@@ -1,9 +1,10 @@
 # OpenAPI Generator config for Kotlin
-# Models-only output written to generated/kotlin (gitignored, in-repo).
+# Output written to generated/kotlin (gitignored, in-repo); includes models and API clients.
 # Reference/diff aid for the Android consumer (WXYC-Android), which currently
 # hand-maintains its types; see the Code Generation section of CLAUDE.md.
 
-# Only generate models, not API clients
+# Skip generated test stubs (models and API clients are still emitted; see followup
+# on whether this config should be models-only like swift.yaml's generateApis: false)
 generateApiTests: false
 generateModelTests: false
 

--- a/openapi-config/kotlin.yaml
+++ b/openapi-config/kotlin.yaml
@@ -1,5 +1,7 @@
 # OpenAPI Generator config for Kotlin
-# Generates type definitions for Android app (WXYC-Android)
+# Models-only output written to generated/kotlin (gitignored, in-repo).
+# Reference/diff aid for the Android consumer (WXYC-Android), which currently
+# hand-maintains its types; see the Code Generation section of CLAUDE.md.
 
 # Only generate models, not API clients
 generateApiTests: false

--- a/openapi-config/swift.yaml
+++ b/openapi-config/swift.yaml
@@ -1,5 +1,7 @@
 # OpenAPI Generator config for Swift
-# Generates type definitions for iOS app (wxyc-ios-64-copy)
+# Models-only output written to generated/swift (gitignored, in-repo).
+# Reference/diff aid for the Swift consumers (wxyc-dj-ios, wxyc-ios-64), which
+# currently hand-maintain their DTOs; see the Code Generation section of CLAUDE.md.
 
 # Only generate models, not API clients
 generateModelTests: false

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "clean": "rm -rf dist",
     "generate": "npm run generate:typescript && npm run generate:python && npm run generate:swift && npm run generate:kotlin",
     "generate:typescript": "node scripts/generate-models.js",
-    "generate:swift": "openapi-generator-cli generate -i api.yaml -g swift5 -o ../wxyc-ios-64-copy/Shared/WXYCAPI -c openapi-config/swift.yaml --skip-validate-spec",
+    "generate:swift": "openapi-generator-cli generate -i api.yaml -g swift5 -o generated/swift -c openapi-config/swift.yaml --skip-validate-spec",
     "generate:python": "datamodel-codegen --input api.yaml --input-file-type openapi --output generated/python/models.py --output-model-type pydantic_v2.BaseModel --target-python-version 3.12 --use-standard-collections --use-union-operator",
-    "generate:kotlin": "openapi-generator-cli generate -i api.yaml -g kotlin -o ../WXYC-Android/shared/api -c openapi-config/kotlin.yaml --skip-validate-spec",
+    "generate:kotlin": "openapi-generator-cli generate -i api.yaml -g kotlin -o generated/kotlin -c openapi-config/kotlin.yaml --skip-validate-spec",
     "check:breaking": "bash scripts/check-breaking-changes.sh"
   },
   "files": [

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Guards the fix for WXYC/wxyc-shared#197: the Swift/Kotlin codegen scripts
+// used to write into sibling scratch dirs (`-o ../wxyc-ios-64-copy/...`,
+// `-o ../WXYC-Android/shared/api`) that don't exist in a normal checkout.
+// Every `generate:*` output must stay in-repo and gitignored so a maintainer
+// running `npm run generate` updates a real, intended tree.
+
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, "..", "package.json"), "utf-8"),
+) as { scripts: Record<string, string> };
+
+/** Pull the output path out of a generate script's CLI (`-o`/`-output`/`--output`). */
+function outputPath(script: string): string | null {
+  const m = script.match(/(?:-o|--?output)\s+(\S+)/);
+  return m ? m[1] : null;
+}
+
+const generateScripts = Object.entries(pkg.scripts).filter(([name]) =>
+  /^generate:/.test(name),
+);
+
+describe("codegen output paths (#197)", () => {
+  it("has the four generate:* scripts", () => {
+    expect(generateScripts.map(([n]) => n).sort()).toEqual([
+      "generate:kotlin",
+      "generate:python",
+      "generate:swift",
+      "generate:typescript",
+    ]);
+  });
+
+  it.each(generateScripts)(
+    "%s writes inside the repo (no `../`, no absolute path)",
+    (_name, script) => {
+      const out = outputPath(script);
+      // generate:typescript has no -o flag (the node script writes src/generated
+      // internally); nothing to assert for it.
+      if (out === null) return;
+      expect(out.startsWith("../"), `escapes repo: ${out}`).toBe(false);
+      expect(out.startsWith("/"), `absolute path: ${out}`).toBe(false);
+    },
+  );
+
+  it("targets the documented in-repo destinations", () => {
+    expect(outputPath(pkg.scripts["generate:swift"])).toBe("generated/swift");
+    expect(outputPath(pkg.scripts["generate:kotlin"])).toBe("generated/kotlin");
+    expect(outputPath(pkg.scripts["generate:python"])).toBe(
+      "generated/python/models.py",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Repoints the Swift/Kotlin codegen output off the stale sibling scratch trees (`../wxyc-ios-64-copy/Shared/WXYCAPI`, `../WXYC-Android/shared/api`) onto gitignored in-repo dirs (`generated/swift`, `generated/kotlin`), matching the existing `generate:python` → `generated/python` and `generate:typescript` → `src/generated` outputs. Running the old scripts in a normal checkout just created throwaway dirs next to the repo.

## Why not just point at the consumer repo

The issue's first framing — write into "the directory the real consumer repo actually checks the generated client into" — assumes such a directory exists. It doesn't: **no consumer currently checks in generator output.**

- `wxyc-dj-ios/Packages/WXYCAPI` is a hand-maintained SPM package (hand-authored DTOs, hand-written `Package.swift`). Pointing `openapi-generator --useSPMFileStructure` at it would overwrite `Package.swift` and clobber the hand-written `APIClient`/`AuthService`/`Bin`/`Catalog`.
- `WXYC-Android` has no `shared/api` dir and is dormant (last push 2025-12-15).
- `wxyc-ios-64` (listener) has no `WXYCAPI` at all.
- `library-scanner` — the 4th `#106`-named consumer — is now an **archived/read-only** repo.

So these trees are an in-repo regenerate-and-diff reference until each consumer migrates onto generated types (tracked below).

## Changes

- `package.json` — `generate:swift -o generated/swift`, `generate:kotlin -o generated/kotlin`.
- `CLAUDE.md` — Code Generation section now lists each output's destination + consumer, documents that Swift/Kotlin consumers hand-maintain today (reference/diff aid only), and links the migration tickets.
- `openapi-config/{swift,kotlin}.yaml` — header comments updated off the stale repo names.
- `tests/codegen-output-paths.test.ts` — guard: no `generate:*` output may escape the repo (`../`) or be absolute; pins the documented destinations. Red on the old `../` paths, green now.

## Verification

- Ran `npm run generate:swift` + `npm run generate:kotlin`: output lands in `generated/{swift,kotlin}` (gitignored — confirmed via `git check-ignore`); nothing written to any sibling path.
- CI-parity (per `.github/workflows/ci.yml`): `generate:typescript`, `build`, `lint`, `test` all green — **497 tests** incl. the new guard.

## Acceptance criteria (#197)

- [x] `generate:swift`/`generate:kotlin` target a real, intended location (no `*-copy` scratch dir).
- [x] The actual iOS/Android consumers are identified and documented in `CLAUDE.md`.
- [x] Linked follow-ups exist for adopting the regenerated types in the consumer repos.

## Follow-ups (consumer migration — each `blocked_by` this issue, sub-issues of #106)

- WXYC/wxyc-dj-ios#75 — migrate hand-rolled `WXYCAPI` DTOs → generated Swift (incl. the `DeviceAuth*` types).
- WXYC/WXYC-Android#25 — adopt generated Kotlin (create the `shared/api` module).
- WXYC/wxyc-ios-64#412 — adopt generated Swift for the metadata/playlist surfaces.

Closes #197
