### PR TITLE
Add Album discogs-unavailable fields + catch up PATCH /library/{id} contract

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.23.0
+  version: 1.24.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -1180,6 +1180,67 @@ components:
         album_artist:
           type: string
           description: Credited album artist for compilations (e.g., "Kruder & Dorfmeister" on a DJ-Kicks release filed under Various Artists).
+        discogsUnavailable:
+          type: boolean
+          description: |
+            MD-set marker indicating this release is intentionally not on
+            Discogs (embargoed promo, audience-segment release, etc.). When
+            true, the LML runtime-lookup chokepoint does not attempt Discogs
+            resolution for this release. See WXYC/wiki plans/rotation-discogs-unavailable.md.
+        discogsUnavailableNote:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: Optional free-text reason for `discogsUnavailable`.
+        lastDiscogsRecheckAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            Stamped on every recheck attempt by the
+            `library-discogs-unavailable-recheck` cron. Read-only from the
+            client side.
+
+    UpdateAlbumRequest:
+      type: object
+      description: |
+        Partial-update payload for `PATCH /library/{id}` (BS#1154). Mirrors
+        Backend-Service's wire-level `UpdateAlbumRequest` type
+        (apps/backend/controllers/library.controller.ts) exactly: only fields
+        present in the body are validated and written. The 8 legacy fields
+        are snake_case (matching AddAlbumRequest / the DB columns); the two
+        BS#1281 discogs fields are camelCase, per the whitelist BS's
+        `UPDATABLE_ALBUM_FIELDS` actually reads from `req.body`.
+        `artist_name` and `code_number` are deliberately absent — they are
+        server-derived (re-attribution side effects of an `artist_id`
+        change), never read from the client body. `lastDiscogsRecheckAt` is
+        also absent — it is server-write-only (the recheck cron writes it
+        directly).
+      properties:
+        album_title:
+          type: string
+        label:
+          type: string
+        label_id:
+          type: integer
+          nullable: true
+        genre_id:
+          type: integer
+        format_id:
+          type: integer
+        artist_id:
+          type: integer
+        alternate_artist_name:
+          type: string
+          nullable: true
+        disc_quantity:
+          type: integer
+        discogsUnavailable:
+          type: boolean
+        discogsUnavailableNote:
+          type: string
+          nullable: true
+          maxLength: 500
 
     AlbumSearchResult:
       type: object
@@ -7003,6 +7064,43 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/TrackSearchResult'
+
+  /library/{id}:
+    patch:
+      summary: Update catalog album (partial)
+      description: |
+        True partial-update semantics (BS#1154): only fields present in the
+        body are validated and written. See `UpdateAlbumRequest` for the
+        exact wire shape BS reads.
+      tags:
+        - Library
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAlbumRequest'
+      responses:
+        '200':
+          description: Successfully updated album
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlbumSearchResult'
+        '404':
+          description: Album not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
 
   /library/{id}/missing:
     patch:

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -377,6 +377,146 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  // BS#1281 (Not-on-Discogs 1a) read fields + BS#1154 PATCH /library/:id
+  // contract catch-up (wxyc-shared#156). BS#1154 shipped the endpoint and its
+  // wire-level request type in Backend-Service code without ever propagating
+  // the schema here — this closes that gap, matching the SHIPPED server
+  // (apps/backend/controllers/library.controller.ts `UpdateAlbumRequest` +
+  // `UPDATABLE_ALBUM_FIELDS`) exactly, not an idealized/renamed shape.
+  describe('Discogs-Unavailable Album fields + UpdateAlbumRequest (BS#1281 / BS#1154 / #156)', () => {
+    type SchemaProp = {
+      type?: string;
+      nullable?: boolean;
+      format?: string;
+      maxLength?: number;
+      default?: unknown;
+    };
+    type Schema = {
+      properties?: Record<string, SchemaProp>;
+      required?: string[];
+    };
+
+    it('Album gains discogsUnavailable as a boolean', () => {
+      const schema = spec.components.schemas.Album as Schema;
+      const prop = schema.properties?.discogsUnavailable;
+      expect(prop).toBeDefined();
+      expect(prop?.type).toBe('boolean');
+      expect(schema.required ?? []).not.toContain('discogsUnavailable');
+    });
+
+    it('Album gains discogsUnavailableNote as a nullable string capped at 500 chars', () => {
+      const schema = spec.components.schemas.Album as Schema;
+      const prop = schema.properties?.discogsUnavailableNote;
+      expect(prop).toBeDefined();
+      expect(prop?.type).toBe('string');
+      expect(prop?.nullable).toBe(true);
+      expect(prop?.maxLength).toBe(500);
+      expect(schema.required ?? []).not.toContain('discogsUnavailableNote');
+    });
+
+    it('Album gains lastDiscogsRecheckAt as a nullable date-time string (server-write-only)', () => {
+      const schema = spec.components.schemas.Album as Schema;
+      const prop = schema.properties?.lastDiscogsRecheckAt;
+      expect(prop).toBeDefined();
+      expect(prop?.type).toBe('string');
+      expect(prop?.format).toBe('date-time');
+      expect(prop?.nullable).toBe(true);
+      expect(schema.required ?? []).not.toContain('lastDiscogsRecheckAt');
+    });
+
+    it('defines UpdateAlbumRequest matching BS wire format exactly: 10 fields, all optional, no `required` list', () => {
+      const schema = spec.components.schemas.UpdateAlbumRequest as Schema;
+      expect(schema).toBeDefined();
+      expect(schema.required ?? []).toEqual([]);
+      expect(Object.keys(schema.properties ?? {}).sort()).toEqual(
+        [
+          'album_title',
+          'label',
+          'label_id',
+          'genre_id',
+          'format_id',
+          'artist_id',
+          'alternate_artist_name',
+          'disc_quantity',
+          'discogsUnavailable',
+          'discogsUnavailableNote',
+        ].sort(),
+      );
+    });
+
+    it('UpdateAlbumRequest keeps the 8 legacy fields snake_case, matching AddAlbumRequest / BS wire keys', () => {
+      const schema = spec.components.schemas.UpdateAlbumRequest as Schema;
+      const props = schema.properties ?? {};
+      expect(props.album_title?.type).toBe('string');
+      expect(props.label?.type).toBe('string');
+      // BS wire type: `label?: string` — NOT nullable, unlike Album.label's DB column.
+      expect(props.label?.nullable).toBeUndefined();
+      expect(props.label_id?.type).toBe('integer');
+      expect(props.label_id?.nullable).toBe(true);
+      expect(props.genre_id?.type).toBe('integer');
+      expect(props.format_id?.type).toBe('integer');
+      expect(props.artist_id?.type).toBe('integer');
+      expect(props.alternate_artist_name?.type).toBe('string');
+      expect(props.alternate_artist_name?.nullable).toBe(true);
+      expect(props.disc_quantity?.type).toBe('integer');
+    });
+
+    it('UpdateAlbumRequest carries the two discogs fields camelCase, matching the whitelist BS actually reads', () => {
+      const schema = spec.components.schemas.UpdateAlbumRequest as Schema;
+      const props = schema.properties ?? {};
+      expect(props.discogsUnavailable?.type).toBe('boolean');
+      expect(props.discogsUnavailableNote?.type).toBe('string');
+      expect(props.discogsUnavailableNote?.nullable).toBe(true);
+      expect(props.discogsUnavailableNote?.maxLength).toBe(500);
+    });
+
+    it('UpdateAlbumRequest omits lastDiscogsRecheckAt (server-write-only, never client-supplied)', () => {
+      const schema = spec.components.schemas.UpdateAlbumRequest as Schema;
+      expect(schema.properties?.lastDiscogsRecheckAt).toBeUndefined();
+    });
+
+    it('UpdateAlbumRequest omits artist_name and code_number (server-derived; UPDATABLE_ALBUM_FIELDS never reads them from the body)', () => {
+      const schema = spec.components.schemas.UpdateAlbumRequest as Schema;
+      expect(schema.properties?.artist_name).toBeUndefined();
+      expect(schema.properties?.code_number).toBeUndefined();
+    });
+
+    it('declares PATCH /library/{id} under BearerAuth, referencing UpdateAlbumRequest and returning AlbumSearchResult', () => {
+      const path = spec.paths['/library/{id}'] as {
+        patch?: {
+          security?: Array<Record<string, unknown[]>>;
+          parameters?: Array<{ name: string; in: string; schema?: { type?: string } }>;
+          requestBody?: { content?: Record<string, { schema?: { $ref?: string } }> };
+          responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }>;
+        };
+      };
+      expect(path).toBeDefined();
+      expect(path.patch).toBeDefined();
+      expect(path.patch!.security).toEqual([{ BearerAuth: [] }]);
+
+      const idParam = path.patch!.parameters?.find((p) => p.name === 'id');
+      expect(idParam?.in).toBe('path');
+      expect(idParam?.schema?.type).toBe('integer');
+
+      expect(path.patch!.requestBody?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/UpdateAlbumRequest',
+      );
+      // Matches libraryController.updateAlbum, which returns
+      // libraryService.getAlbumFromDB() — the same call markMissing/markFound
+      // use, already documented as AlbumSearchResult on the sibling paths.
+      expect(path.patch!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/AlbumSearchResult',
+      );
+      expect(path.patch!.responses?.['404']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/ApiErrorResponse',
+      );
+    });
+
+    it('bumps info.version to 1.24.0', () => {
+      expect(spec.info.version).toBe('1.24.0');
+    });
+  });
+
   // GET /library/catalog (the gzipped-NDJSON bulk export) and its row shape
   // shipped in Backend-Service#1468 (Epic F, parent #1466) but were never
   // propagated to this cross-repo SSOT — only to BS's local Swagger-only


### PR DESCRIPTION
Closes #156

## Summary

BS#1281 (Not-on-Discogs 1a) adds three columns to `library`, and dj-site/iOS/Android all read/write them via `PATCH /library/:id`, but the contract was never expressed in `api.yaml`. Triage during planning found a second, related gap: BS#1154 shipped `PATCH /library/:id` -> `updateAlbum` in Backend-Service code (with a 12-field partial-update TS type at the service layer) but never propagated the endpoint or a request schema into this contract at all -- `api.yaml` had neither `PATCH /library/{id}` nor `UpdateAlbumRequest`, only the `/missing` and `/found` siblings.

**Scope: full catch-up**, agreed with the maintainer during planning (see issue comment):
1. `PATCH /library/{id}` path, referencing a new `UpdateAlbumRequest` request schema, tagged `Library`/`BearerAuth`, 200 -> `AlbumSearchResult`, 404 -> `ApiErrorResponse`.
2. `UpdateAlbumRequest` -- verified against Backend-Service's actual shipped wire format (`apps/backend/controllers/library.controller.ts`'s `UpdateAlbumRequest` type + the `UPDATABLE_ALBUM_FIELDS` whitelist), not the aspirational 12-field/camelCase shape first proposed. It's **10 fields**, all optional: 8 legacy fields stay snake_case (`album_title`, `label`, `label_id`, `genre_id`, `format_id`, `artist_id`, `alternate_artist_name`, `disc_quantity` -- matching `AddAlbumRequest`'s existing precedent and the exact keys BS reads off `req.body`), and the two BS#1281 fields are camelCase (`discogsUnavailable`, `discogsUnavailableNote`), matching the whitelist exactly. `artist_name` and `code_number` are deliberately omitted -- they're server-derived (re-attribution side effects of an `artist_id` change), never read from the client body. `lastDiscogsRecheckAt` is also omitted -- server-write-only, stamped by the recheck cron.
3. Three read-only fields on `Album`: `discogsUnavailable` (boolean), `discogsUnavailableNote` (string, nullable, maxLength 500), `lastDiscogsRecheckAt` (string date-time, nullable).
4. `info.version` 1.23.0 -> 1.24.0.

