### PR TITLE
docs(api): document X-Caller-Class + X-Caller-Reason headers alongside X-Caller-Budget-Ms

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -3443,7 +3443,19 @@ components:
             (`results` may be empty, `timeout: true`). The hard cap is an
             internal LML safety floor independent of the caller's
             `X-Caller-Budget-Ms` header; see LML#338 / LML#340 / LML#370 for
-            the cascade-budget design.
+            the cascade-budget design. Backend also forwards two sibling
+            informal headers on the same `/lookup` and `/lookup/bulk`
+            requests, both prose-referenced here rather than formal
+            parameters (matching `X-Caller-Budget-Ms`'s own precedent):
+            `X-Caller-Class` (the resolved BS→LML traffic class, an integer
+            1-5 per Backend-Service's per-caller policy, BS#1826) and
+            `X-Caller-Reason` (the `caller` label string itself, e.g.
+            `proxy-library-search` or `catalog-popularity-freetext-resolve`).
+            Both are sent only when Backend has a registered caller for the
+            request and are otherwise omitted; sending them is inert until
+            LML reads them (LML#928 for `X-Caller-Class`-driven lane
+            routing, LML#931 for `X-Caller-Reason` caller telemetry) — see
+            BS#1843.
 
     # ====================================
     # Identity Block (§3.2.2 / §3.2.5 cascade)


### PR DESCRIPTION
## Summary

Backend-Service is adding two new informal request headers on `/lookup` and `/lookup/bulk` — `X-Caller-Class` (resolved BS→LML traffic class, integer 1-5) and `X-Caller-Reason` (the caller label string) — sent alongside the existing `X-Caller-Budget-Ms` whenever a registered caller is present. This PR documents both in `api.yaml` prose, following the exact same informal-header precedent `X-Caller-Budget-Ms` already established (prose-referenced on `LookupResponse.timeout`, not a formal parameter).

Documentation-only change. `npm run check:breaking` reports no breaking changes (spec differs, but no contract break — pure `description` text).

## Related

- Related to WXYC/Backend-Service#1843, which implements the send side (`buildLookupHeaders` in `shared/lml-client/src/index.ts`).
- The two headers are inert until LML reads them: WXYC/library-metadata-lookup#928 (`X-Caller-Class` lane routing) and WXYC/library-metadata-lookup#931 (`X-Caller-Reason` telemetry).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('api.yaml'))"` — YAML parses cleanly
- [x] `npm run check:breaking` — no breaking changes detected