### PR TITLE
chore(deps): widen typescript peerDependency to include 7.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "better-auth": "^1.5.0",
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "better-auth": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "better-auth": "^1.5.0",
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "better-auth": {


### PR DESCRIPTION
## What

Widens `peerDependencies.typescript` from `^5.0.0 || ^6.0.0` to `^5.0.0 || ^6.0.0 || ^7.0.0` (5/6 legs retained). This removes the npm `ERESOLVE` hard-failure that blocked any consumer from installing `@wxyc/shared` alongside **TypeScript 7**.

## Why this is a *consumer-facing* widening only

TypeScript 7.0 is the Go-native (`tsgo`) compiler rewrite. Its npm package ships **CLI-only** — `tsc.js` (a shim to the native binary) + `version`, with **no JS compiler API** (`ts.sys`, `ts.createProgram`, etc. are gone). Any tool that imports the TS compiler API breaks under it, including `tsup`'s declaration emit (via `rollup-plugin-dts`). So `@wxyc/shared`'s own build **stays on TS 5/6** — `devDependencies.typescript` is deliberately left at `^5.6.2 || ^6.0.0`.

A TS 7 *consumer*, however, only reads the pre-built `.d.ts`, which the native checker handles fine.

## Validation

- `npm run build` / `npm run lint` / `npm run lint:e2e` / `npm test` (563 tests) all green on the pinned toolchain (TS 5.9.3).
- Packed the tarball and installed it into a scratch project with `typescript@7.0.2`:
  - installs cleanly with **no `--legacy-peer-deps`**,
  - a consumer importing from `@wxyc/shared/auth-client` and `@wxyc/shared/test-utils` type-checks clean under `tsgo` 7.0.2 (`skipLibCheck: true`, as downstream uses).

## Acceptance criteria notes

Two criteria on the issue assumed TS 7 is a drop-in upgrade; they are not achievable and are intentionally **not** met:

- ~~`devDependencies.typescript` bumped so CI exercises TS 7~~ — not possible: the `tsup`/`rollup-plugin-dts` declaration build requires the JS compiler API that TS 7.0 removed. The build must run on TS 5/6.
- ~~`npm run build` green on TS 7~~ — same reason. Source *type-checking* (`tsc --noEmit`) does pass under TS 7, but declaration *emit* cannot.

The remaining criterion — publishing a new version to GitHub Packages — is handled by the separate tag-triggered `chore(release)` step after merge.

Closes #275