### PR TITLE
api.yaml: add bioTokens (pre-parsed Discogs bio markup) to ArtistMetadataResponse

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -5411,6 +5411,15 @@ components:
         imageUrl:
           type: string
           description: Artist image URL from Discogs
+        bioTokens:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/DiscogsResolvedToken'
+          description: >
+            Pre-parsed structured tokens from the artist's Discogs profile
+            markup. Pass-through of DiscogsArtistDetails.profile_tokens, so
+            clients can share token rendering across the two payloads.
 
     ArtworkSearchResponse:
       type: object

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -983,6 +983,24 @@ describe('OpenAPI Specification', () => {
       expect(schema.properties.imageUrl).toBeDefined();
       expect(schema.properties.imageUrl.type).toBe('string');
     });
+
+    it('should define ArtistMetadataResponse.bioTokens as a nullable array of DiscogsResolvedToken (#251)', () => {
+      const schema = spec.components.schemas.ArtistMetadataResponse as {
+        properties: Record<string, { type?: string; nullable?: boolean; items?: { $ref?: string } }>;
+        required?: string[];
+      };
+      expect(schema.properties.bioTokens).toBeDefined();
+      expect(schema.properties.bioTokens.type).toBe('array');
+      // The backend emits an explicit `?? null` for this field.
+      expect(schema.properties.bioTokens.nullable).toBe(true);
+      // Reuses the existing token schema (pass-through of
+      // DiscogsArtistDetails.profile_tokens) — no parallel token shape.
+      expect(schema.properties.bioTokens.items?.$ref).toBe(
+        '#/components/schemas/DiscogsResolvedToken'
+      );
+      // Not required — additive/optional, existing consumers are unaffected.
+      expect(schema.required ?? []).not.toContain('bioTokens');
+    });
   });
 
   describe('API Endpoints', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -269,6 +269,47 @@ describe('Generated TypeScript Types', () => {
 
       expect(response.imageUrl).toBeUndefined();
     });
+
+    // Pin the consumer-facing contract for bioTokens (#251): optional +
+    // nullable array of DiscogsResolvedToken, pass-through of
+    // DiscogsArtistDetails.profile_tokens at the proxy boundary.
+    it('should accept bioTokens as an array of DiscogsResolvedToken', () => {
+      const response: ArtistMetadataResponse = {
+        discogsArtistId: 67890,
+        bio: 'Autechre are an English electronic music duo...',
+        bioTokens: [
+          { type: 'plainText', text: 'Autechre are an English electronic music duo from ' },
+          {
+            type: 'artistLink',
+            name: 'Autechre',
+            display_name: 'Autechre',
+            url: 'https://www.discogs.com/artist/97545',
+          },
+        ],
+      };
+
+      expect(response.bioTokens).toHaveLength(2);
+      expect(response.bioTokens?.[0].type).toBe('plainText');
+      expect(response.bioTokens?.[1].type).toBe('artistLink');
+    });
+
+    it('should accept null bioTokens (the backend emits an explicit `?? null`)', () => {
+      const response: ArtistMetadataResponse = {
+        discogsArtistId: 67890,
+        bioTokens: null,
+      };
+
+      expect(response.bioTokens).toBeNull();
+    });
+
+    it('should allow omitting bioTokens', () => {
+      const response: ArtistMetadataResponse = {
+        discogsArtistId: 67890,
+        bio: 'Autechre are an English electronic music duo...',
+      };
+
+      expect(response.bioTokens).toBeUndefined();
+    });
   });
 
   describe('TrackListItem', () => {


### PR DESCRIPTION
## Summary
Adds a single `bioTokens` property to `ArtistMetadataResponse` in `api.yaml`: a nullable array of `$ref: '#/components/schemas/DiscogsResolvedToken'`. This closes the reverse contract drift where the iOS listener app's `/proxy/metadata/artist` decoder already reads `bioTokens` but the schema never declared it, which would silently drop pre-parsed bio markup once the app adopts the generated `ArtistMetadataResponse`.

`bioTokens` reuses the existing `DiscogsResolvedToken` schema (already backing `DiscogsArtistDetails.profile_tokens` and `LibraryCatalogItem.profile_tokens`) rather than minting a parallel token shape — it is a pass-through of `DiscogsArtistDetails.profile_tokens` at the Backend-Service proxy boundary (`bioTokens: artist.profile_tokens ?? null`), same bytes, same tag set.

No new component schema was added, and `bio`/`wikipediaUrl`/`imageUrl` are untouched per the issue's explicit non-goal.

## Test plan
- [x] `npm run generate:typescript` — `bioTokens?: components["schemas"]["DiscogsResolvedToken"][] | null` present on `ArtistMetadataResponse`
- [x] `npm run generate:python` — `bioTokens: list[DiscogsResolvedToken] | None` present
- [x] `npm run generate:swift` (swift6 generator) — `public var bioTokens: [DiscogsResolvedToken]?` present, `Sendable, Codable, Hashable`
- [x] `npm run generate:kotlin` — `val bioTokens: kotlin.collections.List<DiscogsResolvedToken>? = null` present
- [x] `npm run check:breaking` — clean, no breaking changes detected
- [x] `npm run lint` (tsc --noEmit) — clean
- [x] `npm run build` (tsup) — clean
- [x] `npm test` — 542/542 passing

Closes #251

Cross-references:
- WXYC/wxyc-ios-64#601 — the iOS consumer this unblocks
- WXYC/wxyc-ios-64#412 — the epic (Phase 1b generated-Swift-types adoption)