### PR TITLE
fix(api): artist-resolve contract text — suffix-aware dedupe, stored-key mint exception, garbage-name 422 semantics

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -3855,7 +3855,7 @@ components:
         `entity.identity` row short-circuited resolution (unverified: the
         store's resolved-at-most-once promise). `api_search` — a
         single-page live Discogs API artist search returned exactly one
-        artist whose normalized identity-match form equals the input's,
+        artist whose fixed-point identity-match form equals the input's,
         whose own title qualifier matches the input's (a "(N)"-titled
         singleton answering a bare input — or vice versa — is family
         evidence, not a resolution), and with no equality-leg cache
@@ -3955,7 +3955,7 @@ components:
             `ambiguous`), while `cache_trigram` entries are fuzzy
             near-misses that never veto (`cache_trigram` is measured
             against the group's probe string — its lexicographically
-            least raw spelling — where the equality legs bind the
+            least sanitized spelling — where the equality legs bind the
             identity-match form). Empty when no leg produced candidates,
             and ALWAYS empty — the cache was never consulted, which is
             not a measured zero-yield — on (a) `identity_store`
@@ -6922,15 +6922,18 @@ paths:
         candidate generation (corroboration only — the cache is a
         pair-wise-filtered sample of Discogs, so a cache hit is not
         evidence of global uniqueness), (3) a single-page live Discogs API
-        artist search (per_page=100) filtered to results whose normalized
-        identity-match form equals the input's. Exactly one exact-form API
-        candidate — whose own title qualifier matches the input's — with
-        no equality-leg cache conflict resolves and mints
-        (`discogs_artist_id` only; keyed on the trimmed verbatim input
-        name, or on the stored key of a Discogs-id-less row the identity
-        read found — see `ArtistResolveBulkRequest.names`; the upsert
-        never overwrites a populated column with NULL, and LML#766 tracks
-        hardening the no-overwrite guarantee against concurrent writers).
+        artist search (per_page=100) filtered to results whose FIXED-POINT
+        identity-match form equals the input's (single-pass normalization
+        is a materially different algorithm: it would exclude
+        multi-qualified family members like "Sault (2) (UK)" from the
+        "sault" family). Exactly one exact-form API candidate — whose own
+        title qualifier matches the input's — with no equality-leg cache
+        conflict resolves and mints (`discogs_artist_id` only; keyed on
+        the group's lexicographically-least sanitized spelling, or on the
+        stored key of a Discogs-id-less row the identity read found — see
+        `ArtistResolveBulkRequest.names`; the upsert never overwrites a
+        populated column with NULL, and LML#766 tracks hardening the
+        no-overwrite guarantee against concurrent writers).
         Qualifier-bearing inputs ("Popsicle (2)") resolve but never mint,
         and skip the cache-evidence tier (stripped-form evidence cannot
         distinguish family members). Two or more exact-form candidates,
@@ -6938,13 +6941,15 @@ paths:
         rows within one group, or an
         equality-leg cache conflict, return `ambiguous` and mint nothing —
         no guessing. The PG tiers run as a batched pre-pass for the whole
-        request before the serial API leg, so when the API tier is shed
-        (LML#755 saturation breaker open, outage cool-down, 429, 5xx after
-        retries) only names still awaiting API verification return the
-        retryable `escalation_unavailable` instead of `not_found` —
-        identity-store resolutions and cache evidence are unaffected by a
-        mid-batch trip, and shed positions need not be a contiguous suffix
-        of `results`. The 25-name cap keeps a fully-escalating batch
+        request before the serial API leg. When a probe couldn't be
+        answered (see `ArtistResolveUnresolvedReason`), that name returns
+        the retryable `escalation_unavailable` instead of `not_found`;
+        only an LML#755 breaker trip additionally short-circuits the
+        REST of the batch's pending probes (a per-name 429/network
+        failure does not — the batch continues). Identity-store
+        resolutions and cache evidence are unaffected by a mid-batch
+        trip, and shed positions need not be a contiguous suffix of
+        `results`. The 25-name cap keeps a fully-escalating batch
         within the shared Discogs API budget (~25 live calls, ~30s at
         50/min); callers page. `dry_run: true` runs every tier identically
         but skips the write-back. Mirrors `bulk-resolve-libraries` /

--- a/api.yaml
+++ b/api.yaml
@@ -3978,9 +3978,20 @@ components:
           type: array
           description: >
             Bare artist names to resolve, verbatim. Inputs are deduplicated
