### PR TITLE
fix(flowsheet): type OnAirDJ.id as a nullable string (v2.0.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -917,9 +917,9 @@ components:
       required:
         - dj_name
       description: >-
-        Minimal on-air DJ shape for the `on_air` field. Deliberately separate from
-        `OnAirDJ`, which requires a numeric `id` that legacy/tubafrenzy-mirrored
-        shows lack (their identity is a `legacy_dj_name` string with no user row).
+        Minimal, name-only on-air DJ shape for the `on_air` field. Deliberately
+        separate from `OnAirDJ`, which additionally carries an `id` (a nullable
+        `auth_user.id` string) that the `on_air` banner has no use for.
       properties:
         dj_name:
           type: string
@@ -932,7 +932,15 @@ components:
         - dj_name
       properties:
         id:
-          type: integer
+          type: string
+          nullable: true
+          description: >-
+            The DJ's better-auth `auth_user.id` (an opaque `varchar(255)`
+            string), or `null` for a legacy/tubafrenzy-mirrored show whose on-air
+            DJ has no Backend-Service account (their identity is `legacy_dj_name`,
+            surfaced on `/flowsheet/djs-on-air` with a null id). Historically
+            mistyped as `integer`; corrected to the nullable string it is at
+            runtime (BS#1547).
         dj_name:
           type: string
 

--- a/e2e/types/generated-types.test.ts
+++ b/e2e/types/generated-types.test.ts
@@ -211,7 +211,9 @@ describe('Generated Type Parsing (E2E)', () => {
       expect(Array.isArray(response.body)).toBe(true);
 
       for (const dj of response.body) {
-        expect(typeof dj.id).toBe('number');
+        // id is the better-auth auth_user.id string for account DJs, or null for
+        // legacy/tubafrenzy-mirrored shows with no account (BS#1547) — not a number.
+        expect(typeof dj.id === 'string' || dj.id === null).toBe(true);
         expect(typeof dj.dj_name).toBe('string');
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.18.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "1.18.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "1.18.0",
+  "version": "2.0.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -135,7 +135,7 @@ export const testFlowsheetSongEntry: FlowsheetSongEntry = {
 };
 
 export const testOnAirDJ: OnAirDJ = {
-  id: 1,
+  id: 'wk3n2f8s0qz1', // better-auth auth_user.id (varchar), not an integer
   dj_name: 'DJ Test',
 };
 

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -108,6 +108,27 @@ describe('OpenAPI Specification', () => {
       expect(spec.components.schemas.OnAirStatusResponse).toBeDefined();
     });
 
+    // OnAirDJ.id is the better-auth `auth_user.id` (a varchar(255) string) at
+    // runtime, and legacy/tubafrenzy-mirrored shows have no user account at all
+    // (their DJ surfaces on /flowsheet/djs-on-air with a null id). The schema is
+    // typed accordingly: a nullable string, not the historically-wrong integer.
+    describe('OnAirDJ.id (BS#1547)', () => {
+      function onAirDjId(): Record<string, unknown> {
+        const schema = spec.components.schemas.OnAirDJ as {
+          properties: Record<string, Record<string, unknown>>;
+        };
+        return schema.properties.id;
+      }
+
+      it('is a string, not an integer', () => {
+        expect(onAirDjId().type).toBe('string');
+      });
+
+      it('is nullable (legacy DJs have no user account id)', () => {
+        expect(onAirDjId().nullable).toBe(true);
+      });
+    });
+
     describe('track_position field (catalog-track-search Track 3 / E6)', () => {
       function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
         const schema = spec.components.schemas[schemaName] as

--- a/tests/v2-flowsheet.test.ts
+++ b/tests/v2-flowsheet.test.ts
@@ -19,6 +19,7 @@ import {
   type FlowsheetV2BreakpointEntry,
   type FlowsheetV2MessageEntry,
   type FlowsheetV2PaginatedResponse,
+  type OnAirDJ,
   RotationBin,
 } from '../src/generated/models/index.js';
 import {
@@ -381,5 +382,22 @@ describe('FlowsheetV2PaginatedResponse', () => {
     };
 
     expect(response.on_air).toBeUndefined();
+  });
+});
+
+// OnAirDJ backs GET /flowsheet/djs-on-air. Its `id` is the better-auth
+// `auth_user.id` (a string) for account DJs, and `null` for legacy/tubafrenzy
+// shows whose on-air DJ has no user account (BS#1547). The annotations document
+// the accepted shapes; the enforced compile-time coupling lives in
+// src/test-utils/fixtures.ts (`testOnAirDJ`, which tsc type-checks under src/).
+describe('OnAirDJ.id shape (BS#1547)', () => {
+  it('accepts a string id for an account DJ', () => {
+    const dj: OnAirDJ = { id: 'wk3n2f8s0qz1', dj_name: 'DJ HOUNDSTOOTH' };
+    expect(dj.id).toBe('wk3n2f8s0qz1');
+  });
+
+  it('accepts a null id for a legacy/tubafrenzy DJ', () => {
+    const dj: OnAirDJ = { id: null, dj_name: 'DJ MONSTER' };
+    expect(dj.id).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #210

## What

Corrects `OnAirDJ.id` in the API SSOT from `integer` to a nullable `string`, aligning the contract with reality: it is the better-auth `auth_user.id` (a `varchar(255)` string) for account DJs, and `null` for legacy/tubafrenzy-mirrored shows whose on-air DJ has no Backend-Service account. The change flows to every `$ref` of `OnAirDJ` (`/flowsheet/djs-on-air`, `OnAirStatusResponse.djs`, `ShowPlaylist.show_djs`). Also narrows the now-stale `OnAirInfo` docstring — it is separate from `OnAirDJ` because it is name-only, not because `OnAirDJ`'s id was numeric.

Ships the `v2.0.0` major bump. This is a **breaking** response-type correction per oasdiff (`response-property-type-changed` + `response-property-became-nullable`), so the "Breaking Change Check" going red is expected and acknowledged. Fan-out is nil: no repo imports the generated `OnAirDJ` type (dj-site and Backend-Service both hand-write it; dj-site already as `id: string`). Publishing happens when the `v2.0.0` tag is pushed after merge.

## Test plan

- `npm test` — 512/512 (new: api-spec asserts `OnAirDJ.id` is string + nullable; generated-type shape tests accept both a string id and a null id)
- `npm run lint`, `npm run build` — pass
- `npm run check:breaking` — reports only the intended breaking changes (the acknowledged major)

## Related (cross-repo on-air fix)

- Backend-Service returns legacy DJs with a null id: WXYC/Backend-Service#1547
- dj-site widens OnAirDJResponse.id: WXYC/dj-site#828
