### PR TITLE
feat(api): add LiveFsInsertEvent to the LiveFsEvent SSE union

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.24.0
+  version: 1.25.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -5779,6 +5779,37 @@ components:
           type: string
           format: date-time
 
+    LiveFsInsertEvent:
+      description: >
+        SSE event emitted on the `live-fs-topic` the instant a new flowsheet row
+        is created (BS#1888), before enrichment runs. Payload carries the same
+        client-facing flowsheet row (`FlowsheetEntryResponse`) as
+        `LiveFsUpdateEvent`, but at insert time the row is `metadata_status:
+        'pending'` with the enrichment fields (`artwork_url`, `release_year`,
+        `discogs_url`, ...) still null — all of which `FlowsheetEntryResponse`
+        already models as nullable, so a not-yet-enriched row is valid. A
+        subscriber appends the row immediately; the enrichment fields arrive
+        seconds later as the existing `LiveFsUpdateEvent`. Same anonymous
+        `live-fs-topic` allow-list projection as `update` (BS#1534) — internal
+        columns (`search_doc`, `composer`, `legacy_*`, ...) do not ride this
+        stream. Removes Epic C's ([WXYC/Backend-Service#877]) polling latency
+        floor: consumers (WXYC/wxyc-ios-64#269, dj-site) learn of a new track on
+        the SSE push instead of the next reconciliation poll.
+      type: object
+      required:
+        - type
+        - payload
+        - timestamp
+      properties:
+        type:
+          type: string
+          enum: [insert]
+        payload:
+          $ref: '#/components/schemas/FlowsheetEntryResponse'
+        timestamp:
+          type: string
+          format: date-time
+
     LiveFsEvent:
       description: >
         Discriminated union of events emitted on the `live-fs-topic`. Every
@@ -5787,11 +5818,13 @@ components:
       oneOf:
         - $ref: '#/components/schemas/LiveFsUpdateEvent'
         - $ref: '#/components/schemas/LiveFsRefetchEvent'
+        - $ref: '#/components/schemas/LiveFsInsertEvent'
       discriminator:
         propertyName: type
         mapping:
           update: '#/components/schemas/LiveFsUpdateEvent'
           refetch: '#/components/schemas/LiveFsRefetchEvent'
+          insert: '#/components/schemas/LiveFsInsertEvent'
 
     # ── Auto-DJ system ─────────────────────────────────────────────────────
     # Orchestrator <-> Arduino management channel, and the dj-site virtual
@@ -8234,7 +8267,10 @@ paths:
         `data: {...}\n\n` frames. The first frame is always a
         `connection-established` event carrying the server-assigned `client_id`.
         Subsequent frames depend on the subscribed topics — for `live-fs-topic`
-        the frames are `LiveFsEvent` instances.
+        the frames are `LiveFsEvent` instances: a `LiveFsInsertEvent` (`insert`)
+        when a row is first created (pending, pre-enrichment), a
+        `LiveFsUpdateEvent` (`update`) when its metadata is finalized, and a
+        `LiveFsRefetchEvent` (`refetch`) on bulk state changes.
 
         Contract: `CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH`.
       security: []

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -511,10 +511,6 @@ describe('OpenAPI Specification', () => {
         '#/components/schemas/ApiErrorResponse',
       );
     });
-
-    it('bumps info.version to 1.24.0', () => {
-      expect(spec.info.version).toBe('1.24.0');
-    });
   });
 
   // GET /library/catalog (the gzipped-NDJSON bulk export) and its row shape
@@ -1302,16 +1298,39 @@ describe('OpenAPI Specification', () => {
       expect(schema.properties.type.enum).toEqual(['refetch']);
     });
 
