### PR TITLE
chore(release): @wxyc/shared v2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release `@wxyc/shared` **v2.6.0** — publishes the `LiveFsInsertEvent` SSE contract member added in #273 (PR #276).

A concurrent **v2.5.0** release (the `typescript` peerDependency widen, `83bf0dd`) landed ~10 min before #276 merged, so published 2.5.0 does **not** carry `LiveFsInsertEvent`. This minor bump publishes it so the Backend producer ([WXYC/Backend-Service#1888](https://github.com/WXYC/Backend-Service/issues/1888)) can consume the generated type.

Version-only change (package.json 2.5.0 → 2.6.0); no api.yaml/source diff. On merge, the `v2.6.0` tag is pushed to trigger `publish.yml` → GH Packages.