### PR TITLE
ci: typecheck e2e/ in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Type check
         run: npm run lint
 
+      # Typecheck the e2e/ suite too. It's excluded from `lint` (base tsconfig
+      # excludes e2e/) and from `npm test` (vitest excludes e2e/**), so without
+      # this step a broken e2e file merges green here and first surfaces as a
+      # bs-lml-gate failure that blocks BS/LML prod promotion. See #266.
+      - name: Type check (e2e)
+        run: npm run lint:e2e
+
       - name: Test
         run: npm test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,8 +140,11 @@ Run `npm run check:breaking` before changing `api.yaml` to detect breaking chang
 
 ```bash
 npm test              # Unit tests
+npm run lint:e2e      # Typecheck the e2e/ suite (no live stack needed)
 npm run test:e2e      # E2E tests (requires running services)
 ```
+
+The `e2e/` directory is excluded from both `lint` (base `tsconfig.json` excludes `e2e`) and `npm test` (vitest excludes `e2e/**`), and the live suite (`npm run test:e2e`) only runs from another repo's deploy gate (`bs-lml-gate.yml`). To keep a broken `e2e/` file from merging green and first surfacing as a `bs-lml-gate` failure that blocks BS/LML prod promotion, PR CI runs `lint:e2e` — `tsc -p tsconfig.e2e.json`, a typecheck-only pass over `e2e/**` with `rootDir: "."` so the e2e files aren't flagged as outside the base `rootDir: "./src"`. It does not run the stack; it's cheap and dependency-free. See #266.
 
 ## Testing Standards
 

--- a/e2e/concerts.test.ts
+++ b/e2e/concerts.test.ts
@@ -162,12 +162,40 @@ function expectMatchesConcertsResponseShape(body: unknown): asserts body is Conc
 
 // ---------------------------------------------------------------------------
 
