### PR TITLE
feat: add Concert.station_plays for On Tour station-affinity

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2235,11 +2235,14 @@ components:
           type: integer
           nullable: true
           description: >-
-            All-time WXYC flowsheet play count of the resolved (in-library) headliner,
-            from the semantic-index graph; null when the headliner is not in the library
-            or has no play count. Identical for every listener — the station-affinity
-            signal behind the On Tour "For You" shelf. Not personalized; carries no
-            listener data.
+            All-time WXYC flowsheet play count of the resolved (in-library)
+            headliner, computed nightly from the semantic-index graph; null
+            when the headliner is not in the library or has no play count.
+            Identical for every listener — the station-affinity signal behind
+            the On Tour "For You" shelf. Not personalized; carries no listener
+            data. Optional (not in `required`) so it can land ahead of the
+            Backend-Service emitter and older clients decode
+            forward-compatibly — same discipline as `Concert.similar_artists`.
 
     ConcertsResponse:
       type: object

--- a/api.yaml
+++ b/api.yaml
@@ -2231,6 +2231,15 @@ components:
             against liked-artist ids). Optional (not in `required`) so it can
             land ahead of the Backend-Service emitter and older clients
             decode forward-compatibly — same discipline as `Concert.genres`.
+        station_plays:
+          type: integer
+          nullable: true
+          description: >-
+            All-time WXYC flowsheet play count of the resolved (in-library) headliner,
+            from the semantic-index graph; null when the headliner is not in the library
+            or has no play count. Identical for every listener — the station-affinity
+            signal behind the On Tour "For You" shelf. Not personalized; carries no
+            listener data.
 
     ConcertsResponse:
       type: object


### PR DESCRIPTION
## What

Adds `station_plays` (type integer, `nullable: true`, not `required`) to the `Concert` schema in `api.yaml` — the cross-repo OpenAPI SSOT.

`station_plays` is the resolved (in-library) headliner's all-time WXYC flowsheet play count, from the semantic-index graph. It's the wire delivery for the On Tour "For You" **station play-affinity** signal ([WXYC/Backend-Service#1702](https://github.com/WXYC/Backend-Service/issues/1702)) — identical for every listener, carries no listener data, preserving the For You privacy invariant.

The field joins `genres`/`similar_artists` as the third optional-enrichment member and carries the same forward-compat contract clause (optional so it can land ahead of the Backend emitter; older clients decode forward-compatibly).

## Validation

Additive/non-breaking confirmed via `check:breaking` (oasdiff). Codegen regenerated for all four targets and each carries the field — TS `station_plays?: number | null`, Python `int | None`, Swift `Int?`, Kotlin `Int? = null` (generated dirs are gitignored per repo convention; only `api.yaml` is committed). `tsc`/`build`/vitest (535) green. `/review-loop` run to convergence. Not a frozen surface per the Tag Stability Policy.

Part of WXYC/Backend-Service#1702.
