### PR TITLE
test: purge residual also_available_on naming from api-spec test description

### DIFF
--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -1129,7 +1129,7 @@ describe('OpenAPI Specification', () => {
       expect(schema.properties.include_locations).toBeUndefined();
     });
 
-    it('should not define LookupResponse.also_available_on — locations fold into results instead', () => {
+    it('should not define the removed separate LookupResponse locations field — locations fold into results instead', () => {
       const schema = spec.components.schemas.LookupResponse as {
         properties: Record<string, unknown>;
       };


### PR DESCRIPTION
Trivial follow-up to #284 (location-union transparent fold, v3.0.0). Rewords the `LookupResponse` locations test description so it no longer names the removed field literally — the design folds shelf locations into `results` as first-class rows, so no "also available on" sidecar framing should linger even in test prose.

The assertion at `api-spec.test.ts:1136` still references `schema.properties.also_available_on` and stays — it must name the removed property to prove it's `undefined`. This is the last of the cross-repo naming cleanup (LML #1030 and request-o-matic #202 carry the rest).

Test-description-only; no contract or code change.