### PR TITLE
feat(concert): add nullable station_recommended_rank to the Concert schema

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.20.0
+  version: 1.21.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -2258,10 +2258,28 @@ components:
             have no library releases to hold rotation membership. The
             rotation-membership signal behind the On Tour "For You" station
             tier ("WXYC recommends", WXYC/wxyc-ios-64#576); replaces the
-            deprecated `station_plays`. Identical for every listener; carries
-            no listener data. Optional (not in `required`) so it can land
-            ahead of the Backend-Service emitter and older clients decode
-            forward-compatibly — same discipline as `Concert.similar_artists`.
+            deprecated `station_plays`. This is the GATE (rotation
+            membership) — see `station_recommended_rank` for the
+            plays-ordered selection rank within that gate. Identical for
+            every listener; carries no listener data. Optional (not in
+            `required`) so it can land ahead of the Backend-Service emitter
+            and older clients decode forward-compatibly — same discipline as
+            `Concert.similar_artists`.
+        station_recommended_rank:
+          type: integer
+          nullable: true
+          description: >-
+            1-based rank of this concert within the station's "WXYC recommends"
+            set — among upcoming concerts whose resolved headliner is in rotation
+            (station_recommended = true), ordered by the station's ranking signal
+            (all-time WXYC plays), rank 1 = strongest. Null when the concert is
+            not in the set (headliner not rotation-gated). This is the field the
+            client sorts the station tier by; station_recommended is the gate
+            (rotation membership), this is the plays-ordered selection rank within
+            that gate. Identical for every listener; carries no listener data.
+            Optional (not in `required`) and nullable so it can land ahead of the
+            Backend-Service emitter and older clients decode forward-compatibly —
+            same discipline as `Concert.station_plays`.
         artist_bio:
           type: string
           nullable: true

--- a/tests/concerts.test.ts
+++ b/tests/concerts.test.ts
@@ -58,6 +58,7 @@ const sampleTimedConcert: Concert = {
   age_restriction: 'All Ages',
   status: 'on_sale',
   station_recommended: true,
+  station_recommended_rank: 3,
 };
 
 // Date-only event: starts_at is null; only the calendar date is known.
@@ -105,6 +106,17 @@ describe('Concert generated types', () => {
     expect(sampleTimedConcert.station_recommended).toBe(true);
     // No library-resolved headliner (headlining_artist_id: null) — the field is simply omitted.
     expect(sampleDateOnlyConcert.station_recommended).toBeUndefined();
+  });
+
+  it('carries station_recommended_rank as the plays-ordered selection within the station_recommended gate, and allows omitting it', () => {
+    expect(sampleTimedConcert.station_recommended_rank).toBe(3);
+    // Not in the "WXYC recommends" set — the field is simply omitted.
+    expect(sampleDateOnlyConcert.station_recommended_rank).toBeUndefined();
+  });
+
+  it('allows station_recommended_rank: null (rotation-gated headliner outside the ranked set)', () => {
+    const rankedOutOfSet: Concert = { ...sampleTimedConcert, station_recommended_rank: null };
+    expect(rankedOutOfSet.station_recommended_rank).toBeNull();
   });
 
   it('composes ConcertsResponse from concerts + PaginationInfo', () => {
@@ -173,6 +185,22 @@ describe('Concerts in api.yaml', () => {
     expect(field, 'Concert.station_plays must stay on the wire').toBeDefined();
     expect(field.deprecated).toBe(true);
     expect(field.description).toContain('station_recommended');
+  });
+
+  it('documents station_recommended as the gate, distinct from the station_recommended_rank selection', () => {
+    const field = spec.components.schemas.Concert.properties.station_recommended;
+    expect(field.description).toContain('station_recommended_rank');
+  });
+
+  it('defines station_recommended_rank as an optional nullable integer carrying the plays-ordered selection rank', () => {
+    const concert = spec.components.schemas.Concert;
+    const field = concert.properties.station_recommended_rank;
+    expect(field, 'Concert.station_recommended_rank').toBeDefined();
+    expect(field.type).toBe('integer');
+    expect(field.nullable).toBe(true);
+    expect(concert.required).not.toContain('station_recommended_rank');
+    expect(field.description).toContain('1-based');
+    expect(field.description).toContain('rotation');
   });
 
   it('defines GET /concerts with curated, from/to window, and page/limit params', () => {


### PR DESCRIPTION
## Summary
Adds an optional, nullable integer field `station_recommended_rank` to the `Concert` schema in `api.yaml`: the 1-based rank of a concert within the station's "WXYC recommends" set, ordered by the station's ranking signal (all-time WXYC plays), rank 1 = strongest, null when the concert is not in the set (headliner not rotation-gated). This is the field the iOS client will sort the station tier by. `station_recommended` is unchanged in behavior — it remains the rotation-membership GATE (boolean) — its description now cross-references `station_recommended_rank` to make the gate-vs-selection-rank split explicit. `station_plays` is untouched by this PR. Mirrors the `station_plays` nullable-optional discipline: additive, `nullable: true`, not in `required`, so the generated TypeScript type is `station_recommended_rank?: number | null` and the field can land ahead of the Backend-Service emitter with older clients decoding forward-compatibly. Bumps `info.version` 1.20.0 → 1.21.0 (additive minor).

This is the contract link in the chain: epic WXYC/wxyc-ios-64#576, emitter WXYC/Backend-Service#1756, consumer WXYC/wxyc-ios-64#594.

Closes #248

## Test plan
- [x] `tests/concerts.test.ts`: new spec assertions for `station_recommended_rank` (type/nullable/optional/description) and the updated `station_recommended` description cross-reference, written failing first against the unmodified `api.yaml`
- [x] `tests/concerts.test.ts`: new generated-type assertions accepting a populated rank, an omitted rank, and an explicit `null` rank
- [x] `npm run generate:typescript` regenerated `src/generated/` (gitignored) from the updated `api.yaml`
- [x] `npm run build` passes
- [x] `npm test` — 542/542 passing
- [x] `npm run check:breaking` — no breaking changes detected