### PR TITLE
docs(api): point library_url descriptions at the dj.wxyc.org permalink

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -3147,7 +3147,11 @@ components:
             and release_call_number.
         library_url:
           type: string
-          description: URL to view this release in the WXYC library
+          description: >
+            Per-release dj.wxyc.org permalink for this release. Points at the dj-site
+            legacy front door `/dashboard/album/legacy/{id}`, which resolves the legacy
+            library `id` to the canonical release route server-side and 308-redirects.
+            Empty string for a row-less result (`id == 0`).
         on_streaming:
           type: boolean
           description: True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.
@@ -5230,7 +5234,11 @@ components:
           description: Computed call number (e.g. "Rock CD S 1/1")
         library_url:
           type: string
-          description: URL to the release on wxyc.info
+          description: >
+            Per-release dj.wxyc.org permalink for this release. Points at the dj-site
+            legacy front door `/dashboard/album/legacy/{id}`, which resolves the legacy
+            library `id` to the canonical release route server-side and 308-redirects.
+            Null when unavailable.
         matched_via:
           type: array
           items:


### PR DESCRIPTION
Closes #268.

## What

Re-points both `library_url` field descriptions in `api.yaml` from the legacy tubafrenzy target to the dj.wxyc.org per-release permalink:

- `LibraryCatalogItem.library_url` — was "URL to view this release in the WXYC library"
- `LibrarySearchItem.library_url` — was "URL to the release on wxyc.info"

LML started emitting `https://dj.wxyc.org/dashboard/album/legacy/{id}` for this field in [library-metadata-lookup#1015](https://github.com/WXYC/library-metadata-lookup/pull/1015) (PR4). This aligns the contract prose with the runtime value.

## Why `/dashboard/album/legacy/{id}` (the id-space detail)

`self.id` on a library row is the **legacy** library id (== tubafrenzy `LIBRARY_RELEASE.ID`), not the Backend-Service serial `library.id`. The dj-site legacy front door ([dj-site#1050](https://github.com/WXYC/dj-site/pull/1050)) resolves legacy → serial server-side (via [Backend-Service#1881](https://github.com/WXYC/Backend-Service/pull/1881)'s `GET /library/info?legacy_release_id=`) and 308-redirects to the canonical serial route. The descriptions now capture that so a reader isn't surprised by the `legacy` segment.

## Scope

Description text only — no type, `required`, or nullability change on either field. Consequently:

- `oasdiff` (via `npm run check:breaking`) reports **no breaking changes**.
- `info.version` is **not** bumped, matching the `docs(api)` precedent (commit `01dfaf2`).

## Testing (local)

- `npm run check:breaking` → no breaking changes
- `npm run generate:typescript`, `npm run lint`, `npm run lint:e2e` → clean
- `npm test` → 550 passed
- Previewed the downstream Python regen with the pinned `datamodel-codegen`: only the two `library_url` `Field(description=...)` strings change.

## Downstream follow-ups (separate PRs, after this merges)

LML and request-o-matic both commit `generated/api_models.py` and run a PR-only Codegen Freshness job that downloads `api.yaml` from this repo's `main` and diffs. Once this lands, each must regenerate to stay green:

- WXYC/library-metadata-lookup — regen `generated/api_models.py` (PR5b)
- WXYC/request-o-matic — regen `generated/api_models.py` (PR5c)

## Chain

PR5a of the dj.wxyc.org per-release permalink effort. PR2 (BS#1881) + PR3 (dj-site#1050) + PR4 (LML#1015) are merged and deployed to prod.
