### PR TITLE
feat(api): add criticReviews to AlbumMetadataResponse

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -5260,6 +5260,32 @@ components:
           type: string
           description: Track duration (e.g. "5:23")
 
+    CriticReviewItem:
+      type: object
+      required:
+        - source
+        - url
+        - snippet
+      properties:
+        source:
+          type: string
+          description: Publication name (e.g. "The Quietus")
+        url:
+          type: string
+          description: Link to the original review on the publisher's site (mandatory link-out)
+        snippet:
+          type: string
+          description: Short attributed excerpt (<= ~300 chars); never the full review body
+        author:
+          type: string
+          description: Review author, when available
+        publishedDate:
+          type: string
+          description: Review publication date when available (e.g. "2024-03-15")
+        rating:
+          type: string
+          description: Source-native rating string when available (e.g. "8.0")
+
     AlbumMetadataResponse:
       type: object
       properties:
@@ -5299,6 +5325,11 @@ components:
           items:
             $ref: '#/components/schemas/TrackListItem'
           description: Release tracklist
+        criticReviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/CriticReviewItem'
+          description: Attributed external critic-review snippets, each linking out to the original
         spotifyUrl:
           type: string
           description: Spotify URL for the album or track


### PR DESCRIPTION
## What

Adds an additive, optional `criticReviews` array to `AlbumMetadataResponse` plus a new `CriticReviewItem` schema in `api.yaml`. This is the contract (PR-1 of 3) for surfacing short attributed external critic-review snippets in the iOS playcut detail view.

`CriticReviewItem` requires `source`, `url`, and `snippet` (the attributed excerpt, capped downstream at ~300 chars); `author`, `publishedDate`, and `rating` are optional.

## Why this name

`criticReviews` / `CriticReviewItem`, not bare `reviews` — that name collides with the in-flight DJ `GET /album-reviews` work (`album_review_submissions`, ADR 0011) and the closed `AlbumReview` DTO (#229). This is a distinct concept: external critic snippets, not DJ-authored reviews.

## Non-breaking

- `criticReviews` is optional; no existing field changes.
- `npm run check:breaking` (oasdiff): no breaking changes.
- `npm run generate:typescript`, `lint`, `build`, `test` (535 passing) all green locally.

Swift/Kotlin generated output is hand-mirrored by consumers, so no generated-client change ships here; the Swift mirror lands in the iOS PR (WXYC/wxyc-ios-64#566).

## Part of

Epic WXYC/Backend-Service#1718 — the Backend-Service serve layer (WXYC/Backend-Service#1719) and iOS render (WXYC/wxyc-ios-64#566) both build against this contract.

Closes #242