+/**
+ * A row to seed into the `concerts` table. `key`, `venue_id`, `starts_on`, and
+ * `headlining_artist_raw` identify every seeded concert and are always supplied
+ * by the caller; the rest carry a default in `seedConcert`. Declared explicitly
+ * because the defaults object omits the four required fields, so TS could not
+ * infer them from the `...overrides` spread — the latent gap #266 surfaced.
+ */
+interface ConcertSeed {
+  key: string;
+  venue_id: number;
+  starts_on: string;
+  headlining_artist_raw: string;
+  source?: string;
+  starts_at?: string | null;
+  doors_at?: string | null;
+  headlining_artist_id?: number | null;
+  title?: string | null;
+  supporting_artists?: string[];
+  ticket_url?: string | null;
+  image_url?: string | null;
+  event_url?: string | null;
+  price_min?: string | null;
+  price_max?: string | null;
+  age_restriction?: string | null;
+  status?: string;
+  removed_at?: string | null;
+}
+
 describe('Concerts E2E', () => {
   let client: E2EClient;
   let sql: ReturnType<typeof postgres> | undefined;
   const SCHEMA = config.schemaName;
 
-  const seedConcert = async (overrides: Record<string, unknown>): Promise<void> => {
+  const seedConcert = async (overrides: ConcertSeed): Promise<void> => {
     const row = {
       source: 'triangle_shows',
       starts_at: null,
@@ -232,20 +260,22 @@ describe('Concerts E2E', () => {
     sql = postgres(config.dbUrl!, { max: 1, onnotice: () => {} });
     await cleanup(); // idempotent across re-runs on the shared schema
 
-    const [venue] = await sql.unsafe(
+    const [venue] = await sql.unsafe<{ id: number }[]>(
       `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
        VALUES ($1, 'WXYC Shared E2E Room', 'Carrboro', 'NC', '300 E Main St')
        RETURNING id`,
       [VENUE_SLUG]
     );
-    const venueId = (venue as { id: number }).id;
+    if (!venue) throw new Error('failed to seed venue');
+    const venueId = venue.id;
 
-    const [artist] = await sql.unsafe(
+    const [artist] = await sql.unsafe<{ id: number }[]>(
       `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters)
        VALUES ($1, $1, 'ZZ') RETURNING id`,
       [ARTIST_NAME]
     );
-    const artistId = (artist as { id: number }).id;
+    if (!artist) throw new Error('failed to seed artist');
+    const artistId = artist.id;
 
     // Past — excluded by the default "today forward" window.
     await seedConcert({
@@ -403,8 +433,10 @@ describe('Concerts E2E', () => {
       expect(res.status).toBe(200);
       const rows = seeded(res.body);
       expect(rows).toHaveLength(1);
-      expect(rows[0].headlining_artist_raw).toBe(ARTIST_NAME);
-      expect(typeof rows[0].headlining_artist_id).toBe('number');
+      const [only] = rows;
+      expect(only).toBeDefined();
+      expect(only!.headlining_artist_raw).toBe(ARTIST_NAME);
+      expect(typeof only!.headlining_artist_id).toBe('number');
       // The removed row also has a non-null headlining_artist_id — its absence
       // here proves curated still ANDs in removed_at IS NULL.
       expect(rows.map((c) => c.headlining_artist_raw)).not.toContain(REMOVED_NAME);

--- a/e2e/contract/openapi-compliance.test.ts
+++ b/e2e/contract/openapi-compliance.test.ts
@@ -46,7 +46,11 @@ let schemas: Record<string, SchemaObject>;
  */
 function resolveRef(ref: string, schemas: Record<string, SchemaObject>): SchemaObject {
   const name = ref.replace('#/components/schemas/', '');
-  return schemas[name];
+  const schema = schemas[name];
+  if (!schema) {
+    throw new Error(`Unresolved $ref: ${ref}`);
+  }
+  return schema;
 }
 
 /**

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -252,6 +252,9 @@ export class E2EAuthHelper {
 
     // Decode JWT payload (no verification — the backend does that)
     const payloadB64 = token.split('.')[1];
+    if (!payloadB64) {
+      return null;
+    }
     const payload = JSON.parse(
       Buffer.from(payloadB64, 'base64url').toString('utf-8')
     );

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:drift-guard": "bats scripts/__tests__/check-corpus-drift.test.sh",
     "test:bs-lml-gate": "bats scripts/__tests__/bs-lml-gate/*.test.sh",
     "lint": "tsc --noEmit --declaration false --declarationMap false",
+    "lint:e2e": "tsc -p tsconfig.e2e.json",
     "clean": "rm -rf dist",
     "generate": "npm run generate:typescript && npm run generate:python && npm run generate:swift && npm run generate:kotlin",
     "generate:typescript": "node scripts/generate-models.js",

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["e2e/**/*.ts", "src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds a **typecheck-only** guard for the `e2e/` suite to wxyc-shared's own PR CI, and fixes the pre-existing type errors that blocked it from going green.

`e2e/` currently gets zero validation on a wxyc-shared PR: it's excluded from `lint` (base `tsconfig.json` excludes `e2e`) and from `npm test` (vitest excludes `e2e/**`), and the live suite (`npm run test:e2e`) only runs from **another repo's** deploy gate (`bs-lml-gate.yml`, triggered by BS/LML staging deploys). So a broken edit to any `e2e/*.test.ts` merges green here and first surfaces as a `bs-lml-gate` failure that blocks BS/LML prod promotion for an unrelated team — the exact root cause that let the stale `../src/dtos/*.dto.js` imports rot undetected (cleaned up in #265).

## How

- `tsconfig.e2e.json` — extends the base config with `rootDir: "."` (so the e2e files aren't flagged `TS6059` for being outside the base `rootDir: "./src"`), `types: ["node"]` for `Buffer`/`process`, and `noEmit`.
- `lint:e2e` npm script (`tsc -p tsconfig.e2e.json`).
- `.github/workflows/ci.yml` — a **Type check (e2e)** step after the existing **Type check**. No new job: the required status check is the whole `test` job, so the guard is required automatically. No live stack, no service dependency — cheap.

## Pre-existing errors fixed

The issue inventoried 9 errors from a probe against a *symlinked* `node_modules`. Under a clean `npm ci` the `postgres` `TS2307` is spurious (gone) but two `TS2352` casts on the seed rows appear (the real `postgres` types apply where the probe had `any`). Net **10 errors across 3 files**, all fixed:

- **`concerts.test.ts` seed rows** — explicit `ConcertSeed` interface so the four always-supplied identity fields (`key`, `venue_id`, `starts_on`, `headlining_artist_raw`) are typed rather than inferred-away from the defaults object. (Verified every `seedConcert(...)` call already supplies all four — no latent seed bug, just a typing gap.)
- **`concerts.test.ts` venue/artist seed** — `sql.unsafe<{ id: number }[]>` + an undefined guard instead of a cast that only compiled while `postgres` resolved to `any`.
- **`concerts.test.ts` curated assertion** — guard `rows[0]` under `noUncheckedIndexedAccess`.
- **`openapi-compliance.test.ts` `resolveRef`** — throw on an unresolved `$ref` instead of returning `undefined` as `SchemaObject`.
- **`setup.ts` `getJWTToken`** — guard the JWT payload segment before `Buffer.from` (return `null` on a malformed token, matching the function's other failure paths).

## Verification

- Local, clean `npm ci`: `generate:typescript` → `build` → `lint` → `lint:e2e` → `npm test` (550 tests) all green.
- Guard proven: dropping a nonexistent import into an `e2e/` file makes `lint:e2e` fail (`TS2307`); it goes green again on removal. Satisfies the acceptance criterion.
- `bs-lml-gate` behavior unchanged — the live-stack suite still runs there; this PR only adds a typecheck.

Closes #266