### PR TITLE
feat(auto-dj): add @wxyc/shared/auto-dj type contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Watch for the **caller-callee narrowing trap** when changing the workflow's own 
 
 This package provides:
 - **DTOs** (`@wxyc/shared/dtos`) - Generated from OpenAPI spec (`api.yaml`)
+- **Auto-DJ** (`@wxyc/shared/auto-dj`) - Auto-DJ type contracts: the orchestrator <-> Arduino management-channel messages + virtual switch API, plus a discriminated-union type and type guards
 - **Auth Client** (`@wxyc/shared/auth-client`) - Better Auth client with role/capability system
 - **Validation** (`@wxyc/shared/validation`) - Shared validation utilities
 - **Test Utilities** (`@wxyc/shared/test-utils`) - Fixtures and factories for testing

--- a/README.md
+++ b/README.md
@@ -283,6 +283,14 @@ if (hasPermission(user.role, "catalog", "write")) {
 | `metadata.dto` | External metadata (Discogs, Spotify) |
 | `common.dto` | Shared types (errors, pagination, genres) |
 
+### Auto-DJ (`@wxyc/shared/auto-dj`)
+
+Type contracts for the auto-DJ system — the orchestrator <-> Arduino management-channel messages (`AutoDJHeartbeat`, `AutoDJCommand`, `AutoDJAck`, `AutoDJNowPlaying`, `AutoDJErrorReport`, `AutoDJButtonToggle`) and the dj-site <-> orchestrator virtual switch API (`AutoDJStatus`, `AutoDJDeactivateResponse`, ...). Adds a hand-written `AutoDJWebSocketMessage` discriminated union and type guards (`isHeartbeat`, `isCommand`, ...) over the generated schemas; string enums (`AutoDJCommandAction`, ...) are exported as runtime values.
+
+```ts
+import { isHeartbeat, AutoDJCommandAction, type AutoDJStatus } from '@wxyc/shared/auto-dj';
+```
+
 ### Test Utilities (`@wxyc/shared/test-utils`)
 
 | Module | Description |

--- a/api.yaml
+++ b/api.yaml
@@ -4630,6 +4630,338 @@ components:
           update: '#/components/schemas/LiveFsUpdateEvent'
           refetch: '#/components/schemas/LiveFsRefetchEvent'
 
+    # ── Auto-DJ system ─────────────────────────────────────────────────────
+    # Orchestrator <-> Arduino management channel, and the dj-site virtual
+    # switch API. Source of truth: auto-dj-arduino-switch/docs/networking-spec.md
+    # section 5.2. The `state` enum is reconciled to the re-architected
+    # firmware's 4-state vocabulary (BOOTING/CONNECTING/CONNECTED/ERROR_STATE);
+    # the Arduino is now a relay/button reporter, not a flowsheet writer.
+    AutoDJState:
+      type: string
+      enum: [BOOTING, CONNECTING, CONNECTED, ERROR_STATE]
+    AutoDJTransport:
+      type: string
+      enum: [ethernet, wifi]
+    AutoDJCommandAction:
+      type: string
+      enum: [set_config, pause, resume, end_show, restart, ping]
+    AutoDJErrorLevel:
+      type: string
+      enum: [warning, error, fatal]
+    AutoDJErrorCode:
+      type: string
+      enum:
+        - HTTP_TIMEOUT
+        - JSON_PARSE
+        - WIFI_DISCONNECT
+        - WS_DISCONNECT
+        - TLS_HANDSHAKE
+        - NTP_FAIL
+        - KVSTORE_WRITE
+        - FLOWSHEET_POST
+        - AZURACAST_POLL
+    AutoDJActivationSourceType:
+      type: string
+      enum: [virtual_switch, button, relay]
+    AutoDJRelayState:
+      type: string
+      enum: [auto_dj_active, dj_live]
+
+    AutoDJLastTrack:
+      type: object
+      required: [artist, title, posted_at]
+      properties:
+        artist:
+          type: string
+        title:
+          type: string
+        posted_at:
+          type: integer
+          description: Unix timestamp
+
+    AutoDJHeartbeat:
+      type: object
+      required:
+        - type
+        - state
+        - transport
+        - uptime_s
+        - free_ram
+        - firmware_version
+        - config_hash
+        - loop_max_ms
+        - reconnect_count
+        - tracks_detected
+        - tracks_posted
+        - errors_since_boot
+      properties:
+        type:
+          type: string
+          enum: [heartbeat]
+        state:
+          $ref: '#/components/schemas/AutoDJState'
+        transport:
+          $ref: '#/components/schemas/AutoDJTransport'
+        uptime_s:
+          type: integer
+        wifi_rssi:
+          type: integer
+          nullable: true
+        free_ram:
+          type: integer
+        radio_show_id:
+          type: integer
+          nullable: true
+          description: Always null in the reporter model; retained for schema compatibility.
+        last_track:
+          $ref: '#/components/schemas/AutoDJLastTrack'
+        last_error:
+          type: string
+          nullable: true
+        firmware_version:
+          type: string
+        config_hash:
+          type: string
+        loop_max_ms:
+          type: integer
+        reconnect_count:
+          type: integer
+        tracks_detected:
+          type: integer
+        tracks_posted:
+          type: integer
+        errors_since_boot:
+          type: integer
+        button_press_count:
+          type: integer
+          description: Button presses since last heartbeat (HTTP/WiFi fallback; orchestrator toggles if odd). 0 if none.
+        relay_auto_dj_active:
+          type: boolean
+          description: Current debounced relay level. true = relay reports auto-DJ-active (no live DJ); false = live DJ on air.
+
+    AutoDJCommand:
+      type: object
+      required: [type, id, action]
+      properties:
+        type:
+          type: string
+          enum: [command]
+        id:
+          type: string
+          description: Unique command ID for ack correlation
+        action:
+          $ref: '#/components/schemas/AutoDJCommandAction'
+        key:
+          type: string
+          description: Config key (only for set_config)
+        value:
+          type: string
+          description: Config value (only for set_config)
+
+    AutoDJAck:
+      type: object
+      required: [type, id, status]
+      properties:
+        type:
+          type: string
+          enum: [ack]
+        id:
+          type: string
+          description: The id from the command being acknowledged
+        status:
+          type: string
+          enum: [ok, error, unknown_command]
+        error:
+          type: string
+          description: Error message (only when status is error)
+        result:
+          type: object
+          description: 'Optional result data (e.g. { active: boolean } for button_toggle acks)'
+
+    AutoDJNowPlaying:
+      type: object
+      required: [type, sh_id, artist, title, album, is_live]
+      properties:
+        type:
+          type: string
+          enum: [now_playing]
+        sh_id:
+          type: integer
+          description: AzuraCast song history ID
+        artist:
+          type: string
+        title:
+          type: string
+        album:
+          type: string
+        is_live:
+          type: boolean
+          description: Whether a live DJ is streaming
+
+    AutoDJErrorReport:
+      type: object
+      required: [type, level, module, code, message, state, uptime_s, free_ram, count]
+      properties:
+        type:
+          type: string
+          enum: [error]
+        level:
+          $ref: '#/components/schemas/AutoDJErrorLevel'
+        module:
+          type: string
+          description: Source module (e.g. mgmt_client, relay_monitor)
+        code:
+          $ref: '#/components/schemas/AutoDJErrorCode'
+        message:
+          type: string
+        state:
+          $ref: '#/components/schemas/AutoDJState'
+        uptime_s:
+          type: integer
+        free_ram:
+          type: integer
+        count:
+          type: integer
+          description: Occurrences since last report
+
+    AutoDJButtonToggle:
+      type: object
+      required: [type, timestamp]
+      properties:
+        type:
+          type: string
+          enum: [button_toggle]
+        timestamp:
+          type: integer
+          description: Unix timestamp of the button press (from NTP)
+
+    AutoDJWebSocketMessage:
+      oneOf:
+        - $ref: '#/components/schemas/AutoDJHeartbeat'
+        - $ref: '#/components/schemas/AutoDJCommand'
+        - $ref: '#/components/schemas/AutoDJAck'
+        - $ref: '#/components/schemas/AutoDJNowPlaying'
+        - $ref: '#/components/schemas/AutoDJErrorReport'
+        - $ref: '#/components/schemas/AutoDJButtonToggle'
+      discriminator:
+        propertyName: type
+        mapping:
+          heartbeat: '#/components/schemas/AutoDJHeartbeat'
+          command: '#/components/schemas/AutoDJCommand'
+          ack: '#/components/schemas/AutoDJAck'
+          now_playing: '#/components/schemas/AutoDJNowPlaying'
+          error: '#/components/schemas/AutoDJErrorReport'
+          button_toggle: '#/components/schemas/AutoDJButtonToggle'
+
+    AutoDJDeviceStatus:
+      type: object
+      required: [connected, transport, last_heartbeat_at, firmware_version]
+      properties:
+        connected:
+          type: boolean
+        transport:
+          type: string
+          enum: [ethernet, wifi, none]
+        last_heartbeat_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_heartbeat:
+          $ref: '#/components/schemas/AutoDJHeartbeat'
+        pending_commands:
+          type: integer
+          description: Number of unacknowledged commands in the queue
+        firmware_version:
+          type: string
+        device_id:
+          type: string
+          description: MAC address or other unique identifier
+
+    # ── Virtual switch API (dj-site <-> orchestrator) ──────────────────────
+    AutoDJActivationSource:
+      type: object
+      required: [source]
+      properties:
+        source:
+          $ref: '#/components/schemas/AutoDJActivationSourceType'
+        userId:
+          type: string
+          description: Better Auth user ID (only for virtual_switch source)
+        userName:
+          type: string
+          description: Display name (only for virtual_switch source)
+        detail:
+          type: string
+          description: Additional context (e.g. "Live DJ detected" for relay source)
+
+    AutoDJCurrentTrack:
+      type: object
+      required: [artist, title, album, detectedAt]
+      properties:
+        artist:
+          type: string
+        title:
+          type: string
+        album:
+          type: string
+        detectedAt:
+          type: string
+          format: date-time
+
+    AutoDJDeviceSummary:
+      type: object
+      required: [online, transport, lastHeartbeat, relayState]
+      properties:
+        online:
+          type: boolean
+        transport:
+          $ref: '#/components/schemas/AutoDJTransport'
+        lastHeartbeat:
+          type: string
+          format: date-time
+        relayState:
+          $ref: '#/components/schemas/AutoDJRelayState'
+
+    AutoDJStatus:
+      type: object
+      required: [active]
+      properties:
+        active:
+          type: boolean
+        activatedBy:
+          $ref: '#/components/schemas/AutoDJActivationSource'
+        activatedAt:
+          type: string
+          format: date-time
+        showId:
+          type: integer
+        currentTrack:
+          allOf:
+            - $ref: '#/components/schemas/AutoDJCurrentTrack'
+          nullable: true
+        lastDeactivatedAt:
+          type: string
+          format: date-time
+        lastDeactivatedBy:
+          $ref: '#/components/schemas/AutoDJActivationSource'
+        device:
+          allOf:
+            - $ref: '#/components/schemas/AutoDJDeviceSummary'
+          nullable: true
+
+    AutoDJDeactivateResponse:
+      type: object
+      required: [active, deactivatedBy, deactivatedAt]
+      properties:
+        active:
+          type: boolean
+          enum: [false]
+        deactivatedBy:
+          $ref: '#/components/schemas/AutoDJActivationSource'
+        deactivatedAt:
+          type: string
+          format: date-time
+
 security:
   - BearerAuth: []
 

--- a/api.yaml
+++ b/api.yaml
@@ -4776,6 +4776,7 @@ components:
           description: Error message (only when status is error)
         result:
           type: object
+          additionalProperties: true
           description: 'Optional result data (e.g. { active: boolean } for button_toggle acks)'
 
     AutoDJNowPlaying:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/dtos/index.js",
       "default": "./dist/dtos/index.js"
     },
