### PR TITLE
api.yaml: fold /lookup location-union results into results (v3.0.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -3127,19 +3127,6 @@ components:
             is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets
             this to true on every call; other consumers (catalog search,
             dj-site proxy, iOS apps) leave it false.
-        include_locations:
-          type: boolean
-          default: false
-          description: >
-            Per the comprehensive multi-location union (LML#1018/#1022). When
-            true, the response carries an additional `also_available_on`
-            array — every other WXYC library shelf location that carries the
-            same track (V/A compilations, soundtracks), ranked by LML, so a
-            DJ can find a backup copy when the primary is missing or
-            checked-out. When false (the default), the response is
-            byte-identical to today — `also_available_on` is omitted.
-            DJ-facing callers (dj-site catalog, request-o-matic) set this;
-            Backend enrichment does not.
         extended:
           type: boolean
           description: >
@@ -3427,10 +3414,15 @@ components:
           items:
             $ref: '#/components/schemas/TrackMatchHint'
           description: >
-            Populated when a track-title match (LML's new SONG_AS_TRACK strategy)
-            drove this release into the results, per catalog-track-search plan §5.1.
-            Empty or absent when the release matched via artist/album strategies.
-            Backward-compatible — existing consumers ignore the field.
+            Populated when a track-title match drove this release into the results.
+            Two producers: LML's SONG_AS_TRACK strategy (per catalog-track-search
+            plan §5.1) for the primary match, and the comprehensive multi-location
+            union (LML#1018/#1019/#1022) for every other WXYC shelf location
+            carrying the same track (V/A compilations, soundtracks) — those rows
+            are folded directly into `results` alongside the primary, tagged with
+            `source: discogs_release` since the recall index is Discogs-release-
+            derived. Empty or absent when the release matched via artist/album
+            strategies. Backward-compatible — existing consumers ignore the field.
         matched_via_alias:
           type: array
           items:
@@ -3559,17 +3551,6 @@ components:
             LML reads them (LML#928 for `X-Caller-Class`-driven lane
             routing, LML#931 for `X-Caller-Reason` caller telemetry) — see
             BS#1843.
-        also_available_on:
-          type: array
-          items:
-            $ref: '#/components/schemas/LibraryLocation'
-          description: >
-            Every other WXYC library shelf location that carries the same
-            track (V/A compilations, soundtracks), ranked by LML so
-            consumers can render in order. Present only when the request set
-            `include_locations: true`; absent otherwise (empty when the flag
-            is set but no other location carries the track) so existing
-            consumers see a byte-identical response (LML#1018/#1022).
         degraded:
           type: boolean
           default: false
@@ -3605,58 +3586,6 @@ components:
             providers) was rate limited or down and its contribution was
             omitted. Set by LML#930's caller-deadline / admission path; read by
             LML#931 (`degraded-mode-result` telemetry) and wxyc-canary#82.
-
-    LibraryLocation:
-      type: object
-      description: >
-        A single other WXYC shelf location carrying the same track, returned
-        on `LookupResponse.also_available_on` when the request set
-        `include_locations: true` (LML#1018/#1022's comprehensive
-        multi-location union). Deliberately a lean entry rather than a full
-        `LookupResultItem` — no live artwork/identity resolution; art is
-        precomputed at index time.
-      required:
-        - library_id
-        - track_artist
-        - track_title
-      properties:
-        library_id:
-          type: integer
-          description: WXYC library.id (shelf location) for this copy.
-        artist:
-          type: string
-          description: Shelf/album artist (e.g. "Soundtracks - L").
-        album_title:
-          type: string
-          description: Album/release title (e.g. "Lost in Translation").
-        track_position:
-          type: string
-          nullable: true
-          description: The track's position on this release (e.g. "A1"), when known.
-        track_title:
-          type: string
-          description: Track title.
-        track_artist:
-          type: string
-          description: >
-            Credited-as artist for this track (e.g. "Brian Reitzell And
-            Roger J. Manning, Jr."), which may differ from the shelf artist
-            on a compilation.
-        credit_role:
-          type: string
-          enum:
-            - primary
-            - featured
-            - extra
-          description: The role this credit represents on the track.
-        discogs_release_id:
-          type: integer
-          nullable: true
-          description: Discogs release ID, usable as an art re-resolution key.
-        artwork_url:
-          type: string
-          nullable: true
-          description: Precomputed cover art URL for this location.
 
     # ====================================
     # Identity Block (§3.2.2 / §3.2.5 cascade)

--- a/api.yaml
+++ b/api.yaml
@@ -3420,9 +3420,10 @@ components:
             union (LML#1018/#1019/#1022) for every other WXYC shelf location
             carrying the same track (V/A compilations, soundtracks) — those rows
             are folded directly into `results` alongside the primary, tagged with
-            `source: discogs_release` since the recall index is Discogs-release-
-            derived. Empty or absent when the release matched via artist/album
-            strategies. Backward-compatible — existing consumers ignore the field.
+            `source: discogs_release` since the recall index is
+            Discogs-release-derived. Empty or absent when the release matched via
+            artist/album strategies. Backward-compatible — existing consumers
+            ignore the field.
         matched_via_alias:
           type: array
           items:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "2.6.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -1121,65 +1121,51 @@ describe('OpenAPI Specification', () => {
     });
   });
 
-  describe('Lookup Multi-Location Union (LML#1018/#1022)', () => {
-    it('should define LookupRequest.include_locations as an optional boolean defaulting to false', () => {
+  describe('Lookup Multi-Location Union (transparent fold, supersedes LML#1018/#1022)', () => {
+    it('should not define LookupRequest.include_locations — the union runs server-side, no opt-in', () => {
       const schema = spec.components.schemas.LookupRequest as {
-        properties: Record<string, { type?: string; default?: unknown }>;
-        required?: string[];
+        properties: Record<string, unknown>;
       };
-      expect(schema.properties.include_locations).toBeDefined();
-      expect(schema.properties.include_locations.type).toBe('boolean');
-      expect(schema.properties.include_locations.default).toBe(false);
-      // Not required — existing consumers continue to omit it and see the
-      // byte-identical v1 response shape.
-      expect(schema.required ?? []).not.toContain('include_locations');
+      expect(schema.properties.include_locations).toBeUndefined();
     });
 
-    it('should attach optional also_available_on array of LibraryLocation to LookupResponse', () => {
+    it('should not define LookupResponse.also_available_on — locations fold into results instead', () => {
       const schema = spec.components.schemas.LookupResponse as {
-        properties: Record<string, { type?: string; items?: { $ref?: string } }>;
-        required?: string[];
+        properties: Record<string, unknown>;
       };
-      expect(schema.properties.also_available_on).toBeDefined();
-      expect(schema.properties.also_available_on.type).toBe('array');
-      expect(schema.properties.also_available_on.items?.$ref).toBe(
-        '#/components/schemas/LibraryLocation',
-      );
-      // Not required — present only when include_locations: true.
-      expect(schema.required ?? []).not.toContain('also_available_on');
+      expect(schema.properties.also_available_on).toBeUndefined();
     });
 
-    it('should define LibraryLocation as a lean location entry, distinct from LookupResultItem', () => {
-      const schema = spec.components.schemas.LibraryLocation as {
-        required: string[];
-        properties: Record<
-          string,
-          { type?: string; nullable?: boolean; description?: string; enum?: string[] }
-        >;
+    it('should not define a LibraryLocation schema — a folded location is an ordinary LookupResultItem', () => {
+      expect(spec.components.schemas.LibraryLocation).toBeUndefined();
+    });
+
+    it("should broaden LookupResultItem.matched_via's description to name the location-union as a second producer", () => {
+      const schema = spec.components.schemas.LookupResultItem as {
+        properties: Record<string, { description?: string }>;
       };
-      expect(schema).toBeDefined();
-      expect(schema.required).toEqual(['library_id', 'track_artist', 'track_title']);
+      const description = schema.properties.matched_via.description ?? '';
+      expect(description).toContain('SONG_AS_TRACK');
+      expect(description).toContain('multi-location union');
+      expect(description).toContain('discogs_release');
+    });
 
-      expect(schema.properties.library_id.type).toBe('integer');
-      expect(schema.properties.artist.type).toBe('string');
-      expect(schema.properties.album_title.type).toBe('string');
-      expect(schema.properties.track_title.type).toBe('string');
+    it('should leave the AlbumSearchResult.matched_via description untouched (BS catalog search, not the location union)', () => {
+      const schema = spec.components.schemas.AlbumSearchResult as {
+        properties: Record<string, { description?: string }>;
+      };
+      const description = schema.properties.matched_via.description ?? '';
+      expect(description).toContain("Backend's catalog `/library/` search");
+      expect(description).not.toContain('multi-location union');
+    });
 
-      expect(schema.properties.track_position.type).toBe('string');
-      expect(schema.properties.track_position.nullable).toBe(true);
-
-      expect(schema.properties.track_artist.type).toBe('string');
-
-      expect(schema.properties.credit_role.type).toBe('string');
-      expect(schema.properties.credit_role.enum ?? undefined).toEqual(
-        expect.arrayContaining(['primary', 'featured', 'extra']),
-      );
-
-      expect(schema.properties.discogs_release_id.type).toBe('integer');
-      expect(schema.properties.discogs_release_id.nullable).toBe(true);
-
-      expect(schema.properties.artwork_url.type).toBe('string');
-      expect(schema.properties.artwork_url.nullable).toBe(true);
+    it('should leave the LibrarySearchItem.matched_via description untouched (LML catalog search, not the location union)', () => {
+      const schema = spec.components.schemas.LibrarySearchItem as {
+        properties: Record<string, { description?: string }>;
+      };
+      const description = schema.properties.matched_via.description ?? '';
+      expect(description).toContain('catalog-track-search plan §5.1');
+      expect(description).not.toContain('multi-location union');
     });
   });
 


### PR DESCRIPTION
Closes #283

## What

Contract-only revision of the `/lookup` multi-location union shipped in #270. Removes `LookupRequest.include_locations`, `LookupResponse.also_available_on`, and the now-unreferenced `LibraryLocation` schema. Broadens only `LookupResultItem.matched_via`'s description to name the recall-index location union as a second producer (`source: discogs_release`), alongside the existing SONG_AS_TRACK primary-match producer — the `LibrarySearchItem.matched_via` and `AlbumSearchResult.matched_via` descriptions are untouched, since neither is produced by the location union.

Per product direction, shelf locations for a track (V/A compilations, soundtracks) must be transparent, ordinary `results` items rather than a separate opt-in collection every consumer special-cases. A location is losslessly representable as a `LookupResultItem` (`library_item` + `artwork` + a `matched_via` `TrackMatchHint`) — no new schema needed. Full rationale and the fold table: `library-metadata-lookup/plans/location-union-transparent-results.md` §1-§2.

**Supersedes #270** (the separate-field design this reverses).

## Version bump

`2.6.0` → `3.0.0` (major). This repo's convention, per the `v2.0.0` `OnAirDJ.id` precedent: a real breaking removal earns the major even at zero live-consumer fan-out — "semver-correctness warrants the major." Two commits, matching that precedent's shape: the contract edit, then a separate `chore(release)` commit bumping `package.json`/`package-lock.json`. **Publishing `@wxyc/shared` is not done here** — it happens post-merge when the version tag is pushed, per `publish.yml`.

## Breaking-change gate

D3 of the plan explicitly accepts this as breaking (zero live consumers: the prod recall index — LML#1019's `lml_cache.compilation_track_location` — is still empty, and request-o-matic#199's "Also available on:" render is staging-only and is being reverted separately). Ran `npm run check:breaking` locally: oasdiff reports 2 changes, both `WARN` severity (`request-property-removed`, `response-optional-property-removed`), 0 `ERR`. Since the CI breaking-changes gate (`oasdiff/oasdiff-action/breaking` with `fail-on: ERR`) only fails on `ERR`-severity findings, this PR is expected to pass that check rather than fail it — oasdiff classifies removal of *optional* fields below its failure threshold, even though it's a real breaking removal by strict semver. Flagging this so it isn't mistaken for the gate having missed something.

## Codegen

`generated/` and `src/generated/` are both gitignored in this repo (regenerated at build/publish time, not committed) — nothing to commit here. Ran all four generators locally as a smoke test against the revised schema and grepped each output for the removed identifiers:
- `npm run generate:typescript` — clean, no dangling refs.
- `npm run generate:python` (datamodel-codegen) — clean, no dangling refs.
- `npm run generate:swift` (openapi-generator-cli, swift6) — clean, no dangling refs.
- `npm run generate:kotlin` (openapi-generator-cli) — clean, no dangling refs.

## Downstream regen order

1. This PR merges → `@wxyc/shared` publishes (tag push, human-triggered).
2. **library-metadata-lookup** core PR regenerates `generated/api_models.py` against the published contract and folds recall-index locations directly into `results` (replacing the removed separate-field union).
3. **request-o-matic** reverts #199 + its codegen commit, regenerates against the published contract.

## Testing

- `npm run lint` (tsc --noEmit) — pass
- `npm run lint:e2e` — pass
- `npm run build` (tsup) — pass
- `npm test` (vitest, 567 tests / 15 files) — pass, including the reworked `Lookup Multi-Location Union` describe block in `tests/api-spec.test.ts`
- `npm run check:breaking` (oasdiff) — pass (WARN only, see above)
- `npm run test:e2e:contracts` — not run; requires a live Backend-Service (`$E2E_BASE_URL`), same as CI (which gates this step on the var being set)

## Files changed

- `api.yaml` — the three removals + the one description broaden
- `tests/api-spec.test.ts` — reworked the `Lookup Multi-Location Union` describe block for the new contract shape
- `package.json`, `package-lock.json` — version bump