### PR TITLE
feat(api): add Concert.genres — additive nullable Discogs genres (Touring Soon R2)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2164,6 +2164,20 @@ components:
           description: Source-displayed age restriction (e.g. "18+", "All Ages").
         status:
           $ref: '#/components/schemas/ConcertStatus'
+        genres:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: >-
+            Discogs genre tags for the resolved headlining artist,
+            aggregated across their releases (LML discogs-cache,
+            majority-take). Null when the headliner is unresolved or
+            enrichment has not run. Optional (not in `required`) so the
+            field can land ahead of the Backend-Service emitter and older
+            clients decode forward-compatibly — same discipline as
+            `FlowsheetV2TrackEntry.upcoming_show`. Same taxonomy as
+            `FlowsheetV2TrackEntry.genres`.
 
     ConcertsResponse:
       type: object


### PR DESCRIPTION
## What

Adds an optional, nullable `genres: string[]` to the `Concert` schema in `api.yaml` — the Discogs genre tags of the resolved headlining artist, aggregated across their releases (LML discogs-cache, majority-take). Null when the headliner is unresolved or enrichment has not run.

## Why

Contract substrate for the Touring Soon R2 genre filter (WXYC/wxyc-ios-64#474). The concerts feed needs artist-level Discogs genres so iOS can filter; today `Concert` has no genre field. The downstream emitter (WXYC/Backend-Service#1624) and iOS consumer (WXYC/wxyc-ios-64#491) are blocked on this; source data is WXYC/library-metadata-lookup#781.

## Design notes

- **Taxonomy is deliberately Discogs genres via LML** — same taxonomy as `FlowsheetV2TrackEntry.genres`. Not WXYC's internal library-filing codes (record-retrieval codes, not for external presentation) and not triangle-shows `raw_data.genre` (Ticketmaster vocabulary — mixing taxonomies).
- **Optional, not `required`.** The field is intentionally left out of `Concert.required` so it can land ahead of the Backend-Service emitter and older clients decode it forward-compatibly. This mirrors the existing `FlowsheetV2TrackEntry.upcoming_show` discipline in the same spec. It stays optional permanently — promoting optional → required later would itself be a breaking change.

## Verification

- `npm run check:breaking` → changes detected, **non-breaking** (additive optional field).
- `npm run generate` clean for all four consumers; each carries the field as optional + nullable: TS `genres?: string[] | null`, Python `genres: list[str] | None = Field(None, …)`, Swift `public var genres: [String]? = nil` (+ `encodeIfPresent`), Kotlin `val genres: …List<String>? = null`.
- `npm run build`, `npm run lint`, and `npm test` (535 tests) all pass.

## Related

- Sibling contract change: #222 (`Concert.similar_artists`, R3b) — chained on top of this branch.
- Concerts wire-contract E2E gate: #216 (merged).

Closes #221