-            internally on their normalized identity-match form: duplicate
-            positions receive the shared verdict, and only the first
-            occurrence's verbatim string mints.
+            internally on their normalized identity-match form PLUS any raw
+            trailing "(N)" disambiguator: duplicate positions receive the
+            shared verdict, but a Discogs-style suffixed name ("Popsicle
+            (2)") is its own work unit — it denotes a different artist than
+            the bare name and never inherits (or supplies) the bare form's
+            verdict. A verified mint is keyed on the first occurrence's
+            verbatim string, EXCEPT when the identity read found an
+            existing row for the name that lacks `discogs_artist_id` — the
+            mint then fills that row's stored key in place rather than
+            inserting a near-duplicate key; suffixed names never mint.
+            Names that are blank, contain U+0000 or unencodable code
+            points, or normalize to an empty identity-match form are
+            rejected with 422 — never given an in-band verdict (`not_found`
+            means the API tier ran and measured zero).
           minItems: 1
           maxItems: 25
           # Codegen note: the item bounds make datamodel-codegen wrap
@@ -6865,8 +6876,13 @@ paths:
         artist search (per_page=100) filtered to results whose normalized
         identity-match form equals the input's. Exactly one exact-form API
         candidate with no equality-leg cache conflict resolves and mints
-        (keyed on the verbatim input name, `discogs_artist_id` only,
-        never-clobber). Two or more exact-form candidates, or an
+        (`discogs_artist_id` only; keyed on the verbatim input name, or on
+        the stored key of a Discogs-id-less row the identity read found —
+        see `ArtistResolveBulkRequest.names`; the upsert never overwrites
+        a populated column with NULL, and LML#766 tracks hardening the
+        no-overwrite guarantee against concurrent writers). Raw
+        "(N)"-suffixed inputs resolve but never mint. Two or more
+        exact-form candidates, or an
         equality-leg cache conflict, return `ambiguous` and mint nothing —
         no guessing. The PG tiers run as a batched pre-pass for the whole
         request before the serial API leg, so when the API tier is shed
@@ -6917,7 +6933,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
         '422':
-          description: Validation error (per-input field validation failed).
+          description: >
+            Validation error — per-input field validation failed, or a
+            name is semantically unresolvable (blank, contains U+0000 or
+            unencodable code points, or normalizes to an empty
+            identity-match form). Garbage names are caller errors, never
+            in-band verdicts.
           content:
             application/json:
               schema:

--- a/api.yaml
+++ b/api.yaml
@@ -3964,10 +3964,16 @@ components:
             Exact-form candidates the API tier observed: 1 on resolved via
             `api_search`, 0 on not_found; on ambiguous, >= 2 for an
             overloaded family, or exactly 1 when the ambiguity is an
-            equality-leg cache conflict.
+            equality-leg cache conflict or a qualifier mismatch between
+            the lone candidate's own title and the input (a "(N)"-titled
+            singleton answering a bare input, or vice versa, is family
+            evidence — never a resolution).
             Always serialized — never omitted; null when the API tier did
-            not run (identity_store short-circuit, escalation_unavailable)
-            — null means "not measured," never zero.
+            not run: identity_store short-circuit,
+            escalation_unavailable, or an `ambiguous` verdict from
+            conflicting identity-store rows within one deduplicated group
+            (the store contradicting itself is doubt without a
+            measurement) — null means "not measured," never zero.
 
     ArtistResolveBulkRequest:
       type: object
@@ -3977,21 +3983,29 @@ components:
         names:
           type: array
           description: >