+    it('should define LiveFsInsertEvent with the {type, payload, timestamp} envelope', () => {
+      const schema = spec.components.schemas.LiveFsInsertEvent as {
+        type: string;
+        required: string[];
+        properties: Record<string, { enum?: string[]; $ref?: string }>;
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+      expect(schema.required).toEqual(['type', 'payload', 'timestamp']);
+      expect(schema.properties.type.enum).toEqual(['insert']);
+      // Carries the full newly-inserted flowsheet row — same payload shape as
+      // LiveFsUpdateEvent, valid pre-enrichment (metadata_status 'pending',
+      // enrichment fields nullable on FlowsheetEntryResponse).
+      expect(schema.properties.payload.$ref).toBe('#/components/schemas/FlowsheetEntryResponse');
+    });
+
     it('should define LiveFsEvent as a discriminated union over `type`', () => {
       const schema = spec.components.schemas.LiveFsEvent as {
         oneOf: Array<{ $ref: string }>;
         discriminator: { propertyName: string; mapping: Record<string, string> };
       };
       expect(schema).toBeDefined();
-      expect(schema.oneOf).toHaveLength(2);
+      expect(schema.oneOf).toHaveLength(3);
       expect(schema.discriminator.propertyName).toBe('type');
       expect(schema.discriminator.mapping.update).toContain('LiveFsUpdateEvent');
       expect(schema.discriminator.mapping.refetch).toContain('LiveFsRefetchEvent');
+      expect(schema.discriminator.mapping.insert).toContain('LiveFsInsertEvent');
+    });
+
+    // The "current version" sentinel lives with the most recent api.yaml change;
+    // adding LiveFsInsertEvent to the LiveFsEvent union bumped the minor.
+    it('bumps info.version to 1.25.0', () => {
+      expect(spec.info.version).toBe('1.25.0');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a third member to the public `/events` SSE `LiveFsEvent` `oneOf`: **`LiveFsInsertEvent`** (discriminator key `insert`), broadcast the instant a flowsheet row is created — before enrichment runs. Today `LiveFsEvent` carries only `update` / `refetch`, so consumers (iOS, dj-site) learn of a new track only on the next reconciliation poll. This is the contract half of the two-repo chain that removes Epic C's ([#877](https://github.com/WXYC/Backend-Service/issues/877)) polling latency floor.

## Changes

- **`LiveFsInsertEvent`** schema — mirrors `LiveFsUpdateEvent`'s `{ type, payload, timestamp }` envelope with `type: [insert]` and `payload: $ref FlowsheetEntryResponse`. `FlowsheetEntryResponse` already models every enrichment field (`artwork_url`, `release_year`, `discogs_url`, ...) as `nullable`, and `metadata_status` admits `pending`, so a not-yet-enriched insert row is valid without a new payload shape.
- Added to `LiveFsEvent` `oneOf` + discriminator `mapping.insert`.
- `info.version` `1.24.0` → `1.25.0` (additive minor).
- `GET /events/stream` description now names all three `insert` / `update` / `refetch` frames.
- Relocated the "current version" sentinel test into the Live-Updates SSE describe block and added `LiveFsInsertEvent` + union-length assertions.

## Non-breaking

Existing `update` / `refetch` decoding is unaffected. The `swift6` / `kotlin` codegen sets `oneOfUnknownDefaultCase`, so an unrecognized discriminator decodes into `unknownDefault` rather than throwing; the dj-site `live-updates-listener.ts` switches on `type` with a default no-op. Additive per the [`@wxyc/shared` release procedure](https://github.com/WXYC/wxyc-shared/blob/main/CLAUDE.md).

> ⚠️ The advisory **Breaking Change Check** workflow flags `response-property-one-of-added` — `oasdiff` conservatively treats *any* new response-`oneOf` member as breaking for a strict exhaustive consumer. It is **not** a required status check on `main`, and the addition is additive-safe by the codegen/consumer contract above (the same reason new SSE members are additive here).

## Test plan

- [x] `npm test` — 564 passed (new `LiveFsInsertEvent` envelope test + union now expects 3 members + `insert` mapping; version-pin sentinel → `1.25.0`)
- [x] `npm run generate:typescript` — `LiveFsInsertEvent` type + widened `LiveFsEvent` union present in `src/generated/`
- [x] `npm run lint` (tsc) + `npm run lint:e2e` — clean

## Cross-repo

This gates the producer half, [WXYC/Backend-Service#1888](https://github.com/WXYC/Backend-Service/issues/1888) (`blocked_by` this). #1888 cannot build against the type until this merges **and** `@wxyc/shared` is version-published to GH Packages **and** Backend-Service's dependency is bumped. Downstream consumer: [WXYC/wxyc-ios-64#269](https://github.com/WXYC/wxyc-ios-64/issues/269).

Closes #273