+    "./auto-dj": {
+      "types": "./dist/auto-dj/index.d.ts",
+      "import": "./dist/auto-dj/index.js",
+      "default": "./dist/auto-dj/index.js"
+    },
     "./test-utils": {
       "types": "./dist/test-utils/index.d.ts",
       "import": "./dist/test-utils/index.js",

--- a/src/auto-dj/extensions.ts
+++ b/src/auto-dj/extensions.ts
@@ -13,6 +13,7 @@ import type {
   AutoDJNowPlaying,
   AutoDJErrorReport,
   AutoDJButtonToggle,
+  AutoDJWebSocketMessage as AutoDJWebSocketMessageGenerated,
 } from '../generated/models/index.js';
 
 /** Discriminated union of every message that crosses the Arduino <-> orchestrator channel. */
@@ -23,6 +24,14 @@ export type AutoDJWebSocketMessage =
   | AutoDJNowPlaying
   | AutoDJErrorReport
   | AutoDJButtonToggle;
+
+// Compile-time tie: the hand-written union must stay mutually assignable to the
+// generated oneOf, so adding/removing a message type in api.yaml without
+// updating this union (or vice versa) fails the build instead of silently
+// drifting.
+type Mutual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+const _unionTie: Mutual<AutoDJWebSocketMessage, AutoDJWebSocketMessageGenerated> = true;
+void _unionTie;
 
 export function isHeartbeat(msg: AutoDJWebSocketMessage): msg is AutoDJHeartbeat {
   return msg.type === 'heartbeat';

--- a/src/auto-dj/extensions.ts
+++ b/src/auto-dj/extensions.ts
@@ -1,0 +1,49 @@
+/**
+ * Auto-DJ TypeScript extensions.
+ *
+ * The schemas live in api.yaml (`components/schemas`) and are code-generated
+ * into `src/generated/models/`. This file adds the hand-written union type and
+ * type guards over the WebSocket management-channel messages, following the
+ * pattern of `src/dtos/extensions.ts`.
+ */
+import type {
+  AutoDJHeartbeat,
+  AutoDJCommand,
+  AutoDJAck,
+  AutoDJNowPlaying,
+  AutoDJErrorReport,
+  AutoDJButtonToggle,
+} from '../generated/models/index.js';
+
+/** Discriminated union of every message that crosses the Arduino <-> orchestrator channel. */
+export type AutoDJWebSocketMessage =
+  | AutoDJHeartbeat
+  | AutoDJCommand
+  | AutoDJAck
+  | AutoDJNowPlaying
+  | AutoDJErrorReport
+  | AutoDJButtonToggle;
+
+export function isHeartbeat(msg: AutoDJWebSocketMessage): msg is AutoDJHeartbeat {
+  return msg.type === 'heartbeat';
+}
+
+export function isCommand(msg: AutoDJWebSocketMessage): msg is AutoDJCommand {
+  return msg.type === 'command';
+}
+
+export function isAck(msg: AutoDJWebSocketMessage): msg is AutoDJAck {
+  return msg.type === 'ack';
+}
+
+export function isNowPlaying(msg: AutoDJWebSocketMessage): msg is AutoDJNowPlaying {
+  return msg.type === 'now_playing';
+}
+
+export function isErrorReport(msg: AutoDJWebSocketMessage): msg is AutoDJErrorReport {
+  return msg.type === 'error';
+}
+
+export function isButtonToggle(msg: AutoDJWebSocketMessage): msg is AutoDJButtonToggle {
+  return msg.type === 'button_toggle';
+}

--- a/src/auto-dj/index.ts
+++ b/src/auto-dj/index.ts
@@ -1,0 +1,52 @@
+/**
+ * `@wxyc/shared/auto-dj`
+ *
+ * Shared type contracts for the auto-DJ system: the orchestrator <-> Arduino
+ * management channel and the dj-site <-> orchestrator virtual switch API.
+ * Generated from api.yaml (`components/schemas`); see networking-spec.md §5.
+ *
+ * @example
+ * ```ts
+ * import { AutoDJStatus, isHeartbeat } from '@wxyc/shared/auto-dj';
+ * ```
+ */
+
+// Generated schemas (re-exported as the curated public surface).
+export type {
+  // Management channel
+  AutoDJHeartbeat,
+  AutoDJLastTrack,
+  AutoDJCommand,
+  AutoDJCommandAction,
+  AutoDJAck,
+  AutoDJNowPlaying,
+  AutoDJErrorReport,
+  AutoDJErrorLevel,
+  AutoDJErrorCode,
+  AutoDJButtonToggle,
+  AutoDJState,
+  AutoDJTransport,
+  AutoDJDeviceStatus,
+  // The generated oneOf alias is exported under a distinct name; prefer the
+  // hand-written union below (it carries the discriminant for narrowing).
+  AutoDJWebSocketMessage as AutoDJWebSocketMessageSchema,
+  // Virtual switch API
+  AutoDJStatus,
+  AutoDJActivationSource,
+  AutoDJActivationSourceType,
+  AutoDJCurrentTrack,
+  AutoDJDeviceSummary,
+  AutoDJRelayState,
+  AutoDJDeactivateResponse,
+} from '../generated/models/index.js';
+
+// Hand-written union + type guards.
+export {
+  type AutoDJWebSocketMessage,
+  isHeartbeat,
+  isCommand,
+  isAck,
+  isNowPlaying,
+  isErrorReport,
+  isButtonToggle,
+} from './extensions.js';

--- a/src/auto-dj/index.ts
+++ b/src/auto-dj/index.ts
@@ -12,32 +12,40 @@
  */
 
 // Generated schemas (re-exported as the curated public surface).
+// Object/interface schemas (types only).
 export type {
   // Management channel
   AutoDJHeartbeat,
   AutoDJLastTrack,
   AutoDJCommand,
-  AutoDJCommandAction,
   AutoDJAck,
   AutoDJNowPlaying,
   AutoDJErrorReport,
-  AutoDJErrorLevel,
-  AutoDJErrorCode,
   AutoDJButtonToggle,
-  AutoDJState,
-  AutoDJTransport,
   AutoDJDeviceStatus,
-  // The generated oneOf alias is exported under a distinct name; prefer the
-  // hand-written union below (it carries the discriminant for narrowing).
+  // The generated oneOf alias, exported under a distinct name. Prefer the
+  // hand-written `AutoDJWebSocketMessage` union below for `switch`/guard code;
+  // a compile-time tie in extensions.ts keeps the two from drifting apart.
   AutoDJWebSocketMessage as AutoDJWebSocketMessageSchema,
   // Virtual switch API
   AutoDJStatus,
   AutoDJActivationSource,
-  AutoDJActivationSourceType,
   AutoDJCurrentTrack,
   AutoDJDeviceSummary,
-  AutoDJRelayState,
   AutoDJDeactivateResponse,
+} from '../generated/models/index.js';
+
+// String-enum schemas are generated as a const object + type alias — re-export
+// them as VALUES so consumers can use e.g. `AutoDJCommandAction.pause` or iterate
+// `Object.values(...)`, not just the type.
+export {
+  AutoDJCommandAction,
+  AutoDJErrorLevel,
+  AutoDJErrorCode,
+  AutoDJState,
+  AutoDJTransport,
+  AutoDJActivationSourceType,
+  AutoDJRelayState,
 } from '../generated/models/index.js';
 
 // Hand-written union + type guards.

--- a/tests/auto-dj.test.ts
+++ b/tests/auto-dj.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the @wxyc/shared/auto-dj type guards.
+ *
+ * TDD: these lock the discriminated-union narrowing over the Arduino <->
+ * orchestrator management-channel messages.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isHeartbeat,
+  isCommand,
+  isAck,
+  isNowPlaying,
+  isErrorReport,
+  isButtonToggle,
+  type AutoDJWebSocketMessage,
+} from '../src/auto-dj/index.js';
+
+const heartbeat: AutoDJWebSocketMessage = {
+  type: 'heartbeat',
+  state: 'CONNECTED',
+  transport: 'ethernet',
+  uptime_s: 1,
+  free_ram: 1,
+  firmware_version: '2.0.0',
+  config_hash: 'abc',
+  loop_max_ms: 1,
+  reconnect_count: 0,
+  tracks_detected: 0,
+  tracks_posted: 0,
+  errors_since_boot: 0,
+};
+const command: AutoDJWebSocketMessage = { type: 'command', id: 'c1', action: 'pause' };
+const ack: AutoDJWebSocketMessage = { type: 'ack', id: 'c1', status: 'ok' };
+const nowPlaying: AutoDJWebSocketMessage = {
+  type: 'now_playing',
+  sh_id: 1,
+  artist: 'Juana Molina',
+  title: 'la paradoja',
+  album: 'DOGA',
+  is_live: false,
+};
+const errorReport: AutoDJWebSocketMessage = {
+  type: 'error',
+  level: 'error',
+  module: 'mgmt_client',
+  code: 'WS_DISCONNECT',
+  message: 'dropped',
+  state: 'CONNECTING',
+  uptime_s: 1,
+  free_ram: 1,
+  count: 1,
+};
+const buttonToggle: AutoDJWebSocketMessage = { type: 'button_toggle', timestamp: 1709852100 };
+
+const all = [heartbeat, command, ack, nowPlaying, errorReport, buttonToggle];
+
+describe('auto-dj message type guards', () => {
+  it('each guard matches exactly one message type', () => {
+    const guards = [isHeartbeat, isCommand, isAck, isNowPlaying, isErrorReport, isButtonToggle];
+    for (const guard of guards) {
+      expect(all.filter(guard)).toHaveLength(1);
+    }
+  });
+
+  it('narrows so discriminant-specific fields are accessible', () => {
+    for (const msg of all) {
+      if (isHeartbeat(msg)) expect(msg.state).toBe('CONNECTED');
+      else if (isCommand(msg)) expect(msg.action).toBe('pause');
+      else if (isAck(msg)) expect(msg.status).toBe('ok');
+      else if (isNowPlaying(msg)) expect(msg.sh_id).toBe(1);
+      else if (isErrorReport(msg)) expect(msg.code).toBe('WS_DISCONNECT');
+      else if (isButtonToggle(msg)) expect(msg.timestamp).toBe(1709852100);
+    }
+  });
+});

--- a/tests/auto-dj.test.ts
+++ b/tests/auto-dj.test.ts
@@ -12,6 +12,8 @@ import {
   isNowPlaying,
   isErrorReport,
   isButtonToggle,
+  AutoDJCommandAction,
+  type AutoDJAck,
   type AutoDJWebSocketMessage,
 } from '../src/auto-dj/index.js';
 
@@ -60,6 +62,16 @@ describe('auto-dj message type guards', () => {
     for (const guard of guards) {
       expect(all.filter(guard)).toHaveLength(1);
     }
+  });
+
+  it('exposes string enums as runtime values (not just types)', () => {
+    expect(AutoDJCommandAction.pause).toBe('pause');
+    expect(Object.values(AutoDJCommandAction)).toContain('resume');
+  });
+
+  it('an ack can carry a result payload (e.g. { active })', () => {
+    const ack: AutoDJAck = { type: 'ack', id: 'btn_1', status: 'ok', result: { active: true } };
+    expect(ack.result?.active).toBe(true);
   });
 
   it('narrows so discriminant-specific fields are accessible', () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       'dtos/index': 'src/dtos/index.ts',
+      'auto-dj/index': 'src/auto-dj/index.ts',
       'test-utils/index': 'src/test-utils/index.ts',
       'validation/index': 'src/validation/index.ts',
     },


### PR DESCRIPTION
Adds the shared type contracts for the auto-DJ system: the orchestrator <-> Arduino management channel and the dj-site <-> orchestrator virtual switch API. Generated from `api.yaml` (`components/schemas`, [networking-spec.md §5.2](https://github.com/WXYC/auto-dj-arduino-switch/blob/main/docs/networking-spec.md)) and exposed as a new `@wxyc/shared/auto-dj` entry with a discriminated-union type + type guards, mirroring the `dtos`/`validation` entry pattern.

## What

- `api.yaml`: AutoDJ message schemas (`AutoDJHeartbeat`, `AutoDJCommand`, `AutoDJAck`, `AutoDJNowPlaying`, `AutoDJErrorReport`, `AutoDJButtonToggle`, `AutoDJWebSocketMessage`) + virtual-switch types (`AutoDJStatus`, `AutoDJDeactivateResponse`, `AutoDJActivationSource`, `AutoDJCurrentTrack`, `AutoDJDeviceSummary`, `AutoDJDeviceStatus`) and supporting enums.
- `src/auto-dj/{extensions,index}.ts`: hand-written union + type guards, curated re-export.
- `tsup.config.ts` + `package.json`: new `auto-dj/index` build entry and `./auto-dj` export.
- `tests/auto-dj.test.ts`: type-guard narrowing tests.

## Notes

- The heartbeat/error `state` enum is reconciled to the re-architected firmware's 4-state vocabulary (`BOOTING`/`CONNECTING`/`CONNECTED`/`ERROR_STATE`): the Arduino becomes a relay/button reporter; the orchestrator owns all flowsheet writes to Backend-Service (which mirrors to tubafrenzy), so the dual-backend/direct-tubafrenzy paths are dropped.
- Additive schema change (new `components/schemas` only) — no breaking changes to existing types.

## Verification

`npm test` (498 passing), `npm run lint`, and `npm run build` (emits `dist/auto-dj/`) all green locally.

Closes #203