-            Bare artist names to resolve, verbatim. Inputs are deduplicated
-            internally on their normalized identity-match form PLUS any raw
-            trailing "(N)" disambiguator: duplicate positions receive the
-            shared verdict, but a Discogs-style suffixed name ("Popsicle
-            (2)") is its own work unit — it denotes a different artist than
-            the bare name and never inherits (or supplies) the bare form's
-            verdict. A verified mint is keyed on the first occurrence's
-            verbatim string, EXCEPT when the identity read found an
-            existing row for the name that lacks `discogs_artist_id` — the
-            mint then fills that row's stored key in place rather than
-            inserting a near-duplicate key; suffixed names never mint.
-            Names that are blank, contain U+0000 or unencodable code
-            points, or normalize to an empty identity-match form are
-            rejected with 422 — never given an in-band verdict (`not_found`
-            means the API tier ran and measured zero).
+            Bare artist names to resolve, verbatim (leading/trailing
+            whitespace is trimmed for all internal work; responses echo
+            the raw string). Inputs are deduplicated internally on their
+            normalized identity-match form PLUS any trailing
+            parenthesized/bracketed qualifier, detected on the
+            NFKC-folded lowercase name so width/case variants ("（２）")
+            key with their ASCII twins: duplicate positions receive the
+            shared verdict, but a qualified name ("Popsicle (2)",
+            "Popsicle [2]") is its own work unit — a Discogs-style
+            disambiguator denotes a different artist than the bare name,
+            so it never inherits (or supplies) the bare form's verdict,
+            and it resolves only when the API candidate's own title
+            carries the same qualifier. A verified mint is keyed on the
+            first occurrence's trimmed verbatim, EXCEPT when the identity
+            read found an existing row for the name that lacks
+            `discogs_artist_id` — the mint then fills that row's stored
+            key in place rather than inserting a near-duplicate key;
+            qualified names never mint. Names that are blank, contain
+            U+0000 or unencodable code points, normalize to an empty
+            identity-match form, or consist only of a trailing qualifier
+            ("(2)") are rejected with 422 — never given an in-band
+            verdict (`not_found` means the API tier ran and measured
+            zero).
           minItems: 1
           maxItems: 25
           # Codegen note: the item bounds make datamodel-codegen wrap
@@ -6875,14 +6889,18 @@ paths:
         evidence of global uniqueness), (3) a single-page live Discogs API
         artist search (per_page=100) filtered to results whose normalized
         identity-match form equals the input's. Exactly one exact-form API
-        candidate with no equality-leg cache conflict resolves and mints
-        (`discogs_artist_id` only; keyed on the verbatim input name, or on
-        the stored key of a Discogs-id-less row the identity read found —
-        see `ArtistResolveBulkRequest.names`; the upsert never overwrites
-        a populated column with NULL, and LML#766 tracks hardening the
-        no-overwrite guarantee against concurrent writers). Raw
-        "(N)"-suffixed inputs resolve but never mint. Two or more
-        exact-form candidates, or an
+        candidate — whose own title qualifier matches the input's — with
+        no equality-leg cache conflict resolves and mints
+        (`discogs_artist_id` only; keyed on the trimmed verbatim input
+        name, or on the stored key of a Discogs-id-less row the identity
+        read found — see `ArtistResolveBulkRequest.names`; the upsert
+        never overwrites a populated column with NULL, and LML#766 tracks
+        hardening the no-overwrite guarantee against concurrent writers).
+        Qualifier-bearing inputs ("Popsicle (2)") resolve but never mint,
+        and skip the cache-evidence tier (stripped-form evidence cannot
+        distinguish family members). Two or more exact-form candidates,
+        a winner-title qualifier mismatch, conflicting identity-store
+        rows within one group, or an
         equality-leg cache conflict, return `ambiguous` and mint nothing —
         no guessing. The PG tiers run as a batched pre-pass for the whole
         request before the serial API leg, so when the API tier is shed

--- a/api.yaml
+++ b/api.yaml
@@ -3929,9 +3929,14 @@ components:
           description: Verbatim echo of the input name at this index.
         discogs_artist_id:
           type: integer
-          description: The resolved Discogs artist id. Present iff resolved.
+          nullable: true
+          description: >
+            The resolved Discogs artist id. Non-null iff resolved
+            (serialized as an explicit null on unresolved verdicts — the
+            response never omits fields).
         canonical_name:
           type: string
+          nullable: true
           description: >
             The raw Discogs artist title, disambiguation suffix included
             (e.g. `Popsicle (2)`) — the true Discogs string, kept for
@@ -3941,8 +3946,10 @@ components:
         method:
           allOf:
             - $ref: '#/components/schemas/ArtistResolveMethod'
+          nullable: true
           description: >
-            What decided the resolution. Present iff resolved.
+            What decided the resolution. Non-null iff resolved
+            (serialized as an explicit null on unresolved verdicts).
         cache_corroboration:
           type: array
           uniqueItems: true
@@ -3969,8 +3976,12 @@ components:
         unresolved_reason:
           allOf:
             - $ref: '#/components/schemas/ArtistResolveUnresolvedReason'
+          nullable: true
           description: >
