### PR TITLE
feat(api): bulk bare-name artist resolution — POST /api/v1/artists/resolve/bulk (1.18.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.17.0
+  version: 1.18.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3842,6 +3842,178 @@ components:
           $ref: '#/components/schemas/CacheStats'
 
     # ====================================
+    # Bulk bare-name artist resolution (LML#759)
+    # ====================================
+    # Schemas for `POST /api/v1/artists/resolve/bulk` (consumer:
+    # WXYC/Backend-Service#1614 concerts pipeline). The verify-before-mint
+    # resolution model is documented once, on the path description.
+
+    ArtistResolveMethod:
+      type: string
+      description: >
+        What decided a resolved verdict. `identity_store` — a pre-existing
+        `entity.identity` row short-circuited resolution (unverified: the
+        store's resolved-at-most-once promise). `api_search` — a
+        single-page live Discogs API artist search returned exactly one
+        artist whose normalized identity-match form equals the input's,
+        with no equality-leg cache conflict. Cache legs never decide;
+        their evidence appears in `cache_corroboration`.
+      enum:
+        - identity_store
+        - api_search
+
+    ArtistResolveCacheLeg:
+      type: string
+      description: >
+        A discogs-cache candidate-generation leg that produced at least
+        one candidate for the input name. Mirrors the entity-resolution
+        reconciler cascade's legs (exact / member / alias / name-variation
+        / trigram — the cascade subset of `IdentityMethod`), but as
+        candidate sets used for corroboration and conflict detection —
+        never as verdicts. The four equality legs can veto a mint into
+        `ambiguous`; fuzzy `cache_trigram` neighbors never veto.
+      enum:
+        - cache_exact
+        - cache_member
+        - cache_alias
+        - cache_name_variation
+        - cache_trigram
+
+    ArtistResolveUnresolvedReason:
+      type: string
+      description: >
+        Why a name did not resolve. `not_found` — the API tier ran and
+        observed zero exact-form candidates on its single search page
+        (terminal in v1; a search observation, not proof no such artist
+        exists — cache legs, including `cache_exact`, may still
+        show yield in `cache_corroboration`). `ambiguous` — two or
+        more exact-form Discogs artists (including "(N)" disambiguation
+        families, which normalize to the same form), or an equality-leg
+        cache candidate (exact / member / alias / name-variation — never a
+        fuzzy `cache_trigram` neighbor) pointing at a different artist id
+        than the API's single candidate; ambiguous names never mint
+        (terminal). `escalation_unavailable` — the Discogs API tier
+        was shed (saturation breaker open, outage cool-down, 429, or 5xx
+        after retries). This is the RETRYABLE verdict: it means "couldn't
+        ask," not "asked and missed" — consumers must not apply a no-match
+        TTL to it.
+      enum:
+        - not_found
+        - ambiguous
+        - escalation_unavailable
+
+    ArtistResolveResult:
+      type: object
+      description: >
+        Verdict for one input name, index-aligned with
+        `ArtistResolveBulkRequest.names`. Exactly one of
+        `discogs_artist_id` (resolved, with `method`) or
+        `unresolved_reason` is present.
+      required:
+        - name
+        - cache_corroboration
+      properties:
+        name:
+          type: string
+          description: Verbatim echo of the input name at this index.
+        discogs_artist_id:
+          type: integer
+          description: The resolved Discogs artist id. Present iff resolved.
+        canonical_name:
+          type: string
+          description: >
+            The raw Discogs artist title, disambiguation suffix included
+            (e.g. `Popsicle (2)`) — the true Discogs string, kept for
+            provenance; callers render their own input name. Present iff
+            resolved via `api_search`: `entity.identity` rows store no
+            Discogs title, so `identity_store` resolutions omit it.
+        method:
+          allOf:
+            - $ref: '#/components/schemas/ArtistResolveMethod'
+          description: >
+            What decided the resolution. Present iff resolved.
+        cache_corroboration:
+          type: array
+          uniqueItems: true
+          description: >
+            Cache legs that produced at least one candidate for this
+            name's identity-match form, on BOTH verdict kinds — the
+            per-leg yield telemetry sizing a possible v2 alias arm. On
+            resolved verdicts, listed equality legs necessarily agreed
+            with the deciding tier (a disagreeing equality leg forces
+            `ambiguous`), while `cache_trigram` entries are fuzzy
+            near-misses that never veto. Empty when no leg produced
+            candidates, and always empty on `identity_store`
+            short-circuits — the store decides before cache evidence is
+            consulted, and implementations report an empty array there.
+          items:
+            $ref: '#/components/schemas/ArtistResolveCacheLeg'
+        unresolved_reason:
+          allOf:
+            - $ref: '#/components/schemas/ArtistResolveUnresolvedReason'
+          description: >
+            Why the name did not resolve. Present iff unresolved.
+        # Not in `required`: datamodel-codegen's default flags (what LML
+        # generates models with) type a required-plus-nullable field as
+        # non-nullable, rejecting the null this field must carry. The
+        # description pins the always-serialized wire promise instead.
+        candidate_count:
+          type: integer
+          nullable: true
+          description: >
+            Exact-form candidates the API tier observed: 1 on resolved via
+            `api_search`, 0 on not_found; on ambiguous, >= 2 for an
+            overloaded family, or exactly 1 when the ambiguity is an
+            equality-leg cache conflict.
+            Always serialized — never omitted; null when the API tier did
+            not run (identity_store short-circuit, escalation_unavailable)
+            — null means "not measured," never zero.
+
+    ArtistResolveBulkRequest:
+      type: object
+      required:
+        - names
+      properties:
+        names:
+          type: array
+          description: >
+            Bare artist names to resolve, verbatim. Inputs are deduplicated
+            internally on their normalized identity-match form: duplicate
+            positions receive the shared verdict, and only the first
+            occurrence's verbatim string mints.
+          minItems: 1
+          maxItems: 25
+          # Codegen note: the item bounds make datamodel-codegen wrap
+          # items in a `Name` RootModel (`names: list[Name]`, not
+          # `list[str]`) — LML must unwrap `.root` at the route boundary;
+          # a naive str() renders "root='...'" and would mint garbage
+          # entity.identity keys.
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
+        dry_run:
+          type: boolean
+          default: false
+          description: >
+            Run every tier identically — including live Discogs API
+            verification — but skip the `entity.identity` write-back. No
+            partial-write mode.
+
+    ArtistResolveBulkResponse:
+      type: object
+      description: >
+        Response to `POST /api/v1/artists/resolve/bulk`. `results` is
+        index-aligned with the request's `names`.
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArtistResolveResult'
+
+    # ====================================
     # Cache refresh for identities (LML#525)
     # ====================================
     # `POST /api/v1/cache/refresh-for-identities` is the source-agnostic
@@ -6673,6 +6845,90 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
         '422':
           description: Validation error (per-input field validation failed).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
+  /api/v1/artists/resolve/bulk:
+    post:
+      summary: Bulk-resolve bare artist names to Discogs artist identities.
+      description: >
+        Resolves bare artist names — typically touring artists absent from
+        the WXYC library (consumer: WXYC/Backend-Service#1614 concerts
+        pipeline) — to Discogs artist identities, minting `entity.identity`
+        rows for verified matches. Verify-before-mint (LML#759): per name,
+        (1) `entity.identity` read (true short-circuit), (2) discogs-cache
+        candidate generation (corroboration only — the cache is a
+        pair-wise-filtered sample of Discogs, so a cache hit is not
+        evidence of global uniqueness), (3) a single-page live Discogs API
+        artist search (per_page=100) filtered to results whose normalized
+        identity-match form equals the input's. Exactly one exact-form API
+        candidate with no equality-leg cache conflict resolves and mints
+        (keyed on the verbatim input name, `discogs_artist_id` only,
+        never-clobber). Two or more exact-form candidates, or an
+        equality-leg cache conflict, return `ambiguous` and mint nothing —
+        no guessing. The PG tiers run as a batched pre-pass for the whole
+        request before the serial API leg, so when the API tier is shed
+        (LML#755 saturation breaker open, outage cool-down, 429, 5xx after
+        retries) only names still awaiting API verification return the
+        retryable `escalation_unavailable` instead of `not_found` —
+        identity-store resolutions and cache evidence are unaffected by a
+        mid-batch trip, and shed positions need not be a contiguous suffix
+        of `results`. The 25-name cap keeps a fully-escalating batch
+        within the shared Discogs API budget (~25 live calls, ~30s at
+        50/min); callers page. `dry_run: true` runs every tier identically
+        but skips the write-back. Mirrors `bulk-resolve-libraries` /
+        `search-aliases/bulk` for auth + 413 semantics.
+      operationId: artistResolveBulk
+      security:
+        - LMLBearerAuth: []
+      tags:
+        - lookup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArtistResolveBulkRequest'
+      responses:
+        '200':
+          description: One verdict per input name, in input order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtistResolveBulkResponse'
+        '400':
+          description: Malformed request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '401':
+          description: Missing or invalid `LML_API_KEY` bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '413':
+          description: Batch exceeded the 25-name cap.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '422':
+          description: Validation error (per-input field validation failed).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: >
+            The backing discogs-cache PostgreSQL is unavailable —
+            `DATABASE_URL_DISCOGS` unset, connection failure, or a
+            required probe (entity store or cache tables) failed. Never
+            caused by Discogs API saturation, which sheds per-name as
+            `escalation_unavailable`.
           content:
             application/json:
               schema:

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -1230,6 +1230,164 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  describe('Bulk Artist Resolution Schemas (LML#759)', () => {
+    it('should define ArtistResolveMethod with the two deciding tiers only', () => {
+      // Cache legs never decide a resolution — they corroborate. The enum
+      // therefore has exactly two values; cache evidence lives in
+      // cache_corroboration instead.
+      const schema = spec.components.schemas.ArtistResolveMethod as { enum?: string[] };
+      expect(schema).toBeDefined();
+      expect(schema.enum).toEqual(['identity_store', 'api_search']);
+    });
+
+    it('should define ArtistResolveCacheLeg mirroring the reconciler cascade legs', () => {
+      const schema = spec.components.schemas.ArtistResolveCacheLeg as { enum?: string[] };
+      expect(schema).toBeDefined();
+      expect(schema.enum).toEqual([
+        'cache_exact',
+        'cache_member',
+        'cache_alias',
+        'cache_name_variation',
+        'cache_trigram',
+      ]);
+    });
+
+    it('should define ArtistResolveUnresolvedReason with a retryable escalation_unavailable', () => {
+      // escalation_unavailable means "couldn't ask," not "asked and missed" —
+      // consumers must not apply a no-match TTL to it (BS#1614's writer).
+      const schema = spec.components.schemas.ArtistResolveUnresolvedReason as { enum?: string[] };
+      expect(schema).toBeDefined();
+      expect(schema.enum).toEqual(['not_found', 'ambiguous', 'escalation_unavailable']);
+    });
+
+    it('should define ArtistResolveResult requiring name + cache_corroboration', () => {
+      const schema = spec.components.schemas.ArtistResolveResult as {
+        type: string;
+        required: string[];
+        properties: Record<
+          string,
+          {
+            type?: string;
+            allOf?: Array<{ $ref?: string }>;
+            nullable?: boolean;
+            uniqueItems?: boolean;
+            items?: { $ref?: string };
+          }
+        >;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+      expect(schema.required).toEqual(['name', 'cache_corroboration']);
+      expect(schema.properties.name.type).toBe('string');
+      // Verdict fields are optional: exactly one of discogs_artist_id
+      // (resolved) or unresolved_reason (unresolved) appears per result.
+      // method and unresolved_reason are allOf-wrapped so their presence
+      // rules survive codegen ($ref sibling keys are dropped in 3.0).
+      expect(schema.properties.discogs_artist_id.type).toBe('integer');
+      expect(schema.properties.canonical_name.type).toBe('string');
+      expect(schema.properties.method.allOf?.[0]?.$ref).toBe(
+        '#/components/schemas/ArtistResolveMethod',
+      );
+      expect(schema.properties.unresolved_reason.allOf?.[0]?.$ref).toBe(
+        '#/components/schemas/ArtistResolveUnresolvedReason',
+      );
+      // cache_corroboration is present on BOTH verdict kinds (per-leg yield
+      // telemetry), so it is required — empty array when no leg matched. A
+      // leg either yielded or didn't, so entries are unique (and adding
+      // uniqueItems later would flip swift5 codegen Array→Set, a breaking
+      // change that is free to avoid now).
+      expect(schema.properties.cache_corroboration.type).toBe('array');
+      expect(schema.properties.cache_corroboration.uniqueItems).toBe(true);
+      expect(schema.properties.cache_corroboration.items?.$ref).toBe(
+        '#/components/schemas/ArtistResolveCacheLeg',
+      );
+      // candidate_count: always serialized per the description's wire pin;
+      // null means "API tier did not run," never zero. Optional-in-schema
+      // only because datamodel-codegen's default flags (LML's generator)
+      // would type required+nullable as non-nullable int, rejecting null.
+      expect(schema.properties.candidate_count.type).toBe('integer');
+      expect(schema.properties.candidate_count.nullable).toBe(true);
+    });
+
+    it('should define ArtistResolveBulkRequest with the 25-name cap and optional dry_run', () => {
+      const schema = spec.components.schemas.ArtistResolveBulkRequest as {
+        required: string[];
+        properties: Record<
+          string,
+          {
+            type?: string;
+            minItems?: number;
+            maxItems?: number;
+            items?: { type?: string; minLength?: number; maxLength?: number };
+            default?: boolean;
+          }
+        >;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.required).toEqual(['names']);
+      expect(schema.properties.names.type).toBe('array');
+      expect(schema.properties.names.minItems).toBe(1);
+      // 25, not 1000: a fully-escalating batch costs ~25 live Discogs API
+      // calls (~30s at the shared 50/min budget); callers page.
+      expect(schema.properties.names.maxItems).toBe(25);
+      // Per-item bounds: names feed live Discogs querystrings and verbatim
+      // entity.identity mint keys, so empty and unbounded strings are
+      // rejected at the contract.
+      expect(schema.properties.names.items?.type).toBe('string');
+      expect(schema.properties.names.items?.minLength).toBe(1);
+      expect(schema.properties.names.items?.maxLength).toBe(255);
+      expect(schema.properties.dry_run.type).toBe('boolean');
+      expect(schema.properties.dry_run.default).toBe(false);
+    });
+
+    it('should define ArtistResolveBulkResponse requiring index-aligned results', () => {
+      const schema = spec.components.schemas.ArtistResolveBulkResponse as {
+        required: string[];
+        properties: Record<string, { type?: string; items?: { $ref?: string } }>;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.required).toEqual(['results']);
+      expect(schema.properties.results.type).toBe('array');
+      expect(schema.properties.results.items?.$ref).toBe(
+        '#/components/schemas/ArtistResolveResult',
+      );
+    });
+
+    it('should define POST /api/v1/artists/resolve/bulk under LMLBearerAuth', () => {
+      const path = spec.paths['/api/v1/artists/resolve/bulk'] as {
+        post?: {
+          operationId?: string;
+          security?: Array<Record<string, unknown[]>>;
+          requestBody?: {
+            required?: boolean;
+            content?: Record<string, { schema?: { $ref?: string } }>;
+          };
+          responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }>;
+        };
+      };
+      expect(path).toBeDefined();
+      expect(path.post).toBeDefined();
+      expect(path.post!.operationId).toBe('artistResolveBulk');
+      expect(path.post!.security).toEqual([{ LMLBearerAuth: [] }]);
+      expect(path.post!.requestBody?.required).toBe(true);
+      expect(path.post!.requestBody?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/ArtistResolveBulkRequest',
+      );
+      expect(path.post!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/ArtistResolveBulkResponse',
+      );
+      // Full error contract: 400/401/413/422 mirror the sibling bulk
+      // endpoints; 503 means the backing discogs-cache PG is unavailable
+      // (Discogs saturation sheds per-name as escalation_unavailable,
+      // never a batch 503). Every error status carries ApiErrorResponse.
+      for (const status of ['400', '401', '413', '422', '503']) {
+        expect(path.post!.responses?.[status]?.content?.['application/json']?.schema?.$ref).toBe(
+          '#/components/schemas/ApiErrorResponse',
+        );
+      }
+    });
+  });
+
   describe('Security', () => {
     it('should define BearerAuth security scheme', () => {
       expect(spec.components.securitySchemes?.BearerAuth).toBeDefined();


### PR DESCRIPTION
Contract half of WXYC/library-metadata-lookup#759 — bulk bare-name artist resolution for the concerts pipeline (consumer: WXYC/Backend-Service#1614). Bumps `info.version` to 1.18.0.

## What

- New path `POST /api/v1/artists/resolve/bulk` under `LMLBearerAuth`, with the 200/400/401/413/422 response set mirroring `bulk-resolve-libraries` / `search-aliases/bulk`.
- New schemas: `ArtistResolveBulkRequest` (`names` 1–25, optional `dry_run` defaulting false), `ArtistResolveBulkResponse` (index-aligned `results`), `ArtistResolveResult`, and three enums — `ArtistResolveMethod` (`identity_store | api_search`), `ArtistResolveCacheLeg` (the five cascade legs), `ArtistResolveUnresolvedReason` (`not_found | ambiguous | escalation_unavailable`).

## Why this shape

The endpoint's resolution model is verify-before-mint (decided in the LML#759 design review): the discogs-cache is a pair-wise-filtered sample of Discogs, so cache hits corroborate but never decide — which is why `method` has exactly two values and cache evidence rides the separate required `cache_corroboration` array (present on both verdict kinds; it doubles as the per-leg yield telemetry sizing a possible v2 alias arm). `escalation_unavailable` is a first-class retryable verdict (breaker open / outage / 429 / 5xx-after-retries) so consumers don't no-match-TTL names LML never got to ask Discogs about. `candidate_count` is nullable with null-means-not-measured semantics — never zero-as-unknown. The 25-name cap keeps a fully-escalating batch within the shared 50/min Discogs budget; callers page.

## Tests

Spec guards in `tests/api-spec.test.ts` (TDD — written red first): the three enums pinned exactly, `ArtistResolveResult` requiring `name` + `cache_corroboration` with nullable `candidate_count`, the request's 1–25 bounds + optional `dry_run`, the response's index-aligned `results`, and the path under `LMLBearerAuth` with the 401/413 contract.

## Safety

- **oasdiff: no breaking changes** (`npm run check:breaking` — additive path + schemas only).
- Local CI parity green: `generate:typescript`, `build`, `lint`, `test` (536 passing).
- Verified `datamodel-codegen` (LML's generator) emits the six new classes cleanly — `names` gets `max_length=25`, which is what LML's model-introspected 413 gate reads.

This is **PR A** of the LML#759 delivery plan; LML's PR C (regenerated models + endpoint) depends on this being on `main` first (its regen-drift CI downloads `api.yaml` from this repo's main).
