### PR TITLE
feat(api): add FlowsheetV2TrackEntry.artist_id — additive nullable resolved catalog artist (1.19.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.18.0
+  version: 1.19.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -645,6 +645,23 @@ components:
             rotation_id:
               type: integer
               nullable: true
+            artist_id:
+              type: integer
+              nullable: true
+              description: >
+                The played release's resolved WXYC catalog artist id
+                (`flowsheet.album_id → library.artist_id`), computed
+                server-side on the same join that powers `upcoming_show`.
+                Shares the catalog artist-id keyspace with
+                `Concert.headlining_artist_id` and `SimilarArtist.artist_id`,
+                so on-device features — the On Tour likes match — can
+                intersect a liked playcut's artist against concert headliners
+                and their affinity neighbors in one id space.
+
+
+                Null for free-form entries (no `album_id`) and for library
+                rows whose album has no linked artist. Additive and optional:
+                older app builds that don't decode it are unaffected.
             artist_name:
               type: string
               nullable: true
@@ -2073,8 +2090,8 @@ components:
       description: >-
         One affinity neighbor of a resolved concert headliner, drawn from
         the semantic-index graph. `artist_id` shares the WXYC catalog
-        artist-id keyspace with `Concert.headlining_artist_id` (and the
-        planned `FlowsheetV2TrackEntry.artist_id`), so on-device For You
+        artist-id keyspace with `Concert.headlining_artist_id` (and
+        `FlowsheetV2TrackEntry.artist_id`), so on-device For You
         matching can intersect it against liked-artist ids in one id space.
       required:
         - artist_id


### PR DESCRIPTION
## What

Adds an optional, additive `artist_id` (integer, nullable, **not** in `required`) to `FlowsheetV2TrackEntry`, and bumps `info.version` 1.18.0 → 1.19.0.

`artist_id` is the played release's resolved WXYC catalog artist id (`flowsheet.album_id → library.artist_id`) — the same value Backend-Service already computes internally to attach `upcoming_show` (added in 1.16.0 / BS#1607). This is the contract-first (SSOT) half; the Backend projection lands in [WXYC/Backend-Service#1625](https://github.com/WXYC/Backend-Service/issues/1625).

## Why

The iOS On Tour on-device likes feature ([WXYC/wxyc-ios-64#492](https://github.com/WXYC/wxyc-ios-64/issues/492)) needs catalog artist ids at the heart-gesture site (playcut rows) so liked artists can be matched against concerts. It shares the `artists.id` keyspace with `Concert.headlining_artist_id` and `SimilarArtist.artist_id`, so on-device matching intersects a liked playcut against concert headliners and their affinity neighbors in one id space. The `SimilarArtist` description already anticipated this field as "planned"; that wording is now updated.

## Safety

- **Additive, nullable, not required** — older builds that don't decode it are unaffected. Structurally identical to how `upcoming_show` was added to this same frozen surface ([b0b9e40](https://github.com/WXYC/wxyc-shared/commit/b0b9e40)).
- `oasdiff breaking` (base vs revision): **no breaking changes** — 2 info-level `response-optional-property-added` on `GET /v2/flowsheet` and `GET /v2/flowsheet/latest`.
- `npm run generate:typescript` emits `artist_id?: number | null` on the type. (Generated models are gitignored and rebuilt on `prepare`/publish — no committed codegen, matching precedent.)

## Governance

Frozen-surface touch pre-cleared into the [Post-launch service hardening](https://github.com/orgs/WXYC/projects/32) project via [WXYC/Backend-Service#1625](https://github.com/WXYC/Backend-Service/issues/1625) (approved). Parent epic: [WXYC/Backend-Service#1588](https://github.com/WXYC/Backend-Service/issues/1588).

Closes #238