-            Why the name did not resolve. Present iff unresolved.
+            Why the name did not resolve. Non-null iff unresolved
+            (serialized as an explicit null on resolved verdicts). The
+            response carries every field explicitly — consumers must
+            treat null, not absence, as the "other kind" marker.
         # Not in `required`: datamodel-codegen's default flags (what LML
         # generates models with) type a required-plus-nullable field as
         # non-nullable, rejecting the null this field must carry. The
@@ -6979,7 +6990,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
         '401':
-          description: Missing or invalid `LML_API_KEY` bearer token.
+          description: Missing `Authorization` header.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '403':
+          description: >
+            Present but invalid or malformed `LML_API_KEY` bearer token
+            (wrong token, non-Bearer scheme). Distinct from 401 so
+            credential-rotation failures are distinguishable from a
+            consumer that never attached auth.
           content:
             application/json:
               schema:

--- a/api.yaml
+++ b/api.yaml
@@ -3973,7 +3973,9 @@ components:
             escalation_unavailable, or an `ambiguous` verdict from
             conflicting identity-store rows within one deduplicated group
             (the store contradicting itself is doubt without a
-            measurement) — null means "not measured," never zero.
+            measurement; such verdicts also carry an empty
+            `cache_corroboration` — the cache tier was never consulted)
+            — null means "not measured," never zero.
 
     ArtistResolveBulkRequest:
       type: object
@@ -3983,29 +3985,36 @@ components:
         names:
           type: array
           description: >
-            Bare artist names to resolve, verbatim (leading/trailing
-            whitespace is trimmed for all internal work; responses echo
-            the raw string). Inputs are deduplicated internally on their
-            normalized identity-match form PLUS any trailing
-            parenthesized/bracketed qualifier, detected on the
-            NFKC-folded lowercase name so width/case variants ("（２）")
-            key with their ASCII twins: duplicate positions receive the
-            shared verdict, but a qualified name ("Popsicle (2)",
-            "Popsicle [2]") is its own work unit — a Discogs-style
-            disambiguator denotes a different artist than the bare name,
-            so it never inherits (or supplies) the bare form's verdict,
-            and it resolves only when the API candidate's own title
-            carries the same qualifier. A verified mint is keyed on the
-            first occurrence's trimmed verbatim, EXCEPT when the identity
-            read found an existing row for the name that lacks
-            `discogs_artist_id` — the mint then fills that row's stored
-            key in place rather than inserting a near-duplicate key;
-            qualified names never mint. Names that are blank, contain
-            U+0000 or unencodable code points, normalize to an empty
-            identity-match form, or consist only of a trailing qualifier
-            ("(2)") are rejected with 422 — never given an in-band
-            verdict (`not_found` means the API tier ran and measured
-            zero).
+            Bare artist names to resolve, verbatim (Unicode format
+            characters are dropped and whitespace trimmed for all
+            internal work; responses echo the raw string). Inputs are
+            deduplicated internally on their fixed-point identity-match
+            form PLUS any trailing parenthesized/bracketed qualifier.
+            Qualifier detection mirrors the normalizer: every balanced
+            trailing ()/[] group peels off the NFKC-folded lowercase name
+            (nested tails included), bare-number groups canonicalize
+            across bracket/width/spacing spellings ("[2]", "( 2 )",
+            "（２）" all key as "(2)"; zero-padded "(02)" stays distinct),
+            and multi-group tails concatenate ("(2)(uk)"). Duplicate
+            positions receive the shared verdict, but a qualified name is
+            its own work unit — a Discogs-style disambiguator denotes a
+            different artist than the bare name, so it never inherits (or
+            supplies) the bare form's verdict, and it resolves only when
+            the API candidate's own title carries the same qualifier. A
+            name whose only content IS a bracketed group ("(Smog)") is a
+            bare name, not a qualifier — the normalizer makes the same
+            refusal. A verified mint is keyed on the first occurrence's
+            sanitized verbatim, EXCEPT when the identity read found an
+            existing row for the name that lacks `discogs_artist_id` —
+            the mint then fills that row's stored key in place rather
+            than inserting a near-duplicate key (deterministically, the
+            lexicographically-least stored key when several id-less rows
+            match); qualified names never mint. Names that are blank,
+            contain U+0000 or unencodable code points, normalize to an
+            empty identity-match form, or are a bare parenthesized number
+            ("(2)" — a disambiguator whose artist name was lost upstream)
+            are rejected with 422 — never given an in-band verdict
+            (`not_found` means the API tier ran and measured zero).
           minItems: 1
           maxItems: 25
           # Codegen note: the item bounds make datamodel-codegen wrap
