### PR TITLE
feat(flowsheet): add on_air field to FlowsheetV2PaginatedResponse

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -902,10 +902,24 @@ components:
             asserting automation. Not in `required` so absence stays distinct
             from an explicit `null`.
 
+
+            Codegen note: this three-way distinction (object / null / absent)
+            survives openapi-typescript (`on_air?: OnAirInfo | null`), but a
+            *synthesized* decoder in Swift (Codable `decodeIfPresent`), Kotlin
+            (kotlinx default value), or Python (pydantic `| None = None`) collapses
+            JSON `null` and an absent key into the same value. A consumer that
+            needs the third state must decode by key presence (e.g. Swift's
+            `container.contains` + `decodeNil`), as the iOS app does — do not rely
+            on a generated model to tell `null` from absent.
+
     OnAirInfo:
       type: object
       required:
         - dj_name
+      description: >-
+        Minimal on-air DJ shape for the `on_air` field. Deliberately separate from
+        `OnAirDJ`, which requires a numeric `id` that legacy/tubafrenzy-mirrored
+        shows lack (their identity is a `legacy_dj_name` string with no user row).
       properties:
         dj_name:
           type: string

--- a/api.yaml
+++ b/api.yaml
@@ -889,6 +889,27 @@ components:
         totalPages:
           type: integer
           description: Total number of pages
+        on_air:
+          allOf:
+            - $ref: '#/components/schemas/OnAirInfo'
+          nullable: true
+          description: >-
+            The DJ currently on air, when known. An object with `dj_name` means a
+            named DJ is live; JSON `null` means the station is confirmed on
+            automation ("Auto DJ"); the field being absent entirely means the
+            server does not report on-air status (older backends / non-default
+            query branches) and clients should treat it as unknown rather than
+            asserting automation. Not in `required` so absence stays distinct
+            from an explicit `null`.
+
+    OnAirInfo:
+      type: object
+      required:
+        - dj_name
+      properties:
+        dj_name:
+          type: string
+          description: Display name of the DJ currently on air.
 
     OnAirDJ:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/v2-flowsheet.test.ts
+++ b/tests/v2-flowsheet.test.ts
@@ -346,4 +346,40 @@ describe('FlowsheetV2PaginatedResponse', () => {
     expect(response.entries).toHaveLength(0);
     expect(response.total).toBe(0);
   });
+
+  // on_air is a three-state signal: an OnAirInfo object means a named DJ is
+  // live, JSON `null` means confirmed automation ("Auto DJ"), and the field
+  // being absent means the server did not report status (unknown). The type
+  // must model all three so clients can distinguish "nobody on" from "unknown".
+  const paginationFields = { page: 0, limit: 30, total: 1, totalPages: 1 };
+
+  it('should carry an on_air DJ object when a named DJ is live', () => {
+    const response: FlowsheetV2PaginatedResponse = {
+      entries: [sampleTrack],
+      ...paginationFields,
+      on_air: { dj_name: 'DJ MONSTER' },
+    };
+
+    expect(response.on_air).toEqual({ dj_name: 'DJ MONSTER' });
+    expect(response.on_air?.dj_name).toBe('DJ MONSTER');
+  });
+
+  it('should allow on_air to be null for automation', () => {
+    const response: FlowsheetV2PaginatedResponse = {
+      entries: [sampleTrack],
+      ...paginationFields,
+      on_air: null,
+    };
+
+    expect(response.on_air).toBeNull();
+  });
+
+  it('should allow on_air to be absent for unknown on-air status', () => {
+    const response: FlowsheetV2PaginatedResponse = {
+      entries: [sampleTrack],
+      ...paginationFields,
+    };
+
+    expect(response.on_air).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Closes #208

## What

Adds an optional, nullable `on_air` field to `FlowsheetV2PaginatedResponse` in the API SSOT, plus a minimal `OnAirInfo { dj_name }` schema, so clients can render the current on-air DJ without scanning the fetched entry window for a `show_start` marker.

Three-state, distinguished by presence:
- `OnAirInfo` object → a named DJ is live
- JSON `null` → confirmed automation ("Auto DJ")
- **absent** (not in `required`) → server doesn't report on-air status; treat as unknown

A new `OnAirInfo` type is used rather than `OnAirDJ`, which requires a numeric `id` that legacy/tubafrenzy-mirrored shows lack.

Includes the `chore(release): @wxyc/shared v1.18.0` bump (additive, non-breaking minor). Publishing happens when the `v1.18.0` tag is pushed after merge.

## Test plan

- `npm run check:breaking` — clean (oasdiff: no breaking changes)
- `npm run lint`, `npm run build` — pass
- `npm test` — 508/508 pass, including 3 new tri-state type tests on `FlowsheetV2PaginatedResponse.on_air`

## Related (cross-repo on-air banner fix)

- Backend-Service emits `on_air`: WXYC/Backend-Service#1546
- iOS consumes `on_air`, tri-state banner: WXYC/wxyc-ios-64#421
