### PR TITLE
feat(api): Concert/Venue schemas + GET /concerts (Touring Soon, BS#1603)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6368,6 +6368,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '403':
+          description: >
+            Forbidden — the session is banned or the bearer token carries no
+            `sub` claim (auth middleware gate).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
 
   /metadata/album:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.14.0
+  version: 1.15.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -1989,6 +1989,155 @@ components:
         expires_at:
           type: string
           format: date-time
+
+    # ===================
+    # Concerts / Touring Events Types (Backend-Service#1603)
+    # ===================
+
+    Venue:
+      type: object
+      description: |
+        A live-music venue whose calendar WXYC ingests (Backend-Service
+        `venues` table). Embedded whole in `Concert` — the venue set is tiny
+        (~21 rows), so clients get name/city in one call with no follow-up
+        join.
+      required:
+        - id
+        - slug
+        - name
+        - city
+        - state
+        - address
+      properties:
+        id:
+          type: integer
+        slug:
+          type: string
+          description: Stable scraper seed key (e.g. "cats-cradle").
+        name:
+          type: string
+        city:
+          type: string
+        state:
+          type: string
+        address:
+          type: string
+          nullable: true
+
+    ConcertStatus:
+      type: string
+      description: >-
+        Lifecycle state of a concert as observed at the source. Listener
+        surfaces read this to grey out / strike through cancelled or
+        sold-out shows.
+      enum:
+        - on_sale
+        - sold_out
+        - cancelled
+        - rescheduled
+
+    Concert:
+      type: object
+      description: |
+        One upcoming (or recent) concert, as served by `GET /concerts`.
+
+        Date semantics: `starts_on` is the venue-local (America/New_York)
+        calendar date and is always present — clients should window and sort
+        on it. `starts_at` is the exact start instant and is null for
+        date-only events (many sources publish no start time; WXYC never
+        fabricates one).
+
+        Internal ingestion columns (`source`, `source_id`, `raw_data`,
+        `scraped_at`, `first_scraped_at`) are deliberately not exposed.
+      required:
+        - id
+        - venue
+        - starts_on
+        - starts_at
+        - doors_at
+        - headlining_artist_raw
+        - headlining_artist_id
+        - title
+        - supporting_artists_raw
+        - ticket_url
+        - image_url
+        - price_min
+        - price_max
+        - age_restriction
+        - status
+      properties:
+        id:
+          type: integer
+        venue:
+          $ref: '#/components/schemas/Venue'
+        starts_on:
+          type: string
+          format: date
+          description: Venue-local (America/New_York) calendar date.
+        starts_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Exact start instant; null for date-only events.
+        doors_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Doors-open instant, when the source publishes one.
+        headlining_artist_raw:
+          type: string
+          description: Headliner billing string exactly as the source displays it.
+        headlining_artist_id:
+          type: integer
+          nullable: true
+          description: >-
+            WXYC catalog artist id when the resolver matched the headliner;
+            null otherwise. A non-null id is what `curated=true` filters on.
+        title:
+          type: string
+          nullable: true
+          description: >-
+            Event name as the source displays it, when distinct from the
+            artist billing.
+        supporting_artists_raw:
+          type: array
+          items:
+            type: string
+          description: Supporting-act billing strings, in source order.
+        ticket_url:
+          type: string
+          nullable: true
+        image_url:
+          type: string
+          nullable: true
+        price_min:
+          type: number
+          nullable: true
+          description: Dollars. Free events carry price_min = 0.
+        price_max:
+          type: number
+          nullable: true
+          description: Dollars.
+        age_restriction:
+          type: string
+          nullable: true
+          description: Source-displayed age restriction (e.g. "18+", "All Ages").
+        status:
+          $ref: '#/components/schemas/ConcertStatus'
+
+    ConcertsResponse:
+      type: object
+      description: Paginated list of concerts, ordered by `starts_on` ascending.
+      required:
+        - concerts
+        - pagination
+      properties:
+        concerts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Concert'
+        pagination:
+          $ref: '#/components/schemas/PaginationInfo'
 
     # ===================
     # Device Authorization (RFC 8628) — issue #195
@@ -6145,6 +6294,80 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SongRequest'
+
+  # ===================
+  # Concerts Endpoints (Backend-Service#1603)
+  # ===================
+
+  /concerts:
+    get:
+      summary: List upcoming concerts (Touring Soon feed)
+      description: |
+        Returns upcoming non-removed concerts, windowed on the venue-local
+        calendar date `starts_on` (never on the nullable `starts_at` — range
+        predicates on the instant would silently drop date-only events),
+        ordered by `starts_on` ascending, paginated.
+
+        `curated=true` narrows to concerts whose headliner resolved to a
+        WXYC catalog artist. Requires anonymous session auth, matching the
+        other iOS read surfaces.
+      parameters:
+        - name: curated
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            When true, return only concerts whose headliner resolved to a
+            WXYC catalog artist (`headlining_artist_id` non-null).
+        - name: from
+          in: query
+          schema:
+            type: string
+            format: date
+          description: >-
+            Window start (inclusive) on `starts_on`. Defaults to today
+            (venue-local calendar date).
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Window end (inclusive) on `starts_on`. Defaults to unbounded.
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-indexed, per PaginationParams).
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Page size (per PaginationParams).
+      responses:
+        '200':
+          description: Paginated list of upcoming concerts ordered by starts_on.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConcertsResponse'
+        '400':
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
 
   /metadata/album:
     get:

