### PR TITLE
feat(api): add Concert.similar_artists — additive nullable affinity neighbors (Touring Soon R3b)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2068,6 +2068,29 @@ components:
         - cancelled
         - rescheduled
 
+    SimilarArtist:
+      type: object
+      description: >-
+        One affinity neighbor of a resolved concert headliner, drawn from
+        the semantic-index graph. `artist_id` shares the WXYC catalog
+        artist-id keyspace with `Concert.headlining_artist_id` (and the
+        planned `FlowsheetV2TrackEntry.artist_id`), so on-device For You
+        matching can intersect it against liked-artist ids in one id space.
+      required:
+        - artist_id
+        - weight
+      properties:
+        artist_id:
+          type: integer
+          description: >-
+            WXYC catalog artist id, same keyspace as
+            `Concert.headlining_artist_id`.
+        weight:
+          type: number
+          description: >-
+            semantic-index affinity score, used for client-side ranking and
+            the similar-tier noise cap. Higher is closer.
+
     Concert:
       type: object
       description: |
@@ -2178,6 +2201,19 @@ components:
             clients decode forward-compatibly — same discipline as
             `FlowsheetV2TrackEntry.upcoming_show`. Same taxonomy as
             `FlowsheetV2TrackEntry.genres`.
+        similar_artists:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/SimilarArtist'
+          description: >-
+            Top-K affinity neighbors of the resolved headliner, computed
+            nightly from the semantic-index graph and ordered by `weight`
+            descending. Null when the headliner is unresolved or enrichment
+            has not run. Powers on-device For You matching (set intersection
+            against liked-artist ids). Optional (not in `required`) so it can
+            land ahead of the Backend-Service emitter and older clients
+            decode forward-compatibly — same discipline as `Concert.genres`.
 
     ConcertsResponse:
       type: object


### PR DESCRIPTION
> **Chained on #224** (base branch is `feat/concert-genres`, not `main`). The diff below shows only the `similar_artists` change; GitHub will retarget this PR to `main` automatically once #224 merges. Review/merge #224 first.

## What

Adds an optional, nullable `similar_artists` array to the `Concert` schema — the top-K affinity neighbors of the resolved headlining artist, computed nightly from the semantic-index graph and ordered by `weight` descending. Introduces a named `SimilarArtist` component schema (`{ artist_id, weight }`).

## Why

Contract substrate for the Touring Soon "For You" shelf (WXYC/wxyc-ios-64#474, R3b), which matches curated concerts against on-device likes by set intersection — so each concert must carry its headliner's affinity neighbors. The downstream emitter (WXYC/Backend-Service#1626) and iOS consumer (WXYC/wxyc-ios-64#493) are blocked on this; neighbor source is WXYC/semantic-index#354.

## Design notes

- **Named `SimilarArtist` schema, not an inline object.** The issue sketched an inline `items: { type: object, … }`, but the spec's dominant convention is `$ref`s to named schemas for array items (59 `$ref` array-items vs 3 inline in the file; `Concert.venue → Venue` is the local precedent). A named schema (a) generates clean, stable named types across Python/Swift/Kotlin instead of a synthesized `…Inner` name, and (b) centralizes the load-bearing keyspace invariant in one place.
- **Keyspace invariant.** `SimilarArtist.artist_id` shares the WXYC catalog artist-id keyspace with `Concert.headlining_artist_id` (and the planned `FlowsheetV2TrackEntry.artist_id`). On-device matching depends on a single id space, so the schema says so explicitly.
- **Ordering stated at the array level.** The issue put "descending order" on the scalar `weight`; it's an array-level invariant, so it lives on `similar_artists` (`ordered by weight descending`).
- **Optional, not `required`** — lands ahead of the emitter; older clients decode forward-compatibly. Same discipline as `Concert.genres` (#221) and `FlowsheetV2TrackEntry.upcoming_show`. Stays optional permanently.

## Verification

- `npm run check:breaking` → **non-breaking** (new schema + additive optional field).
- `npm run generate` clean for all four consumers. Each gets a named `SimilarArtist` type (`artist_id`/`weight` both required within the object) and an optional + nullable `similar_artists` on `Concert`: TS `similar_artists?: SimilarArtist[] | null`, Python `list[SimilarArtist] | None = Field(None, …)`, Swift `[SimilarArtist]? = nil` (+ `encodeIfPresent`), Kotlin `List<SimilarArtist>? = null`.
- `npm run build`, `npm run lint`, and `npm test` (535 tests) all pass.

## Related

- Sibling contract change: #221 / #224 (`Concert.genres`, R2) — this PR is stacked on it.
- Concerts wire-contract E2E gate: #216 (merged).

Closes #222