### PR TITLE
chore(deps-dev): adopt better-auth 1.6.25 with interim jwtClient type shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.1.10",
         "bats": "^1.11.0",
-        "better-auth": "^1.6.18",
+        "better-auth": "^1.6.25",
         "openapi-typescript": "^7.13.0",
         "postgres": "^3.4.9",
         "tsup": "^8.4.0",
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.20.tgz",
-      "integrity": "sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.25.tgz",
+      "integrity": "sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -128,7 +128,7 @@
         "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.6",
+        "better-call": "1.3.7",
         "jose": "^6.1.0",
         "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
@@ -143,13 +143,13 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.20.tgz",
-      "integrity": "sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.25.tgz",
+      "integrity": "sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "drizzle-orm": "^0.45.2"
       },
@@ -160,13 +160,13 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.20.tgz",
-      "integrity": "sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.25.tgz",
+      "integrity": "sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
@@ -177,24 +177,24 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.20.tgz",
-      "integrity": "sha512-J5Ni0LlFijbzXlwu2rFHaD8zEFocmajyzWkRnHsq8LhV/Dk4iWQwwnqzLrPoDQEj8roECAUF03hrIeMzqWRqJQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.25.tgz",
+      "integrity": "sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.20.tgz",
-      "integrity": "sha512-ClDBJf6h4g85WJswxwQwxLaiyRU67Gmz/uaIf19tY1gqlLJDykSGjmqRNSBMG5rWABNzcNqbO4KG31rYUldbIw==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.25.tgz",
+      "integrity": "sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
@@ -205,13 +205,13 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.20.tgz",
-      "integrity": "sha512-WhYdhSGuVSfu1peCSf2snmmVzfWjRaEvbSrsNCusiwGE9l94HlES4mjSPM48fed24hL7yg4j1dYK/yjEt87FpQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.25.tgz",
+      "integrity": "sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -226,13 +226,13 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.20.tgz",
-      "integrity": "sha512-3BhbY3naQDERvdJvJ7fGszVY6rpsVfc6c9uyBVZlC1coVEF/rkM0rIcjtMVI1GUH7vWy1wjR6qF5vQnMun3XNQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.25.tgz",
+      "integrity": "sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.25",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1"
       }
