### PR TITLE
docs(api): rename "Touring Soon" → "On Tour" in api.yaml descriptions

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -728,7 +728,7 @@ components:
               description: >
                 An optional embedded upcoming Triangle-area concert whose
                 headliner is this track's resolved catalog artist, attached
-                server-side at feed-assembly time so the iOS "Touring Soon"
+                server-side at feed-assembly time so the iOS "On Tour"
                 Box Office CTA renders inline with no second round-trip.
 
 
@@ -748,7 +748,7 @@ components:
                 upcoming date. The field is additive and optional — older app
                 builds that don't decode it are unaffected. Reuses the
                 `Concert` schema verbatim so iOS decodes one type across the
-                Touring Soon tab and the playcut CTA; the
+                On Tour tab and the playcut CTA; the
                 `BoxOfficeTicketPresenter` reads `id`, `title` /
                 `headlining_artist_raw`, `venue` (name + city), `starts_on`,
                 `doors_at`, `status`, `price_min` / `price_max`, `ticket_url`,
@@ -2023,7 +2023,7 @@ components:
           format: date-time
 
     # ===================
-    # Concerts / Touring Events Types (Backend-Service#1603)
+    # Concerts / On Tour Types (Backend-Service#1603)
     # ===================
 
     Venue:
@@ -6634,7 +6634,7 @@ paths:
 
   /concerts:
     get:
-      summary: List upcoming concerts (Touring Soon feed)
+      summary: List upcoming concerts (On Tour feed)
       description: |
         Returns upcoming non-removed concerts, windowed on the venue-local
         calendar date `starts_on` (never on the nullable `starts_at` — range

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -49,7 +49,7 @@ npm run test:e2e -- e2e/flowsheet.test.ts
 - Verifies 401 for unauthenticated requests
 
 ### Concerts E2E (`concerts.test.ts`)
-- The cross-repo wire-contract gate for `GET /concerts` (touring events)
+- The cross-repo wire-contract gate for `GET /concerts` (On Tour)
 - Anonymous-session auth exchanged for a JWT (the mobile-app mechanism); verifies 401 unauthenticated
 - Decodes the live payload through the **generated** `Concert` / `ConcertsResponse` types and asserts every field matches the codegen shape (nullable keys present, no internal ingestion columns leaked, `status` within `ConcertStatus`) — the contract iOS/Android/dj-site consume
 - Self-seeds a deterministic row set (timed+curated, date-only, past, removed) directly into the stack DB, then asserts windowing, ordering, the `event_url` fallback field, and `curated=true`

--- a/e2e/concerts.test.ts
+++ b/e2e/concerts.test.ts
@@ -1,8 +1,8 @@
 /**
- * Concerts (Touring Events) E2E Tests
+ * Concerts (On Tour) E2E Tests
  *
  * The cross-repo wire-contract gate for `GET /concerts` (Backend-Service
- * #1603 / touring-events Phase 2). Where `tests/concerts.test.ts` pins the
+ * #1603 / on-tour Phase 2). Where `tests/concerts.test.ts` pins the
  * `api.yaml` shape statically, this suite hits a *running* backend and
  * asserts the live payload decodes through the **generated** `Concert` /
  * `ConcertsResponse` / `Venue` / `ConcertStatus` types — the same codegen

--- a/tests/concerts.test.ts
+++ b/tests/concerts.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for Concerts / Touring Events Types (Backend-Service#1603)
+ * Tests for Concerts / On Tour Types (Backend-Service#1603)
  *
  * Validates:
  * - api.yaml defines the Venue / Concert / ConcertStatus / ConcertsResponse


### PR DESCRIPTION
Closes #226

The org GitHub Project ([#37](https://github.com/orgs/WXYC/projects/37)) and the iOS feature were renamed from "Touring Soon" / "touring events" to **On Tour**. This updates the human-readable OpenAPI text and test/README doc comments in `api.yaml` (the API-contract source of truth) to match.

## What changed

Description/summary free-text and doc comments only:

- `api.yaml` — `upcoming_show` description iOS "Touring Soon" → "On Tour" (2 mentions); `# Concerts / Touring Events Types` comment → `On Tour`; `GET /concerts` summary `(Touring Soon feed)` → `(On Tour feed)`
- `e2e/concerts.test.ts`, `e2e/README.md`, `tests/concerts.test.ts` — header/doc comments

**No wire identifiers change.** Schema/field/enum names (`Concert`, `Venue`, `ConcertStatus`, `ConcertsResponse`) and the `/concerts` path contain no "touring" and are untouched. The wire contract and generated type surface are unchanged; regenerating the TypeScript types (gitignored, per this repo) only updates doc-comments to say "On Tour". Ordinary English "touring" is left as-is.

## Downstream

Downstream consumers that vendor these descriptions — Backend-Service `app.yaml`, library-metadata-lookup `api_models.py` — are being renamed by separate PRs.