## Codegen verification

Ran all four generators (`npm run generate`) against the updated spec. All three new `Album` fields come out optional + nullable with no `required`/non-optional default in every target:

- **TypeScript**: `discogsUnavailable?: boolean`, `discogsUnavailableNote?: string | null`, `lastDiscogsRecheckAt?: string | null`.
- **Python** (pydantic): `discogsUnavailable: bool | None = None`, etc. -- field names stay camelCase in the generated model, matching the existing precedent for other camelCase api.yaml fields (e.g. `discogsArtistId` on `AlbumMetadataResponse`); this repo's Python codegen doesn't snake_case-ify field names.
- **Swift** (`swift6` generator): all three properties are `Bool?`/`String?`/`Date?` with synthesized `Codable` (no custom `init(from:)`), so old decoders ignore the new JSON keys and new decoders tolerate their absence on pre-bump payloads.
- **Kotlin** (`kotlinx.serialization`): all three properties are nullable with `= null` defaults, so missing keys decode fine.

No decoder issue surfaced, so no `default:` values were needed in `api.yaml` beyond the nullability already specified.

## Test plan

- [x] Extended `tests/api-spec.test.ts` (TDD: added first, confirmed red, then implemented `api.yaml` to green) covering: the 3 `Album` fields (type/nullable/maxLength/not-required), `UpdateAlbumRequest`'s exact 10-field shape (no `required` list), the snake_case/camelCase split, `label`'s non-nullability vs `label_id`/`alternate_artist_name`/`discogsUnavailableNote`'s nullability, absence of `lastDiscogsRecheckAt`/`artist_name`/`code_number`, the `PATCH /library/{id}` path shape (security, path param, request/response refs), and the version bump.
- [x] `npm test` -- 563/563 passing.
- [x] `npm run lint` -- clean.
- [x] `npm run lint:e2e` -- clean.
- [x] `npm run check:breaking` (oasdiff) -- no breaking changes detected.
- [x] `npm run generate` (all four targets) -- verified output shapes above.
- [x] `npm run build` -- clean.