@@ -1049,9 +1049,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2231,24 +2231,24 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.20.tgz",
-      "integrity": "sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.25.tgz",
+      "integrity": "sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.6.20",
-        "@better-auth/drizzle-adapter": "1.6.20",
-        "@better-auth/kysely-adapter": "1.6.20",
-        "@better-auth/memory-adapter": "1.6.20",
-        "@better-auth/mongo-adapter": "1.6.20",
-        "@better-auth/prisma-adapter": "1.6.20",
-        "@better-auth/telemetry": "1.6.20",
+        "@better-auth/core": "1.6.25",
+        "@better-auth/drizzle-adapter": "1.6.25",
+        "@better-auth/kysely-adapter": "1.6.25",
+        "@better-auth/memory-adapter": "1.6.25",
+        "@better-auth/mongo-adapter": "1.6.25",
+        "@better-auth/prisma-adapter": "1.6.25",
+        "@better-auth/telemetry": "1.6.25",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.6",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
         "kysely": "^0.28.17 || ^0.29.0",
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.6.tgz",
-      "integrity": "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3536,9 +3536,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.5.tgz",
+      "integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3606,9 +3606,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
-      "integrity": "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==",
+      "version": "0.29.4",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.4.tgz",
+      "integrity": "sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4107,9 +4107,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
-      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.2.tgz",
+      "integrity": "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==",
       "dev": true,
       "funding": [
         {
@@ -4728,9 +4728,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
-      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "^4.1.10",
     "bats": "^1.11.0",
-    "better-auth": "^1.6.18",
+    "better-auth": "^1.6.25",
     "openapi-typescript": "^7.13.0",
     "postgres": "^3.4.9",
     "tsup": "^8.4.0",

--- a/src/auth-client/index.ts
+++ b/src/auth-client/index.ts
@@ -61,6 +61,13 @@ export function createWXYCAuthClient(baseURL: string) {
     plugins: [
       adminClient(),
       usernameClient(),
+      // better-auth 1.6.24–1.6.25 regressed jwtClient()'s return type so it no longer
+      // satisfies BetterAuthClientPlugin (upstream better-auth#10515; fixed by #10513,
+      // shipping in 1.6.26). We use the JWT plugin only for its /token endpoint, which
+      // getJWTToken() below reaches via raw fetch — the collapsed action inference is
+      // unused here. This directive self-removes: once on >=1.6.26 the error is gone and
+      // tsc flags the unused @ts-expect-error, forcing us to delete it (and drop the shim).
+      // @ts-expect-error better-auth#10515 — remove when on >=1.6.26.
       jwtClient(),
     ],
   });

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -1713,7 +1713,7 @@ describe('OpenAPI Specification', () => {
   describe('Device Authorization (RFC 8628) — #195', () => {
     // Field-list / enum snapshot against api.yaml (the #186 CatalogExportRow house
     // style — NOT a live runtime diff; the plugin's per-route zod schemas are
-    // module-internal and unexported). The contract mirrors better-auth 1.6.20 +
+    // module-internal and unexported). The contract mirrors better-auth 1.6.25 +
     // Backend-Service#1495. Error enums are the RUNTIME superset of the declared zod.
     type Schema = {
       type?: string;
@@ -1901,15 +1901,17 @@ describe('OpenAPI Specification', () => {
     // ---- version forcing-function ----
 
     it('pins the verified better-auth version so a bump forces a conscious re-verification', () => {
-      // The contract above mirrors better-auth 1.6.20 (the version Backend-Service#1495
-      // runs; 1.6.20 added the /device/code `user_id` field over 1.6.18/.19). If this
-      // fails after a bump, re-verify routes.mjs against the new version, update the
-      // enums/fields above, then bump this string. (package.json keeps the ^1.6.18
-      // caret per the issue; package-lock.json resolves it to 1.6.20.)
+      // The contract above mirrors better-auth 1.6.25. Re-verified 2026-07-31 for the
+      // 1.6.20→1.6.25 bump: no device-auth wire changes across 1.6.21–1.6.25 (only a
+      // 1.6.21 Zod-v4 compat fix), so the field/enum/security snapshots above still hold.
+      // (1.6.24 also regressed jwtClient()'s CLIENT type — better-auth#10515 — which is
+      // suppressed in src/auth-client/index.ts and unrelated to the wire contract here.)
+      // If this fails after a bump, re-verify routes.mjs against the new version, update
+      // the enums/fields above, then bump this string.
       const ba = JSON.parse(
         readFileSync(join(__dirname, '..', 'node_modules', 'better-auth', 'package.json'), 'utf-8')
       ) as { version: string };
-      expect(ba.version).toBe('1.6.20');
+      expect(ba.version).toBe('1.6.25');
     });
   });
 });


### PR DESCRIPTION
Supersedes the Dependabot bump #202, which fails CI on a TypeScript regression (not the device-auth version tripwire).

## Why #202 can't merge as-is

better-auth **1.6.24** regressed `jwtClient()`'s client-plugin return type so it no longer satisfies better-auth's own `BetterAuthClientPlugin` interface. `tsc` fails at `src/auth-client/index.ts` with `TS2322` (the `getActions` signature no longer conforms). This is an upstream bug — [better-auth#10515](https://github.com/better-auth/better-auth/issues/10515) — fixed by [better-auth#10513](https://github.com/better-auth/better-auth/pull/10513) (merged 2026-07-27), **but not in 1.6.25** (latest), so it ships in 1.6.26.

## What this does

- Bumps better-auth `^1.6.18` -> `^1.6.25` (package.json + lockfile), matching #202.
- Adds a **targeted, self-removing** `@ts-expect-error` on `jwtClient()` for better-auth#10515. The JWT plugin is used only for its `/token` endpoint, which `getJWTToken()` reaches via raw `fetch`, so the collapsed action inference is functionally unused here. Once on >= 1.6.26 the error clears and `tsc` flags the now-unused directive (TS2578), forcing us to delete it.
- Bumps the device-auth version-pin forcing-function (`tests/api-spec.test.ts`) `1.6.20` -> `1.6.25` with a re-verification note.

## Why it's safe

The RFC 8628 Device Authorization **wire contract is unchanged** across 1.6.21–1.6.25 (only a 1.6.21 Zod-v4 compat fix in `deviceAuthorization()`), so no `api.yaml`/enum edits are needed — and the `#195` device-auth snapshot tests all pass under 1.6.25. This is a client-plugin **type** regression only, orthogonal to the wire shapes the tripwire guards.

## Follow-up

Removing the shim + resolving Backend-Service#1834 (same regression) is tracked in #280 — do it when better-auth >= 1.6.26 publishes.

## Test plan

Local checks green on 1.6.25: `npm run lint`, `npm run lint:e2e`, `npm run build`, `npm test` (564 passed).