### PR TITLE
feat(api): AlbumReview contract + GET /album-reviews for the form-review archive

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2229,6 +2229,10 @@ components:
         pagination:
           $ref: '#/components/schemas/PaginationInfo'
 
+    # ===================
+    # Album Reviews (issue #229)
+    # ===================
+
     AlbumReview:
       type: object
       description: |
@@ -2308,7 +2312,7 @@ components:
           nullable: true
           description: >-
             Raw multi-select of "Rotation", "New DJ Assignment", "Album in
-            the Library".
+            the Library"; comma-joined when multiple were selected.
         rotated:
           type: boolean
           nullable: true

--- a/api.yaml
+++ b/api.yaml
@@ -2229,6 +2229,128 @@ components:
         pagination:
           $ref: '#/components/schemas/PaginationInfo'
 
+    AlbumReview:
+      type: object
+      description: |
+        One archived DJ album review, sourced from the WXYC album-review
+        Google Form (collected since March 2021) and synced nightly by
+        Backend-Service's album-reviews ETL.
+
+        Distinct from ADR 0006's in-app Review model (one-per-album,
+        author-owned, `/reviews`): submissions here are append-only, may
+        number several per album, and identify albums by free text with a
+        best-effort `album_id` link. Reviewer identity is deliberately not
+        exposed — the form promised reviewers their names would not be
+        shared.
+      required:
+        - id
+        - album_id
+        - artist_name
+        - album_title
+        - record_label
+        - artist_blurb
+        - review
+        - recommended_tracks
+        - buzzwords
+        - fcc_violations
+        - review_purpose
+        - rotated
+        - released_within_six_months
+        - social_consent
+        - submitted_at
+      properties:
+        id:
+          type: integer
+        album_id:
+          type: integer
+          nullable: true
+          description: >-
+            WXYC library album id when the free-text artist/album resolved
+            to exactly one catalog row; null otherwise.
+        artist_name:
+          type: string
+          nullable: true
+          description: Artist name exactly as the reviewer entered it.
+        album_title:
+          type: string
+          nullable: true
+          description: Album title exactly as the reviewer entered it.
+        record_label:
+          type: string
+          nullable: true
+        artist_blurb:
+          type: string
+          nullable: true
+          description: Short reviewer-written background on the artist.
+        review:
+          type: string
+          nullable: true
+          description: The review body.
+        recommended_tracks:
+          type: string
+          nullable: true
+          description: >-
+            Raw recommended-tracks text, including the form's `!`-rating
+            notation (1–5 exclamation marks) and "Play All" shorthand.
+        buzzwords:
+          type: string
+          nullable: true
+          description: Comma-separated reviewer-chosen descriptors.
+        fcc_violations:
+          type: string
+          nullable: true
+          description: >-
+            Verbatim reviewer answer listing FCC-violating track numbers.
+            Blank (unanswered) is distinct from "None"/"N/A" (affirmatively
+            clean); values are not normalized.
+        review_purpose:
+          type: string
+          nullable: true
+          description: >-
+            Raw multi-select of "Rotation", "New DJ Assignment", "Album in
+            the Library".
+        rotated:
+          type: boolean
+          nullable: true
+          description: >-
+            Curator-maintained "was this album rotated" flag; null when the
+            sheet cell is blank or unparseable.
+        released_within_six_months:
+          type: boolean
+          nullable: true
+          description: >-
+            Whether the album was released within 6 months of the review;
+            null when unanswered (question added mid-2024).
+        social_consent:
+          type: boolean
+          nullable: true
+          description: >-
+            Whether the reviewer consented to the review being shared on
+            station social media (always anonymously); null when unanswered.
+        submitted_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Form submission instant. Null only for the rare row whose sheet
+            timestamp is missing.
+
+    AlbumReviewsResponse:
+      type: object
+      description: >-
+        Paginated list of album-review submissions, ordered by
+        `submitted_at` descending (nulls last).
+      required:
+        - album_reviews
+        - pagination
+      properties:
+        album_reviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlbumReview'
+        pagination:
+          $ref: '#/components/schemas/PaginationInfo'
+
     # ===================
     # Device Authorization (RFC 8628) — issue #195
     # Mirrors the better-auth device-authorization plugin (1.6.20 — the version
@@ -6689,6 +6811,77 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConcertsResponse'
+        '400':
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '403':
+          description: >
+            Forbidden — the session is banned or the bearer token carries no
+            `sub` claim (auth middleware gate).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
+  /album-reviews:
+    get:
+      summary: List archived DJ album-review submissions
+      description: |
+        Returns album-review submissions from the WXYC album-review Google
+        Form archive, ordered by `submitted_at` descending (nulls last),
+        paginated. Filterable by linked library album or by artist name
+        (normalized exact match).
+
+        Deliberately not `/reviews`, which is reserved for the in-app
+        Review model (ADR 0006, one-per-album, author-owned). Requires
+        anonymous session auth, matching the other iOS read surfaces.
+        Reviewer names are never included in responses.
+      parameters:
+        - name: album_id
+          in: query
+          schema:
+            type: integer
+          description: Return only submissions linked to this library album id.
+        - name: artist
+          in: query
+          schema:
+            type: string
+          description: >-
+            Artist-name filter; matched against the submission's normalized
+            artist name (case-insensitive, leading-"the"-insensitive).
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-indexed, per PaginationParams).
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Page size (per PaginationParams).
+      responses:
+        '200':
+          description: >-
+            Paginated list of album-review submissions ordered by
+            submitted_at descending.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlbumReviewsResponse'
         '400':
           description: Invalid query parameters
           content:


### PR DESCRIPTION
Closes #229.

Adds the wire contract for the WXYC album-review archive (the album-review Google Form, ~1,650 reviews since March 2021, synced nightly by a forthcoming Backend-Service ETL):

- **`AlbumReview`** component schema — form-shaped submission with free-text album identity, nullable best-effort `album_id` library link, verbatim free-form fields, and normalized `rotated` / `released_within_six_months` / `social_consent` booleans. Reviewer identity fields are deliberately absent from the contract (the form promised names would not be shared; they exist DB-side only).
- **`AlbumReviewsResponse`** — `{ album_reviews, pagination }`, resource-named array key per the `ConcertsResponse.concerts` convention.
- **`GET /album-reviews`** path — `album_id` / `artist` / `page` / `limit` params, anonymous-session auth posture matching `/concerts`. Deliberately not `/reviews`, which Backend-Service ADR 0006 reserves for the future in-app one-per-album Review model.

Verified: `check:breaking` clean (pure addition), `generate:typescript` emits `AlbumReview`/`AlbumReviewsResponse`, lint + 535 tests green.

Post-merge: `npm version minor` + tag push to publish, then Backend-Service bumps its `@wxyc/shared` pin in the endpoint PR (BS plan `plans/album-reviews-sheet-sync.md`; BS issue will cross-reference).