### PR TITLE
feat(api): add degraded/cache-only discriminator to LookupResponse

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.21.0
+  version: 1.22.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3456,6 +3456,41 @@ components:
             LML reads them (LML#928 for `X-Caller-Class`-driven lane
             routing, LML#931 for `X-Caller-Reason` caller telemetry) — see
             BS#1843.
+        degraded:
+          type: boolean
+          default: false
+          description: >
+            True when LML returned partial or cache-only data because it
+            intentionally shed the enrichment tail — under a caller deadline,
+            admission-control pressure, or an unavailable upstream (LML#930).
+            Distinguishes a degraded/cache-only result from a full success
+            (`degraded: false`) and from a genuine no-match (empty `results`,
+            `degraded: false`, `timeout: false`). Distinct from `timeout`,
+            which signals the internal hard cap fired and the pipeline was
+            abandoned mid-execution; `degraded` is a deliberate shed-the-tail
+            outcome where the returned data is trustworthy but incomplete.
+            Default false, so existing consumers see a byte-identical response.
+        degraded_reason:
+          type: string
+          enum:
+            - deadline_exceeded
+            - cache_only
+            - upstream_unavailable
+          description: >
+            Why the response was degraded. Present only when `degraded: true`;
+            omitted otherwise. Non-exhaustive — LML may add reasons in a later
+            minor version. The Swift and Kotlin codegen decode an unknown value
+            into an `unknownDefault` case and TypeScript consumers see a widened
+            string-literal union, but the Python (datamodel-codegen → pydantic)
+            consumers use strict enums and must regenerate against the new
+            `@wxyc/shared` minor before LML emits a newly added reason.
+            `deadline_exceeded` — the caller's budget or
+            LML's spine deadline elapsed and the enrichment tail was skipped;
+            `cache_only` — LML served cached data without refreshing from
+            upstream; `upstream_unavailable` — an upstream (Discogs, streaming
+            providers) was rate limited or down and its contribution was
+            omitted. Set by LML#930's caller-deadline / admission path; read by
+            LML#931 (`degraded-mode-result` telemetry) and wxyc-canary#82.
 
     # ====================================
     # Identity Block (§3.2.2 / §3.2.5 cascade)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -954,6 +954,35 @@ describe('OpenAPI Specification', () => {
       // time" on the LML hard-cap path.
       expect(schema.required ?? []).not.toContain('timeout');
     });
+
+    it('should add LookupResponse.degraded as an optional boolean defaulting to false', () => {
+      const schema = spec.components.schemas.LookupResponse as {
+        properties: Record<string, { type?: string; default?: unknown }>;
+        required?: string[];
+      };
+      expect(schema.properties.degraded).toBeDefined();
+      expect(schema.properties.degraded.type).toBe('boolean');
+      expect(schema.properties.degraded.default).toBe(false);
+      // Not required — existing consumers ignore it; new consumers distinguish a
+      // deliberately shed-the-tail cache-only/partial result from both success
+      // and a genuine no-match. Distinct from timeout (hard-cap abandonment).
+      expect(schema.required ?? []).not.toContain('degraded');
+    });
+
+    it('should add LookupResponse.degraded_reason as an optional non-required reason enum', () => {
+      const schema = spec.components.schemas.LookupResponse as {
+        properties: Record<string, { type?: string; enum?: string[] }>;
+        required?: string[];
+      };
+      expect(schema.properties.degraded_reason).toBeDefined();
+      expect(schema.properties.degraded_reason.type).toBe('string');
+      expect(schema.properties.degraded_reason.enum).toEqual([
+        'deadline_exceeded',
+        'cache_only',
+        'upstream_unavailable',
+      ]);
+      expect(schema.required ?? []).not.toContain('degraded_reason');
+    });
   });
 
   describe('Proxy Response Schemas', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -29,6 +29,7 @@ import {
   type LibrarySearchItem,
   type LookupResultItem,
   type LookupRequest,
+  type LookupResponse,
   type DiscogsMatchResult,
   type DiscogsWriterCredits,
   type TrackMatchHint,
@@ -902,6 +903,33 @@ describe('Generated TypeScript Types', () => {
       };
 
       expect(baseline.writer_credits).toBeUndefined();
+    });
+  });
+
+  describe('LookupResponse degraded/cache-only discriminator (BS#943)', () => {
+    it('degraded is a boolean and degraded_reason is an optional closed reason union', () => {
+      const full: LookupResponse = { results: [], degraded: false };
+      const shed: LookupResponse = {
+        results: [],
+        degraded: true,
+        degraded_reason: 'deadline_exceeded',
+      };
+
+      expect(full.degraded).toBe(false);
+      expect(shed.degraded_reason).toBe('deadline_exceeded');
+
+      // degraded_reason is a closed string-literal union in the generated type.
+      const reasons: NonNullable<LookupResponse['degraded_reason']>[] = [
+        'deadline_exceeded',
+        'cache_only',
+        'upstream_unavailable',
+      ];
+      expect(reasons).toHaveLength(3);
+    });
+
+    it('omits degraded_reason on a non-degraded response', () => {
+      const ok: LookupResponse = { results: [], degraded: false };
+      expect(ok.degraded_reason).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Part of WXYC/library-metadata-lookup#943 (PR 1 of 3 in the multi-repo rollout).

Adds `degraded` + optional `degraded_reason` to `LookupResponse` in `api.yaml` (the SSOT), following the existing `timeout` boolean precedent. Both default false, so the change is additive and backward-compatible (oasdiff should report non-breaking).

- `degraded: boolean` (default false) — LML intentionally shed the enrichment tail (caller deadline / admission pressure / upstream unavailable) and returned partial or cache-only data; distinct from `timeout` (internal hard cap, pipeline abandoned) and from a genuine no-match.
- `degraded_reason: enum {deadline_exceeded, cache_only, upstream_unavailable}` — present only when `degraded: true`; documented non-exhaustive (mobile codegen decodes unknown values into `unknownDefault`; strict-pydantic Python consumers must regen before LML emits a new reason).
- `api.yaml` `info.version`: 1.21.0 → 1.22.0
- package: 2.3.0 → 2.4.0 (minor)

Tests (mirroring the `timeout` precedent): spec-level pins in `tests/api-spec.test.ts` (both fields optional/non-required, `degraded` boolean default false, `degraded_reason` enum values) + generated-type characterization in `tests/generated-types.test.ts`. Verified locally: `generate:typescript` emits both fields, `build` clean, `test` 550 passed.

**Rollout:** once merged, tagging `v2.4.0` publishes `@wxyc/shared@2.4.0`. The Backend-Service consumer PR then bumps to `^2.4.0`, regenerates types, and adds the `getAlbumMetadata` degraded-vs-success test (AC #3). LML `generated/api_models.py` regen + the actual field-set are deferred to #930 PR1.

This PR does **not** close #943 — the closing test AC lands in the Backend-Service consumer PR.