### PR TITLE
feat(api): add Concert.station_recommended — rotation-membership station tier; deprecate station_plays

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2234,14 +2234,33 @@ components:
         station_plays:
           type: integer
           nullable: true
+          deprecated: true
           description: >-
-            All-time WXYC flowsheet play count of the resolved (in-library)
-            headliner, computed nightly from the semantic-index graph; null
-            when the headliner is not in the library or has no play count.
-            Identical for every listener — the station-affinity signal behind
-            the On Tour "For You" shelf. Not personalized; carries no listener
-            data. Optional (not in `required`) so it can land ahead of the
-            Backend-Service emitter and older clients decode
+            Deprecated — use `station_recommended` instead. Play counts were
+            rejected as the station-tier signal in the "WXYC recommends"
+            redesign (WXYC/wxyc-ios-64#576); the tier now keys on rotation
+            membership. All-time WXYC flowsheet play count of the resolved
+            (in-library) headliner, computed nightly from the semantic-index
+            graph; null when the headliner is not in the library or has no
+            play count. Identical for every listener. Stays on the wire until
+            the removal ticket (WXYC/Backend-Service#1732) clears its
+            adoption gate; will be removed in a future major version.
+        station_recommended:
+          type: boolean
+          description: >-
+            True when the concert's resolved headliner
+            (`headlining_artist_id`) has at least one WXYC library release
+            that has been in rotation — any rotation row, past or present
+            ("has been in rotation", not "currently in rotation"). Omitted or
+            false for concerts with no library-resolved headliner, including
+            Discogs-only resolutions (`headlining_discogs_artist_id` without
+            `headlining_artist_id` in the Backend), which by construction
+            have no library releases to hold rotation membership. The
+            rotation-membership signal behind the On Tour "For You" station
+            tier ("WXYC recommends", WXYC/wxyc-ios-64#576); replaces the
+            deprecated `station_plays`. Identical for every listener; carries
+            no listener data. Optional (not in `required`) so it can land
+            ahead of the Backend-Service emitter and older clients decode
             forward-compatibly — same discipline as `Concert.similar_artists`.
 
     ConcertsResponse:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/concerts.test.ts
+++ b/tests/concerts.test.ts
@@ -40,6 +40,7 @@ const sampleVenue: Venue = {
 };
 
 // Timed event: starts_at present, starts_on derived from it by the DB trigger.
+// Library-resolved headliner, so the rotation-membership signal is carried.
 const sampleTimedConcert: Concert = {
   id: 101,
   venue: sampleVenue,
@@ -56,6 +57,7 @@ const sampleTimedConcert: Concert = {
   price_max: 28,
   age_restriction: 'All Ages',
   status: 'on_sale',
+  station_recommended: true,
 };
 
 // Date-only event: starts_at is null; only the calendar date is known.
@@ -97,6 +99,12 @@ describe('Concert generated types', () => {
     expect(Object.values(ConcertStatus).sort()).toEqual(
       ['cancelled', 'on_sale', 'rescheduled', 'sold_out'].sort()
     );
+  });
+
+  it('carries station_recommended on a library-resolved headliner and allows omitting it', () => {
+    expect(sampleTimedConcert.station_recommended).toBe(true);
+    // No library-resolved headliner (headlining_artist_id: null) — the field is simply omitted.
+    expect(sampleDateOnlyConcert.station_recommended).toBeUndefined();
   });
 
   it('composes ConcertsResponse from concerts + PaginationInfo', () => {
@@ -146,6 +154,25 @@ describe('Concerts in api.yaml', () => {
     for (const internal of ['raw_data', 'source', 'source_id', 'scraped_at', 'first_scraped_at']) {
       expect(concert.properties[internal], `internal column ${internal}`).toBeUndefined();
     }
+  });
+
+  it('defines station_recommended as an optional boolean carrying rotation-membership semantics', () => {
+    const concert = spec.components.schemas.Concert;
+    const field = concert.properties.station_recommended;
+    expect(field, 'Concert.station_recommended').toBeDefined();
+    expect(field.type).toBe('boolean');
+    expect(concert.required).not.toContain('station_recommended');
+    // The description is the authoritative semantics text the Backend emitter
+    // and iOS consumer both defer to (wxyc-ios-64#576 decision record).
+    expect(field.description).toContain('has been in rotation');
+    expect(field.description).toContain('headlining_artist_id');
+  });
+
+  it('deprecates station_plays and points at station_recommended', () => {
+    const field = spec.components.schemas.Concert.properties.station_plays;
+    expect(field, 'Concert.station_plays must stay on the wire').toBeDefined();
+    expect(field.deprecated).toBe(true);
+    expect(field.description).toContain('station_recommended');
   });
 
   it('defines GET /concerts with curated, from/to window, and page/limit params', () => {


### PR DESCRIPTION
## What

Adds an optional `station_recommended: boolean` to the `Concert` schema in `api.yaml` — true when the concert's resolved headliner (`headlining_artist_id`) has at least one WXYC library release that has been in rotation (any rotation row, past or present). Marks `station_plays` `deprecated: true` with a pointer to the replacement. Minor bump `@wxyc/shared` 2.1.0 → 2.2.0.

## Why

Contract substrate for the On Tour For You station-tier redesign (decision record in WXYC/wxyc-ios-64#576): the tier's signal moves from all-time flowsheet play counts to rotation membership, labeled "WXYC recommends" — "heavy rotation" is reserved for the station's actual rotation system, and absolute play counts can misrepresent a band's relevance to WXYC's programming (the Stanczyks R.E.M.-tribute incident, WXYC/Backend-Service#1730). The Backend emitter (WXYC/Backend-Service#1731) and iOS consumer (WXYC/wxyc-ios-64#577) are blocked on this.

## Design notes

- **Optional, not `required`, not nullable.** Semantics are "omitted or false" — there is no unknown state to encode, and leaving it out of `required` lets it land ahead of the emitter with forward-compatible decoding, mirroring the `genres`/`similar_artists` discipline (#221/#222).
- **"Has been in rotation", not "currently in rotation."** Any rotation row, past or present — the schema description is the authoritative wording; the emitter and consumer tickets defer to it.
- **Discogs-only headliners are false by construction** (resolution state without a library artist has no library releases to hold rotation membership).
- **`station_plays` stays on the wire.** Removal is breaking and rides a future major, gated on client adoption — WXYC/Backend-Service#1732 owns it. This PR only marks the deprecation.

## Verification

- `npm run check:breaking` → no breaking changes (additive optional field; `deprecated: true` is metadata-only).
- All four codegen outputs regenerated and carry the field as optional: TS `station_recommended?: boolean` (+ `@deprecated` JSDoc on `station_plays`), Python `bool | None`, Swift `Bool? = nil` (+ `encodeIfPresent`), Kotlin `Boolean? = null`.
- `npm run lint`, `npm run build`, `npm test` → 538/538 pass (3 new contract assertions, written red-first against the spec shape).

## Related

- Emitter: WXYC/Backend-Service#1731 (blocked on this) · consumer: WXYC/wxyc-ios-64#577 · removal: WXYC/Backend-Service#1732 · epic: WXYC/wxyc-ios-64#576.
- Sibling additive-Concert-field precedents: #224 (`genres`), #225 (`similar_artists`).

Closes #244
