### PR TITLE
feat(concert): add nullable artist_bio to the Concert schema

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.19.0
+  version: 1.20.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -2261,6 +2261,19 @@ components:
             deprecated `station_plays`. Identical for every listener; carries
             no listener data. Optional (not in `required`) so it can land
             ahead of the Backend-Service emitter and older clients decode
+            forward-compatibly — same discipline as `Concert.similar_artists`.
+        artist_bio:
+          type: string
+          nullable: true
+          description: >-
+            Artist biography from the resolved headliner's Discogs profile
+            (raw Discogs markup, parsed client-side), keyed on the effective
+            Discogs artist id and cached nightly on `artist_metadata`. Null
+            when the headliner is unresolved, has no Discogs profile, or
+            enrichment has not run. Identical for every listener; carries no
+            listener data. Renders the On Tour concert-detail "About the
+            Artist" card. Optional (not in `required`) so it can land ahead of
+            the Backend-Service emitter and older clients decode
             forward-compatibly — same discipline as `Concert.similar_artists`.
 
     ConcertsResponse:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Adds `artist_bio` (nullable string) to the `Concert` schema — the resolved headliner's Discogs profile, projected on `GET /concerts` to render the On Tour concert-detail "About the Artist" card. Optional (not in `required`) so it lands ahead of the Backend-Service emitter and older clients decode forward-compatibly, matching the genres / similar_artists / station_recommended discipline.

- api.yaml `info.version` 1.19.0 → 1.20.0 (additive)
- package 2.2.0 → 2.3.0

Generated types are gitignored (rebuilt on publish), so the tracked diff is api.yaml + package.json only. Lint + 538 tests green.

Contract gate for WXYC/Backend-Service#1734 (DTO pin) and WXYC/wxyc-ios-64#583 (decode).

Closes #246. Part of the On Tour artist-bio epic WXYC/wxyc-ios-64#582.