@@ -6954,9 +6963,10 @@ paths:
           description: >
             Validation error — per-input field validation failed, or a
             name is semantically unresolvable (blank, contains U+0000 or
-            unencodable code points, or normalizes to an empty
-            identity-match form). Garbage names are caller errors, never
-            in-band verdicts.
+            unencodable code points, normalizes to an empty
+            identity-match form, or is a bare parenthesized number like
+            "(2)"). Garbage names are caller errors, never in-band
+            verdicts.
           content:
             application/json:
               schema:

--- a/api.yaml
+++ b/api.yaml
@@ -3856,8 +3856,11 @@ components:
         store's resolved-at-most-once promise). `api_search` — a
         single-page live Discogs API artist search returned exactly one
         artist whose normalized identity-match form equals the input's,
-        with no equality-leg cache conflict. Cache legs never decide;
-        their evidence appears in `cache_corroboration`.
+        whose own title qualifier matches the input's (a "(N)"-titled
+        singleton answering a bare input — or vice versa — is family
+        evidence, not a resolution), and with no equality-leg cache
+        conflict. Cache legs never decide; their evidence appears in
+        `cache_corroboration`.
       enum:
         - identity_store
         - api_search
@@ -3888,15 +3891,23 @@ components:
         exists — cache legs, including `cache_exact`, may still
         show yield in `cache_corroboration`). `ambiguous` — two or
         more exact-form Discogs artists (including "(N)" disambiguation
-        families, which normalize to the same form), or an equality-leg
+        families, which normalize to the same form); an equality-leg
         cache candidate (exact / member / alias / name-variation — never a
         fuzzy `cache_trigram` neighbor) pointing at a different artist id
-        than the API's single candidate; ambiguous names never mint
-        (terminal). `escalation_unavailable` — the Discogs API tier
-        was shed (saturation breaker open, outage cool-down, 429, or 5xx
-        after retries). This is the RETRYABLE verdict: it means "couldn't
-        ask," not "asked and missed" — consumers must not apply a no-match
-        TTL to it.
+        than the API's single candidate; a lone API candidate whose own
+        title qualifier mismatches the input's; or conflicting
+        identity-store rows across one deduplicated group's spellings
+        (`candidate_count` null — nothing was measured); ambiguous names
+        never mint (terminal). `escalation_unavailable` — the Discogs API
+        tier couldn't answer: saturation breaker open, outage cool-down,
+        429 or 5xx after retries, network errors, other non-2xx
+        responses, a distrusted/unparseable page, or a deployment with no
+        Discogs credentials configured. It means "couldn't ask," not
+        "asked and missed" — consumers must not apply a no-match TTL.
+        Retry with bounded attempts and backoff: most causes are
+        transient, but a persistent `escalation_unavailable` across
+        attempts indicates a configuration or upstream condition that
+        retrying will not move.
       enum:
         - not_found
         - ambiguous
@@ -3942,10 +3953,17 @@ components:
             resolved verdicts, listed equality legs necessarily agreed
             with the deciding tier (a disagreeing equality leg forces
             `ambiguous`), while `cache_trigram` entries are fuzzy
-            near-misses that never veto. Empty when no leg produced
-            candidates, and always empty on `identity_store`
-            short-circuits — the store decides before cache evidence is
-            consulted, and implementations report an empty array there.
+            near-misses that never veto (`cache_trigram` is measured
+            against the group's probe string — its lexicographically
+            least raw spelling — where the equality legs bind the
+            identity-match form). Empty when no leg produced candidates,
+            and ALWAYS empty — the cache was never consulted, which is
+            not a measured zero-yield — on (a) `identity_store`
+            short-circuits (the store decides before cache evidence is
+            consulted), (b) qualifier-bearing inputs (stripped-form
+            evidence cannot distinguish family members, so the cache
+            tier is skipped), and (c) store-conflict `ambiguous`
+            verdicts.
           items:
             $ref: '#/components/schemas/ArtistResolveCacheLeg'
         unresolved_reason:
@@ -3995,7 +4013,9 @@ components:
             (nested tails included), bare-number groups canonicalize
             across bracket/width/spacing spellings ("[2]", "( 2 )",
             "（２）" all key as "(2)"; zero-padded "(02)" stays distinct),
