### PR TITLE
feat(api): add DiscogsWriterCredits for BMI songwriter/composer reporting

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2773,6 +2773,8 @@ components:
             Pair with `LookupRequest.warm_cache=true` on write-path calls
             to progressively populate the cache so subsequent reads render
             richer.
+        writer_credits:
+          $ref: '#/components/schemas/DiscogsWriterCredits'
 
     LookupResultItem:
       type: object
@@ -3803,6 +3805,55 @@ components:
           type: string
           nullable: true
           description: Role for extra artists (e.g. "Producer", "Mixed By")
+
+    DiscogsWriterCredits:
+      type: object
+      description: >
+        Songwriter/composer credits for the resolved playcut, derived from the
+        Discogs writer-role credits already fetched at resolution time (the
+        `extra=1` artist credits whose `role` is a writer role — e.g.
+        "Written-By", "Composed By", "Music By", "Lyrics By", "Songwriter",
+        "Words By", including hyphen/space, bracketed, and comma-compound
+        variants). Surfaced on `DiscogsMatchResult.writer_credits` for BMI
+        performance-list reporting; populated only when `extended` is true and
+        a writer credit resolves, and omitted entirely when nothing resolves —
+        names are never fabricated. A consumer with no resolved composer falls
+        back to artist-as-proxy.
+      required:
+        - names
+        - provenance
+      properties:
+        names:
+          type: array
+          items:
+            type: string
+          description: Distinct songwriter/composer names for the resolved track.
+        roles:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: >
+            The verbatim Discogs role strings the names were drawn from (e.g.
+            "Written-By", "Words By, Music By"), for auditability of the
+            writer-role mapping.
+        provenance:
+          type: string
+          enum:
+            - track
+            - release
+          description: >
+            `track` = scoped to the resolved track's per-track credits
+            (precise); `release` = a release-level credit applied to the whole
+            release (approximate for an individual track, mirroring tubafrenzy's
+            auto-fill-from-artist fallback). Populated as `release` in the
+            initial rollout; `track` is added when per-track resolution lands.
+        track_position:
+          type: string
+          nullable: true
+          description: >
+            The resolved track's position (e.g. "A1", "5") when
+            `provenance` is `track`; null for release-level credits.
 
     DiscogsLabelCredit:
       type: object

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -819,6 +819,40 @@ describe('OpenAPI Specification', () => {
       expect(prop.nullable).toBe(true);
       expect(schema.required ?? []).not.toContain('master_id');
     });
