### PR TITLE
fix(contract): client-facing liveFs SSE projection prose + declare projection-parity fields (BS#1534)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -278,6 +278,31 @@ components:
                 `release_track.position`. Null for free-text entries and legacy rows.
             metadata_status:
               $ref: '#/components/schemas/MetadataStatus'
+            # Projection-parity fields (BS#1513 / BS#1534). These ride the
+            # flowsheet mutation echoes and the liveFs:update SSE payload via
+            # Backend's CLIENT_FACING_FLOWSHEET_COLUMNS allow-list, but were
+            # previously undeclared here. Optional: absent/nullable on some rows.
+            entry_type:
+              $ref: '#/components/schemas/FlowsheetEntryType'
+            add_time:
+              type: string
+              format: date-time
+              description: The instant this row was logged (ISO 8601).
+            radio_hour:
+              type: string
+              format: date-time
+              nullable: true
+              description: >-
+                Top-of-hour a breakpoint row marks (ISO 8601), sourced from
+                tubafrenzy's RADIO_HOUR. Null on non-breakpoint rows and rows
+                predating the producer rollout. Mirrors the V2 breakpoint entry.
+            dj_name:
+              type: string
+              nullable: true
+              description: >-
+                Resolved public display name of the DJ on the row's show. Nullable
+                per the PII-safe resolution chain (BS#1371): user.djName ->
+                shows.legacy_dj_name -> null; never the real-name PII column.
 
     FlowsheetSongEntry:
       description: Song entry in the flowsheet
@@ -4566,10 +4591,14 @@ components:
     LiveFsUpdateEvent:
       description: >
         SSE event emitted on the `live-fs-topic` when an enrichment-worker (BS#892)
-        finalizes the metadata for a flowsheet row. Payload carries the full
-        flowsheet row so a newly-mounted client (e.g. a /live viewer that just
-        opened the page) can surface the post-enrichment fields (`artwork_url`,
-        `release_year`, ...) without a follow-up GET. Provider:
+        finalizes the metadata for a flowsheet row. Payload carries the
+        client-facing flowsheet row (the `FlowsheetEntryResponse` fields) so a
+        newly-mounted client (e.g. a /live viewer that just opened the page) can
+        surface the post-enrichment fields (`artwork_url`, `release_year`, ...)
+        without a follow-up GET. The `live-fs-topic` is anonymous, so Backend
+        projects the raw CDC row through its client-facing allow-list (BS#1534)
+        — internal columns (`search_doc`, `composer`, `legacy_*`, ...) do not
+        ride this stream. Provider:
         Backend-Service/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
         (`filterMetadataUpdate`). Consumer: dj-site `live-updates-listener.ts`.
         Contract: `CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW`.

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -79,19 +79,24 @@ export const CONTRACTS = {
     'flowsheet.dj_name is non-NULL on entries inserted after migration 0053',
 
   /**
-   * The `liveFs:update` SSE event payload carries the full flowsheet row,
-   * not just `{id, metadata_status}`.
+   * The `liveFs:update` SSE event payload carries the client-facing flowsheet
+   * row (the `FlowsheetEntryResponse` fields), not just `{id, metadata_status}`.
    *
    * Provider: `Backend-Service/apps/backend/services/metadata-broadcast/metadata-broadcast.ts:filterMetadataUpdate`
    * Consumer: `dj-site/lib/features/flowsheet/live-updates-listener.ts`
    *
    * Status: ENFORCED once Backend-Service BS-2 lands. Before BS-2 the payload
    * was `{id, metadata_status}` and a freshly-mounted /live viewer wouldn't see
-   * the post-enrichment fields until the next full GET fired. The full-row
-   * payload is what makes cross-tab cache patching actually work.
+   * the post-enrichment fields until the next full GET fired. The rich payload
+   * is what makes cross-tab cache patching actually work. Since BS#1534 the row
+   * is projected through Backend's client-facing allow-list before it hits this
+   * anonymous stream — the payload stays sufficient to cache-patch, but internal
+   * columns (`search_doc`, `composer`, `legacy_*`, ...) are stripped. The key
+   * name is retained for continuity; "full row" now means the full client-facing
+   * row, i.e. every `FlowsheetEntryResponse` field.
    */
   LIVE_FS_UPDATE_INCLUDES_FULL_ROW:
-    'liveFs:update payload includes the full flowsheet row, not just {id, metadata_status}',
+    'liveFs:update payload includes the client-facing flowsheet row (FlowsheetEntryResponse fields), not just {id, metadata_status}',
 
   /**
    * `GET /events/stream?topics=live-fs-topic` accepts anonymous subscription.

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -268,6 +268,70 @@ describe('OpenAPI Specification', () => {
         expect(required).not.toContain('metadata_status');
       });
     });
+
+    describe('projection-parity fields on FlowsheetEntryResponse (BS#1513 / BS#1534)', () => {
+      // FlowsheetEntryResponse is the declared shape of the flowsheet mutation
+      // echoes (POST/DELETE/PATCH /flowsheet) and the anonymous liveFs:update
+      // SSE payload ($ref target of LiveFsUpdateEvent). Backend projects those
+      // through CLIENT_FACING_FLOWSHEET_COLUMNS, which carries entry_type,
+      // add_time, radio_hour, and dj_name — fields that rode the wire but were
+      // undeclared here, so the SSOT under-described its own payload. They are
+      // optional (absent/nullable on some rows), so none is added to `required`.
+      function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
+        const schema = spec.components.schemas[schemaName] as
+          | { properties?: Record<string, Record<string, unknown>>; allOf?: Array<{ properties?: Record<string, Record<string, unknown>> }> }
+          | undefined;
+        if (!schema) return undefined;
+        if (schema.properties?.[prop]) return schema.properties[prop];
+        for (const branch of schema.allOf ?? []) {
+          if (branch.properties?.[prop]) return branch.properties[prop];
+        }
+        return undefined;
+      }
+
+      function requiredKeys(schemaName: string): string[] {
+        const schema = spec.components.schemas[schemaName] as {
+          allOf?: Array<{ required?: string[] }>;
+          required?: string[];
+        };
+        return [...(schema.required ?? []), ...(schema.allOf ?? []).flatMap((b) => b.required ?? [])];
+      }
+
+      it('declares entry_type via the FlowsheetEntryType enum', () => {
+        const entryType = getProperty('FlowsheetEntryResponse', 'entry_type');
+        expect(entryType).toBeDefined();
+        expect(entryType?.$ref).toBe('#/components/schemas/FlowsheetEntryType');
+      });
+
+      it('declares add_time as a date-time string', () => {
+        const addTime = getProperty('FlowsheetEntryResponse', 'add_time');
+        expect(addTime).toBeDefined();
+        expect(addTime?.type).toBe('string');
+        expect(addTime?.format).toBe('date-time');
+      });
+
+      it('declares radio_hour as a nullable date-time string', () => {
+        const radioHour = getProperty('FlowsheetEntryResponse', 'radio_hour');
+        expect(radioHour).toBeDefined();
+        expect(radioHour?.type).toBe('string');
+        expect(radioHour?.format).toBe('date-time');
+        expect(radioHour?.nullable).toBe(true);
+      });
+
+      it('declares dj_name as a nullable string', () => {
+        const djName = getProperty('FlowsheetEntryResponse', 'dj_name');
+        expect(djName).toBeDefined();
+        expect(djName?.type).toBe('string');
+        expect(djName?.nullable).toBe(true);
+      });
+
+      it('keeps all four projection-parity fields optional', () => {
+        const required = requiredKeys('FlowsheetEntryResponse');
+        for (const field of ['entry_type', 'add_time', 'radio_hour', 'dj_name']) {
+          expect(required).not.toContain(field);
+        }
+      });
+    });
   });
 
   describe('Catalog Schemas', () => {


### PR DESCRIPTION
## Summary

Companion contract change for [WXYC/Backend-Service#1534](https://github.com/WXYC/Backend-Service/issues/1534) (PR [WXYC/Backend-Service#1542](https://github.com/WXYC/Backend-Service/pull/1542)), which projects the anonymous `liveFs:update` SSE payload through Backend's client-facing allow-list instead of forwarding the raw CDC `to_jsonb(NEW)` row.

Two changes:

### 1. Reword `LIVE_FS_UPDATE_INCLUDES_FULL_ROW`

The contract prose said the payload is the *full flowsheet row*. It is now the *client-facing row* — the `FlowsheetEntryResponse` fields — still rich enough for dj-site's listener to cache-patch without a follow-up GET, but with internal columns (`search_doc`, `composer`, `legacy_*`, `linkage_*`, …) stripped before they reach the anonymous stream.

- `src/contracts.ts` — reworded the JSDoc and the statement string. **Key name retained** (`LIVE_FS_UPDATE_INCLUDES_FULL_ROW`) for continuity — nothing imports it programmatically, and "full row" now reads as "the full client-facing row."
- `api.yaml` `LiveFsUpdateEvent` description — same reword; `payload.$ref` stays `FlowsheetEntryResponse` (unchanged), which the `api-spec.test.ts` structural assertion already pins.

### 2. Declare four projection-parity fields on `FlowsheetEntryResponse`

Surfaced by the BS#1513/#1534 review: `FlowsheetEntryResponse` is the declared shape of the flowsheet mutation echoes **and** the `liveFs:update` payload, but Backend's `CLIENT_FACING_FLOWSHEET_COLUMNS` projection carries `entry_type`, `add_time`, `radio_hour`, and `dj_name` — which rode the wire **undeclared**, so the SSOT under-described its own payload. Now declared as **optional** properties:

| field | type | notes |
|---|---|---|
| `entry_type` | `$ref FlowsheetEntryType` | the canonical discriminator enum |
| `add_time` | `string` / `date-time` | matches `FlowsheetV2Base` |
| `radio_hour` | `string` / `date-time`, nullable | mirrors the V2 breakpoint entry |
| `dj_name` | `string`, nullable | PII-safe chain can end in null (BS#1371) |

None added to `required` — they're absent/nullable on some rows, and keeping them optional makes this a pure widening.

## Non-breaking

`npm run check:breaking` → **no breaking changes** (additive optional properties + prose only). Generated TS/Swift/Kotlin/Python types are gitignored and rebuilt at publish; `npm run generate:typescript` runs clean against the new spec.

## Testing

- `tests/api-spec.test.ts` — new `projection-parity fields on FlowsheetEntryResponse (BS#1513 / BS#1534)` block asserts each of the four fields is declared with the right type/nullability and stays optional. TDD: added RED first, then the api.yaml declarations turned them GREEN.
- Full suite: **505 passed**, `lint` (tsc) clean, `build` clean.

Part of WXYC/Backend-Service#1534 (its acceptance criteria track this companion PR). Merge alongside or after BS#1542.
