### PR TITLE
feat(api): add wxycReviews to AlbumMetadataResponse

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -5383,6 +5383,27 @@ components:
           type: string
           description: Source-native rating string when available (e.g. "8.0")
 
+    WxycReviewItem:
+      type: object
+      required:
+        - review
+      properties:
+        review:
+          type: string
+          description: The DJ review body
+        artistBlurb:
+          type: string
+          description: Reviewer-written artist background, when provided
+        recommendedTracks:
+          type: string
+          description: Raw recommended-tracks text, including the form's "!"-rating notation
+        buzzwords:
+          type: string
+          description: Comma-separated descriptors chosen by the reviewer
+        submittedDate:
+          type: string
+          description: Form submission date when available (e.g. "2024-03-15")
+
     AlbumMetadataResponse:
       type: object
       properties:
@@ -5427,6 +5448,11 @@ components:
           items:
             $ref: '#/components/schemas/CriticReviewItem'
           description: Attributed external critic-review snippets, each linking out to the original
+        wxycReviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/WxycReviewItem'
+          description: Consented WXYC DJ album reviews (social_consent = true) for this album. Reviewer identity is never included.
         spotifyUrl:
           type: string
           description: Spotify URL for the album or track


### PR DESCRIPTION
## What

Adds an additive, optional `wxycReviews` array to `AlbumMetadataResponse` plus a new `WxycReviewItem` schema in `api.yaml`. This is the contract (PR-1) for surfacing consented WXYC DJ album reviews in the iOS playcut detail view, mirroring how `criticReviews` / `CriticReviewItem` (#242/#243) shipped the same slice for external critic reviews.

`WxycReviewItem` requires `review` (the review body); `artistBlurb`, `recommendedTracks`, `buzzwords`, and `submittedDate` are optional.

## Why a distinct DTO

- `CriticReviewItem` (external): `source`, `url`, `snippet` (excerpt-capped for copyright), `author`, `publishedDate`, `rating` — wrong shape, these are external, link-out, excerpt-capped.
- `AlbumReview` (#229, closed, the internal browse DTO): carries `id`, `album_id`, `social_consent`, `fcc_violations`, `review_purpose` — wrong altitude for a public per-album attach.
- DJ reviews are WXYC-authored, so unlike external critic reviews the full `review` body may be surfaced (no excerpt cap, no copyright link-out constraint).
- `WxycReviewItem` deliberately omits reviewer name, `social_consent`, `id`, `album_id`, `fcc_violations`, and `review_purpose`. The consent gate (`social_consent = true AND review IS NOT NULL`) is enforced server-side in Backend-Service SQL, not in this DTO — this schema only carries fields safe to publish once that gate has already passed.

## Non-breaking

- `wxycReviews` is optional; no existing field changes.
- `npm run check:breaking` (oasdiff): no breaking changes.
- `npm run generate:typescript`, `lint`, `build`, `test` (550 passing) all green locally. `WxycReviewItem` confirmed exported from `dist/dtos/index.d.ts` alongside `CriticReviewItem`.

Swift/Kotlin generated output is hand-mirrored by consumers, so no generated-client change ships here.

## Related

Backend-Service plan `plans/bs-surface-consented-dj-reviews.md` (PR 1 of 3: this contract, then the Backend-Service serve layer, then the iOS render).

Closes #258