+
+    it('should define DiscogsWriterCredits with names + provenance required (LML#699)', () => {
+      // Songwriter/composer credits surfaced for BMI performance-list reporting
+      // after the tubafrenzy turndown (WXYC/library-metadata-lookup#699). names +
+      // provenance are required; roles + track_position are auxiliary/optional.
+      const schema = spec.components.schemas.DiscogsWriterCredits as {
+        properties: Record<string, SchemaProp & { enum?: string[] }>;
+        required?: string[];
+      };
+
+      expect(schema).toBeDefined();
+      expect(schema.required).toEqual(['names', 'provenance']);
+      expect(schema.properties.names.type).toBe('array');
+      expect(schema.properties.names.items?.type).toBe('string');
+      expect(schema.properties.provenance.enum).toEqual(['track', 'release']);
+      expect(schema.required ?? []).not.toContain('roles');
+      expect(schema.required ?? []).not.toContain('track_position');
+    });
+
+    it('should attach writer_credits to DiscogsMatchResult as an optional $ref (LML#699)', () => {
+      // writer_credits rides the album_metadata passthrough to Backend-Service; it
+      // is a bare $ref kept OUT of `required`, so codegen emits it as optional and
+      // the additive contract doesn't break existing LML/BS/iOS/Android consumers.
+      const schema = spec.components.schemas.DiscogsMatchResult as {
+        properties: Record<string, SchemaProp>;
+        required?: string[];
+      };
+
+      expect(schema.properties.writer_credits).toBeDefined();
+      expect(schema.properties.writer_credits.$ref).toBe(
+        '#/components/schemas/DiscogsWriterCredits',
+      );
+      expect(schema.required ?? []).not.toContain('writer_credits');
+    });
   });
 
   describe('Lookup Hard Cap (LML#370)', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -30,6 +30,7 @@ import {
   type LookupResultItem,
   type LookupRequest,
   type DiscogsMatchResult,
+  type DiscogsWriterCredits,
   type TrackMatchHint,
   RotationBin,
   DayOfWeek,
@@ -818,6 +819,48 @@ describe('Generated TypeScript Types', () => {
       };
 
       expect(baseline.master_id).toBeUndefined();
+    });
+  });
+
+  describe('DiscogsMatchResult writer_credits (BMI composer, LML#699)', () => {
+    // Pin the consumer-facing contract: writer_credits is optional, so a caller
+    // that omits it (no resolved composer) is unaffected. Backend reads it off
+    // the album_metadata passthrough to populate a flowsheet composer for BMI.
+    it('accepts a result with release-level writer_credits', () => {
+      const withWriters: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        writer_credits: {
+          names: ['Juana Molina'],
+          roles: ['Written-By'],
+          provenance: 'release',
+          track_position: null,
+        },
+      };
+
+      expect(withWriters.writer_credits?.names).toEqual(['Juana Molina']);
+      expect(withWriters.writer_credits?.provenance).toBe('release');
+    });
+
+    it('accepts a standalone track-scoped DiscogsWriterCredits with a position', () => {
+      const trackScoped: DiscogsWriterCredits = {
+        names: ['Duke Ellington', 'John Coltrane'],
+        roles: ['Written-By'],
+        provenance: 'track',
+        track_position: 'A1',
+      };
+
+      expect(trackScoped.provenance).toBe('track');
+      expect(trackScoped.track_position).toBe('A1');
+    });
+
+    it('accepts a result that omits writer_credits entirely', () => {
+      const baseline: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+      };
+
+      expect(baseline.writer_credits).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Schema half of WXYC/library-metadata-lookup#699 — exposing Discogs songwriter/composer credits so WXYC can keep submitting BMI performance lists after the 2026-08-31 tubafrenzy turndown.

## What

- New `DiscogsWriterCredits` schema: `names` (required), `roles` (verbatim source role strings, for auditability of the writer-role mapping), `provenance` (`track` | `release`), and `track_position`.
- New optional `DiscogsMatchResult.writer_credits` — a bare `$ref` kept out of `required`, so codegen emits it as optional (`DiscogsWriterCredits | None`), matching the existing `artwork` / `reconciled_identity` convention in this file.

## Why this shape

LML already fetches the writer-role credits (`release_track_artist` / `release_artist` rows with `extra=1` and a writer role) at resolution time and currently discards them. Surfacing them on `DiscogsMatchResult` means the value rides the existing `album_metadata` jsonb passthrough to Backend-Service with no new LML→BS plumbing. `provenance` distinguishes a track-scoped credit (precise) from a release-level fallback (approximate for an individual track). The initial rollout populates `release`; per-track precision (`track`) follows.

## Tests

- Spec guards (`tests/api-spec.test.ts`): `writer_credits` stays out of `DiscogsMatchResult.required`; `DiscogsWriterCredits` requires `names` + `provenance` with a `track`/`release` enum.
- Generated-type construction tests (`tests/generated-types.test.ts`): a result with release-level credits, a standalone track-scoped value, and a result omitting the field — mirroring the `master_id` / extended-metadata precedents.

## Safety

- **oasdiff: no breaking changes** (additive optional field + new schema).
- Local CI parity green: `generate:typescript`, `build`, `lint`, `test` (180 passing in the two touched files).
- Verified `datamodel-codegen` (LML's generator) emits `DiscogsWriterCredits` + `writer_credits: DiscogsWriterCredits | None` cleanly.

This is **PR-A** of the LML#699 plan; LML's PR-B (release-level populate) depends on this being on `main` first (its regen reads `wxyc-shared` main).