-            and multi-group tails concatenate ("(2)(uk)"). Duplicate
+            and multi-group tails concatenate ("(2)(uk)"); non-numeric
+            groups drop internal whitespace, so "(Chk Chk Chk)" and
+            "(ChkChkChk)" share a key. Duplicate
             positions receive the shared verdict, but a qualified name is
             its own work unit — a Discogs-style disambiguator denotes a
             different artist than the bare name, so it never inherits (or
@@ -4003,18 +4023,24 @@ components:
             the API candidate's own title carries the same qualifier. A
             name whose only content IS a bracketed group ("(Smog)") is a
             bare name, not a qualifier — the normalizer makes the same
-            refusal. A verified mint is keyed on the first occurrence's
-            sanitized verbatim, EXCEPT when the identity read found an
+            refusal. A verified mint is keyed on the group's
+            lexicographically-least sanitized spelling (deterministic in
+            batch content — the same representative the API probe uses;
+            the store's read legs are case-insensitive, so any spelling
+            stays findable), EXCEPT when the identity read found an
             existing row for the name that lacks `discogs_artist_id` —
             the mint then fills that row's stored key in place rather
             than inserting a near-duplicate key (deterministically, the
             lexicographically-least stored key when several id-less rows
             match); qualified names never mint. Names that are blank,
             contain U+0000 or unencodable code points, normalize to an
-            empty identity-match form, or are a bare parenthesized number
-            ("(2)" — a disambiguator whose artist name was lost upstream)
-            are rejected with 422 — never given an in-band verdict
-            (`not_found` means the API tier ran and measured zero).
+            empty identity-match form, or whose entire identity content
+            is a bare parenthesized ASCII number ("(2)", "[2]", "(2)(3)"
+            — a Discogs disambiguator whose artist name was lost
+            upstream; a fully-bracketed NON-numeric name like "(Smog)"
+            stays resolvable) are rejected with 422 — never given an
+            in-band verdict (`not_found` means the API tier ran and
+            measured zero).
           minItems: 1
           maxItems: 25
           # Codegen note: the item bounds make datamodel-codegen wrap
@@ -6964,9 +6990,9 @@ paths:
             Validation error — per-input field validation failed, or a
             name is semantically unresolvable (blank, contains U+0000 or
             unencodable code points, normalizes to an empty
-            identity-match form, or is a bare parenthesized number like
-            "(2)"). Garbage names are caller errors, never in-band
-            verdicts.
+            identity-match form, or its entire identity content is a
+            bare parenthesized ASCII number like "(2)" or "(2)(3)").
+            Garbage names are caller errors, never in-band verdicts.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Description-only truth-up of the `POST /api/v1/artists/resolve/bulk` contract after [LML#765](https://github.com/WXYC/library-metadata-lookup/pull/765)'s review round 1 confirmed three divergences between the shipped text and the (corrected) resolver semantics. No schema shapes change; `npm run check:breaking` reports no breaking changes; unit tests pass.

1. **Suffix-aware dedupe** (`ArtistResolveBulkRequest.names`): inputs group on the identity-match form PLUS any raw trailing "(N)" disambiguator. A suffixed name denotes a different artist than the bare name by Discogs convention and never inherits (or supplies) the bare form's verdict — the review confirmed the old text's pure-form dedupe let a stored `Popsicle` row answer for `Popsicle (2)` with a confidently wrong id.
2. **Stored-key mint exception + suffixed-no-mint**: a verified mint keys on the first occurrence's verbatim EXCEPT when the identity read found an existing row lacking `discogs_artist_id` — the mint fills that row's stored key in place (anti-near-duplicate-key accretion); "(N)"-suffixed names resolve but never mint (unreachable keys, pure pollution).
3. **Honest never-clobber + 422 semantics**: the endpoint description now states what the upsert actually guarantees (no NULL overwrites; concurrent-writer hardening tracked in [LML#766](https://github.com/WXYC/library-metadata-lookup/issues/766)), and the 422 response covers semantically unresolvable names (blank / U+0000 / unencodable / empty identity-match form), which are rejected as caller errors rather than given an in-band `not_found` a consumer might durably negative-cache.

**Merge-order note**: once this merges to main, open LML PRs will regen-drift against it — the LML side regenerates `generated/api_models.py` immediately after (lands with the stacked #764/#765 chain).

## Related

- WXYC/library-metadata-lookup#759 (parent design) / #765 (PR C1) / #764 (PR C2) / #766 (mint hardening follow-up)