### PR TITLE
api.yaml: LookupRequest.include_locations + LookupResponse.also_available_on

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -3066,6 +3066,19 @@ components:
             is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets
             this to true on every call; other consumers (catalog search,
             dj-site proxy, iOS apps) leave it false.
+        include_locations:
+          type: boolean
+          default: false
+          description: >
+            Per the comprehensive multi-location union (LML#1018/#1022). When
+            true, the response carries an additional `also_available_on`
+            array — every other WXYC library shelf location that carries the
+            same track (V/A compilations, soundtracks), ranked by LML, so a
+            DJ can find a backup copy when the primary is missing or
+            checked-out. When false (the default), the response is
+            byte-identical to today — `also_available_on` is omitted.
+            DJ-facing callers (dj-site catalog, request-o-matic) set this;
+            Backend enrichment does not.
         extended:
           type: boolean
           description: >
@@ -3485,6 +3498,17 @@ components:
             LML reads them (LML#928 for `X-Caller-Class`-driven lane
             routing, LML#931 for `X-Caller-Reason` caller telemetry) — see
             BS#1843.
+        also_available_on:
+          type: array
+          items:
+            $ref: '#/components/schemas/LibraryLocation'
+          description: >
+            Every other WXYC library shelf location that carries the same
+            track (V/A compilations, soundtracks), ranked by LML so
+            consumers can render in order. Present only when the request set
+            `include_locations: true`; absent otherwise (empty when the flag
+            is set but no other location carries the track) so existing
+            consumers see a byte-identical response (LML#1018/#1022).
         degraded:
           type: boolean
           default: false
@@ -3520,6 +3544,58 @@ components:
             providers) was rate limited or down and its contribution was
             omitted. Set by LML#930's caller-deadline / admission path; read by
             LML#931 (`degraded-mode-result` telemetry) and wxyc-canary#82.
+
+    LibraryLocation:
+      type: object
+      description: >
+        A single other WXYC shelf location carrying the same track, returned
+        on `LookupResponse.also_available_on` when the request set
+        `include_locations: true` (LML#1018/#1022's comprehensive
+        multi-location union). Deliberately a lean entry rather than a full
+        `LookupResultItem` — no live artwork/identity resolution; art is
+        precomputed at index time.
+      required:
+        - library_id
+        - track_artist
+        - track_title
+      properties:
+        library_id:
+          type: integer
+          description: WXYC library.id (shelf location) for this copy.
+        artist:
+          type: string
+          description: Shelf/album artist (e.g. "Soundtracks - L").
+        album_title:
+          type: string
+          description: Album/release title (e.g. "Lost in Translation").
+        track_position:
+          type: string
+          nullable: true
+          description: The track's position on this release (e.g. "A1"), when known.
+        track_title:
+          type: string
+          description: Track title.
+        track_artist:
+          type: string
+          description: >
+            Credited-as artist for this track (e.g. "Brian Reitzell And
+            Roger J. Manning, Jr."), which may differ from the shelf artist
+            on a compilation.
+        credit_role:
+          type: string
+          enum:
+            - primary
+            - featured
+            - extra
+          description: The role this credit represents on the track.
+        discogs_release_id:
+          type: integer
+          nullable: true
+          description: Discogs release ID, usable as an art re-resolution key.
+        artwork_url:
+          type: string
+          nullable: true
+          description: Precomputed cover art URL for this location.
 
     # ====================================
     # Identity Block (§3.2.2 / §3.2.5 cascade)

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -985,6 +985,68 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  describe('Lookup Multi-Location Union (LML#1018/#1022)', () => {
+    it('should define LookupRequest.include_locations as an optional boolean defaulting to false', () => {
+      const schema = spec.components.schemas.LookupRequest as {
+        properties: Record<string, { type?: string; default?: unknown }>;
+        required?: string[];
+      };
+      expect(schema.properties.include_locations).toBeDefined();
+      expect(schema.properties.include_locations.type).toBe('boolean');
+      expect(schema.properties.include_locations.default).toBe(false);
+      // Not required — existing consumers continue to omit it and see the
+      // byte-identical v1 response shape.
+      expect(schema.required ?? []).not.toContain('include_locations');
+    });
+
+    it('should attach optional also_available_on array of LibraryLocation to LookupResponse', () => {
+      const schema = spec.components.schemas.LookupResponse as {
+        properties: Record<string, { type?: string; items?: { $ref?: string } }>;
+        required?: string[];
+      };
+      expect(schema.properties.also_available_on).toBeDefined();
+      expect(schema.properties.also_available_on.type).toBe('array');
+      expect(schema.properties.also_available_on.items?.$ref).toBe(
+        '#/components/schemas/LibraryLocation',
+      );
+      // Not required — present only when include_locations: true.
+      expect(schema.required ?? []).not.toContain('also_available_on');
+    });
+
+    it('should define LibraryLocation as a lean location entry, distinct from LookupResultItem', () => {
+      const schema = spec.components.schemas.LibraryLocation as {
+        required: string[];
+        properties: Record<
+          string,
+          { type?: string; nullable?: boolean; description?: string; enum?: string[] }
+        >;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.required).toEqual(['library_id', 'track_artist', 'track_title']);
+
+      expect(schema.properties.library_id.type).toBe('integer');
+      expect(schema.properties.artist.type).toBe('string');
+      expect(schema.properties.album_title.type).toBe('string');
+      expect(schema.properties.track_title.type).toBe('string');
+
+      expect(schema.properties.track_position.type).toBe('string');
+      expect(schema.properties.track_position.nullable).toBe(true);
+
+      expect(schema.properties.track_artist.type).toBe('string');
+
+      expect(schema.properties.credit_role.type).toBe('string');
+      expect(schema.properties.credit_role.enum ?? undefined).toEqual(
+        expect.arrayContaining(['primary', 'featured', 'extra']),
+      );
+
+      expect(schema.properties.discogs_release_id.type).toBe('integer');
+      expect(schema.properties.discogs_release_id.nullable).toBe(true);
+
+      expect(schema.properties.artwork_url.type).toBe('string');
+      expect(schema.properties.artwork_url.nullable).toBe(true);
+    });
+  });
+
   describe('Proxy Response Schemas', () => {
     it('should define AlbumMetadataResponse with enriched fields', () => {
       const schema = spec.components.schemas.AlbumMetadataResponse as {


### PR DESCRIPTION
## Summary

Adds the contract for LML's comprehensive multi-location union (WXYC/library-metadata-lookup#1022): for a track query, `/lookup` can now optionally return the primary match plus a ranked list of every other WXYC shelf location carrying the same track (V/A compilations, soundtracks), so a DJ can find a backup copy when the primary is missing or checked-out.

- `LookupRequest.include_locations`: optional boolean, default false. Mirrors the `include_identity` precedent — absent/false leaves the response byte-identical to today.
- `LookupResponse.also_available_on`: array of `LibraryLocation`, present only when `include_locations: true` is set on the request.
- `LibraryLocation`: a new, deliberately lean schema (required `library_id`, `track_artist`, `track_title`; optional/nullable `track_position`, `credit_role`, `discogs_release_id`, `artwork_url`, plus `artist`/`album_title`) — not a full `LookupResultItem`, since it avoids live artwork/identity resolution (art is precomputed).

`npm run check:breaking` confirms this is non-breaking (additive minor).

Closes #270

## Test plan

- [x] `npm test` — full suite passes (553 tests), including new coverage for `include_locations`, `also_available_on`, and the `LibraryLocation` schema shape
- [x] `npm run lint` / `npm run lint:e2e` pass
- [x] `npm run generate` regenerates TS/Python/Swift/Kotlin cleanly against the new schema
- [x] `npm run check:breaking` reports no breaking changes