### PR TITLE
Add event_url to the Concert schema (1.17.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.16.0
+  version: 1.17.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -2093,6 +2093,7 @@ components:
         - supporting_artists_raw
         - ticket_url
         - image_url
+        - event_url
         - price_min
         - price_max
         - age_restriction
@@ -2142,6 +2143,13 @@ components:
         image_url:
           type: string
           nullable: true
+        event_url:
+          type: string
+          nullable: true
+          description: >-
+            The venue's own event-detail page, distinct from `ticket_url`
+            (often a third-party seller like Etix/Ticketmaster). Null when no
+            venue page is known; clients fall back to `ticket_url`.
         price_min:
           type: number
           nullable: true


### PR DESCRIPTION
## Summary

Adds `event_url` to the `Concert` response schema — the venue's own event-detail page, distinct from `ticket_url` (often a third-party seller like Etix/Ticketmaster). Modeled `required` + `nullable`, matching the `ticket_url`/`image_url` sibling convention (`type: string`, `nullable: true`, **no `format`**), so the backend always emits the key with `null` when no venue page is known and clients fall back to `ticket_url`.

This is the cross-repo SSOT half of the touring-events event-url work: it restores the venue-page target the iOS Box Office CTA lost when its DTO was reshaped onto `Concert` (the old `UpcomingShow` DTO's `source_url`). Once shipped, iOS sets `ctaURL = event_url ?? ticket_url` and the "See Venue Page" copy matches the tap again.

## Details

- `Concert.event_url`: `type: string`, `nullable: true`, added to the schema's `required` list, no `format`.
- Version bump `1.16.0 → 1.17.0` (minor; additive).
- `check:breaking` / `oasdiff`: **no breaking changes** — adding a required property to a response is non-breaking, and nothing consuming `Concert` has shipped yet.
- TypeScript codegen regenerated cleanly (`event_url: string | null` in `src/generated/`); build + 528 tests pass. The Python/Swift/Kotlin trees are gitignored reference-only outputs (not committed here, per repo convention).

## Consumers

- Backend projection + both scraper writers + migration: WXYC/Backend-Service#1610 (closes WXYC/Backend-Service#1609).
- iOS unblocked: WXYC/wxyc-ios-64#472 / #475 (the `Concert` DTO whose `ctaURL` lost the venue-page fallback) and #476 (CTA copy vs target mismatch).

Part of WXYC/Backend-Service#1609.
