### PR TITLE
feat(api): add GET /concerts/{id} — public, windowless single-concert read

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6973,8 +6973,9 @@ paths:
         - **No authentication.** `security: []` — anonymous-session auth
           is not required, matching the public flowsheet read.
         - **No date window.** Past concerts and concerts delisted at the
-          source (tombstoned upstream via `removed_at`, never deleted)
-          are served with whatever `status` they last carried; clients
+          source (tombstoned upstream via the internal `removed_at`
+          column — never deleted, and not exposed on `Concert`) are
+          served with whatever `status` they last carried; clients
           derive "this show has passed" from `starts_on`/`starts_at`.
         - **Publicly cacheable.** Responses carry no per-session data;
           servers should emit `Cache-Control: public` with an edge TTL of

--- a/api.yaml
+++ b/api.yaml
@@ -6957,6 +6957,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
 
+  /concerts/{id}:
+    get:
+      summary: Get a single concert by id (public share/deep-link read)
+      description: |
+        Returns one concert by its serial `id`, regardless of date. Unlike
+        `GET /concerts`, this endpoint is deliberately public and
+        windowless — it exists to serve the `wxyc.org/shows/<id>` share
+        page (a Cloudflare Worker with no sane path to minting anonymous
+        sessions) and the iOS universal-link fallback, both of which may
+        reference a show outside the list window, including one that
+        already happened.
+
+        Contract semantics (WXYC/wxyc-shared#236):
+        - **No authentication.** `security: []` — anonymous-session auth
+          is not required, matching the public flowsheet read.
+        - **No date window.** Past concerts and concerts delisted at the
+          source (tombstoned upstream via `removed_at`, never deleted)
+          are served with whatever `status` they last carried; clients
+          derive "this show has passed" from `starts_on`/`starts_at`.
+        - **Publicly cacheable.** Responses carry no per-session data;
+          servers should emit `Cache-Control: public` with an edge TTL of
+          roughly five minutes.
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: The concert's serial `Concert.id`.
+      responses:
+        '200':
+          description: The concert.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Concert'
+        '404':
+          description: No concert with this id exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
   /album-reviews:
     get:
       summary: List archived DJ album-review submissions


### PR DESCRIPTION
Adds the by-id concert read to the contract for the On Tour sharing loop: the wxyc.org/shows/<id> share page (a Cloudflare Worker with no sane path to minting anonymous sessions) and the iOS universal-link fallback both need a single-concert read with no auth and no date window — a shared link can reference a show outside the list window, including one that already happened (tombstoned upstream via removed_at, never deleted).

Contract semantics spelled out in the path description: no authentication (security: [], matching the public flowsheet read); no date window (past and source-delisted rows served with whatever status they last carried); publicly cacheable (~5-minute edge TTL). 200 returns the existing Concert schema unchanged; 404 uses ApiErrorResponse. Additive only — the list endpoint and Concert/Venue schemas are untouched.

Verification: oasdiff breaking check passes; all four codegen targets (typescript/python/swift/kotlin) regenerate clean — outputs are gitignored per repo policy, so the diff is api.yaml only, same discipline as #224/#225; build, typecheck, and 535 unit tests green.

Closes #236