--- a/tests/concerts.test.ts
+++ b/tests/concerts.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for Concerts / Touring Events Types (Backend-Service#1603)
+ *
+ * Validates:
+ * - api.yaml defines the Venue / Concert / ConcertStatus / ConcertsResponse
+ *   schemas and the GET /concerts operation with its query params
+ * - Generated types accept valid object literals, including the date-only
+ *   case (`starts_at: null` with `starts_on` present) that the endpoint's
+ *   windowing contract is built around
+ * - Internal ingestion columns are not part of the Concert schema
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { parse } from 'yaml';
+import { join } from 'path';
+import {
+  ConcertStatus,
+  type Concert,
+  type ConcertsResponse,
+  type Venue,
+} from '../src/generated/models/index.js';
+
+interface OpenAPISpec {
+  components: { schemas: Record<string, any> };
+  paths: Record<string, any>;
+}
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+const sampleVenue: Venue = {
+  id: 3,
+  slug: 'cats-cradle',
+  name: "Cat's Cradle",
+  city: 'Carrboro',
+  state: 'NC',
+  address: '300 E Main St, Carrboro, NC 27510',
+};
+
+// Timed event: starts_at present, starts_on derived from it by the DB trigger.
+const sampleTimedConcert: Concert = {
+  id: 101,
+  venue: sampleVenue,
+  starts_on: '2026-08-14',
+  starts_at: '2026-08-15T00:00:00.000Z',
+  doors_at: '2026-08-14T23:00:00.000Z',
+  headlining_artist_raw: 'Nilüfer Yanya',
+  headlining_artist_id: 4211,
+  title: null,
+  supporting_artists_raw: ['Hermanos Gutiérrez'],
+  ticket_url: 'https://catscradle.com/event/nilufer-yanya/',
+  image_url: 'https://catscradle.com/img/nilufer-yanya.jpg',
+  price_min: 25,
+  price_max: 28,
+  age_restriction: 'All Ages',
+  status: 'on_sale',
+};
+
+// Date-only event: starts_at is null; only the calendar date is known.
+// This is the shape range predicates on starts_at would silently drop.
+const sampleDateOnlyConcert: Concert = {
+  id: 102,
+  venue: { ...sampleVenue, id: 7, slug: 'local-506', name: 'Local 506', address: null },
+  starts_on: '2026-09-01',
+  starts_at: null,
+  doors_at: null,
+  headlining_artist_raw: 'Csillagrablók',
+  headlining_artist_id: null,
+  title: 'Csillagrablók with special guests',
+  supporting_artists_raw: [],
+  ticket_url: null,
+  image_url: null,
+  price_min: null,
+  price_max: null,
+  age_restriction: null,
+  status: 'on_sale',
+};
+
+// =============================================================================
+// Generated types
+// =============================================================================
+
+describe('Concert generated types', () => {
+  it('accepts a fully-populated timed concert', () => {
+    expect(sampleTimedConcert.starts_at).not.toBeNull();
+    expect(sampleTimedConcert.venue.slug).toBe('cats-cradle');
+  });
+
+  it('accepts a date-only concert (null starts_at, starts_on present)', () => {
+    expect(sampleDateOnlyConcert.starts_at).toBeNull();
+    expect(sampleDateOnlyConcert.starts_on).toBe('2026-09-01');
+  });
+
+  it('exposes ConcertStatus as a const object with the four lifecycle states', () => {
+    expect(Object.values(ConcertStatus).sort()).toEqual(
+      ['cancelled', 'on_sale', 'rescheduled', 'sold_out'].sort()
+    );
+  });
+
+  it('composes ConcertsResponse from concerts + PaginationInfo', () => {
+    const response: ConcertsResponse = {
+      concerts: [sampleTimedConcert, sampleDateOnlyConcert],
+      pagination: { page: 1, limit: 50, total: 2, hasMore: false },
+    };
+    expect(response.concerts).toHaveLength(2);
+    expect(response.pagination.page).toBe(1);
+  });
+});
+
+// =============================================================================
+// api.yaml spec shape
+// =============================================================================
+
+describe('Concerts in api.yaml', () => {
+  let spec: OpenAPISpec;
+
+  beforeAll(() => {
+    const specPath = join(__dirname, '..', 'api.yaml');
+    spec = parse(readFileSync(specPath, 'utf-8')) as OpenAPISpec;
+  });
+
+  it('defines Venue, Concert, ConcertStatus, and ConcertsResponse schemas', () => {
+    for (const name of ['Venue', 'Concert', 'ConcertStatus', 'ConcertsResponse']) {
+      expect(spec.components.schemas[name], `schema ${name}`).toBeDefined();
+    }
+  });
+
+  it('requires starts_on but marks starts_at nullable on Concert', () => {
+    const concert = spec.components.schemas.Concert;
+    expect(concert.required).toContain('starts_on');
+    expect(concert.properties.starts_on.format).toBe('date');
+    expect(concert.properties.starts_at.nullable).toBe(true);
+    expect(concert.properties.starts_at.format).toBe('date-time');
+  });
+
+  it('embeds the full Venue object in Concert (not a venue_id)', () => {
+    const concert = spec.components.schemas.Concert;
+    expect(concert.properties.venue.$ref).toBe('#/components/schemas/Venue');
+    expect(concert.properties.venue_id).toBeUndefined();
+  });
+
+  it('does not expose internal ingestion columns', () => {
+    const concert = spec.components.schemas.Concert;
+    for (const internal of ['raw_data', 'source', 'source_id', 'scraped_at', 'first_scraped_at']) {
+      expect(concert.properties[internal], `internal column ${internal}`).toBeUndefined();
+    }
+  });
+
+  it('defines GET /concerts with curated, from/to window, and page/limit params', () => {
+    const operation = spec.paths['/concerts']?.get;
+    expect(operation).toBeDefined();
+    const params = new Map(
+      (operation.parameters as Array<{ name: string; in: string; schema: any }>).map((p) => [
+        p.name,
+        p,
+      ])
+    );
+    expect(params.get('curated')?.schema.type).toBe('boolean');
+    expect(params.get('from')?.schema.format).toBe('date');
+    expect(params.get('to')?.schema.format).toBe('date');
+    expect(params.get('page')?.schema.minimum).toBe(1);
+    expect(params.get('limit')?.schema.maximum).toBe(100);
+    for (const p of params.values()) {
+      expect(p.in).toBe('query');
+    }
+  });
+
+  it('responds with ConcertsResponse and keeps the global BearerAuth security', () => {
+    const operation = spec.paths['/concerts']?.get;
+    expect(operation.responses['200'].content['application/json'].schema.$ref).toBe(
+      '#/components/schemas/ConcertsResponse'
+    );
+    // No `security: []` opt-out — anonymous-session bearer auth, like /proxy.
+    expect(operation.security).toBeUndefined();
+  });
+});


### PR DESCRIPTION


---

**Consumer PR:** WXYC/Backend-Service#1606 (the `GET /concerts` endpoint) reads these types. It is not draft-blocked on this PR publishing — it ships local DTO aliases mirroring these schemas and swaps to the codegen imports once `@wxyc/shared` 1.15.0 publishes.


## Review fixes

- **Undeclared 403 on `GET /concerts`.** The operation declared only 200/400/401, but the consuming auth middleware can return 403 (banned session, or a bearer token missing its `sub` claim). Added a 403 response referencing `ApiErrorResponse`. Additive change: `api.yaml` stays at **1.15.0**, `check:breaking` reports **no breaking changes**, and codegen was re-run (`generate:typescript`) — the generated TS type surface is unchanged because the 403 reuses the existing `ApiErrorResponse` schema, so only the operation's response-code set moved. `vitest` (528 tests), lint, and build all pass.
