### PR TITLE
feat(api): per-service streaming_status on DiscogsMatchResult (LML#1053)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.25.0
+  version: 1.26.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3059,6 +3059,52 @@ components:
           nullable: true
           description: SoundCloud search URL
 
+    StreamingResolutionStatus:
+      type: string
+      enum:
+        - verified
+        - absent
+        - unresolved
+      description: >
+        Per-service streaming resolution verdict for one release on a lookup
+        result. `verified` — the service was consulted and a URL was found
+        (accompanies a non-null sibling `*_url`). `absent` — the service was
+        consulted and returned no match; the null `*_url` is terminal and must
+        NOT be re-probed. `unresolved` — a probe was attempted but was
+        inconclusive (timed out, the enrichment tail was shed, or the cache was
+        a cold miss); the null `*_url` is transient and MAY resolve on a later
+        retry. A service that was never consulted at all is represented by the
+        ABSENCE of its key from `StreamingResolution` (never by `absent`), so a
+        consumer never negative-caches a service that was simply never asked.
+        Reuses the per-service verdict vocabulary of `/api/v1/streaming-check`
+        (LML#376). See LML#1053 / BS#1819.
+
+    StreamingResolution:
+      type: object
+      description: >
+        Per-service streaming resolution status for one lookup result, keyed by
+        streaming service (keys match the `*_url` prefixes on
+        `DiscogsMatchResult`). A service's key is PRESENT only when that service
+        was consulted during this lookup; an omitted service was never probed and
+        must NOT be treated as `absent` (the never-consulted state — key omission
+        is its sole encoding, so a consumer has one rule, not two).
+        Additive and independent of the `*_url` fields: it annotates why a
+        `*_url` is null (transient `unresolved` vs terminal `absent`) without
+        changing the meaning of the url fields themselves. Mirrors the
+        per-service shape of `StreamingCheckSources` (LML#376), except a
+        consulted-but-absent service is the explicit `absent` verdict rather than
+        a null, so these per-service fields are non-nullable. Covers the
+        services with a genuine probe/absence distinction on the lookup path
+        (`spotify`, `apple_music`, `bandcamp`); YouTube Music and SoundCloud are
+        search-URL-only and carry no resolution verdict.
+      properties:
+        spotify:
+          $ref: '#/components/schemas/StreamingResolutionStatus'
+        apple_music:
+          $ref: '#/components/schemas/StreamingResolutionStatus'
+        bandcamp:
+          $ref: '#/components/schemas/StreamingResolutionStatus'
+
     ReconciledIdentity:
       type: object
       description: >
@@ -3307,6 +3353,29 @@ components:
           type: string
           nullable: true
           description: SoundCloud search URL
+        streaming_status:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/StreamingResolution'
+          description: >
+            Per-service streaming resolution status (verified / absent /
+            unresolved) for this result, disambiguating WHY a sibling `*_url`
+            field is null. A service marked `unresolved` timed out, had its
+            enrichment tail shed, or was a cold cache miss — its null url is
+            transient and MAY resolve on a later retry; `absent` means the
+            service was consulted and genuinely has no match — its null url is
+            terminal and must NOT be re-probed (re-asking `absent` is the
+            per-play LML-call amplifier BS#1747 killed). A service whose key is
+            OMITTED from this object was never consulted (e.g. Bandcamp on the
+            `/lookup/bulk` path, or the library.db override skipped for a
+            non-library row) and must not be treated as `absent`. Additive and
+            optional: null/omitted on responses from an LML predating the
+            producer rollout, or on paths that resolve no per-service status.
+            Does not change the meaning of the `*_url` fields — it only
+            annotates them. Emitted identically on `/lookup` and `/lookup/bulk`
+            (the LML#681 parity rule). Mirrors the per-service verdict
+            vocabulary of `/api/v1/streaming-check` (LML#376). See LML#1053 /
+            BS#1819.
         discogs_artist_id:
           type: integer
           nullable: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -1313,10 +1313,63 @@ describe('OpenAPI Specification', () => {
       expect(schema.discriminator.mapping.insert).toContain('LiveFsInsertEvent');
     });
 
+  });
+
+  describe('Per-Service Streaming Resolution Status (LML#1053)', () => {
+    it('defines StreamingResolutionStatus as a closed verified/absent/unresolved enum', () => {
+      const schema = spec.components.schemas.StreamingResolutionStatus as {
+        type?: string;
+        enum?: string[];
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('string');
+      expect(schema.enum).toEqual(['verified', 'absent', 'unresolved']);
+    });
+
+    it('defines StreamingResolution with per-service optional (non-nullable) status refs', () => {
+      const schema = spec.components.schemas.StreamingResolution as {
+        type?: string;
+        properties: Record<string, { $ref?: string; nullable?: boolean }>;
+        required?: string[];
+      };
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+      for (const svc of ['spotify', 'apple_music', 'bandcamp']) {
+        const prop = schema.properties[svc];
+        expect(prop, `${svc} property`).toBeDefined();
+        expect(prop.$ref).toBe('#/components/schemas/StreamingResolutionStatus');
+        // Optional but NOT nullable: never-consulted is encoded solely by key
+        // omission; a consulted-but-absent service is the `absent` verdict — so
+        // `null` would be a redundant second encoding of never-consulted.
+        expect(prop.nullable).toBeUndefined();
+      }
+      // Every per-service status is optional: a service key is present only when
+      // that service was consulted this lookup. An omitted service was never
+      // probed and must NOT be read as `absent` (the never-consulted state).
+      expect(schema.required ?? []).toEqual([]);
+    });
+
+    it('attaches streaming_status to DiscogsMatchResult as an optional nullable $ref', () => {
+      const schema = spec.components.schemas.DiscogsMatchResult as {
+        properties: Record<string, { nullable?: boolean; allOf?: Array<{ $ref?: string }> }>;
+        required?: string[];
+      };
+      expect(schema.properties.streaming_status).toBeDefined();
+      expect(schema.properties.streaming_status.nullable).toBe(true);
+      expect(schema.properties.streaming_status.allOf?.[0]?.$ref).toBe(
+        '#/components/schemas/StreamingResolution',
+      );
+      // Additive: not required, so existing LML/BS consumers are unaffected and a
+      // null/omitted object means "no per-service status resolved on this path"
+      // (e.g. an LML predating the producer rollout). Does not change the meaning
+      // of the sibling `*_url` fields — it only annotates why a url is null.
+      expect(schema.required ?? []).not.toContain('streaming_status');
+    });
+
     // The "current version" sentinel lives with the most recent api.yaml change;
-    // adding LiveFsInsertEvent to the LiveFsEvent union bumped the minor.
-    it('bumps info.version to 1.25.0', () => {
-      expect(spec.info.version).toBe('1.25.0');
+    // adding the per-service streaming_status contract bumped the minor.
+    it('bumps info.version to 1.26.0', () => {
+      expect(spec.info.version).toBe('1.26.0');
     });
   });
 

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -932,4 +932,55 @@ describe('Generated TypeScript Types', () => {
       expect(ok.degraded_reason).toBeUndefined();
     });
   });
+
+  describe('DiscogsMatchResult per-service streaming_status (LML#1053)', () => {
+    // Pin the consumer-facing contract BS#1915's self-heal reads: each streaming
+    // service carries verified / absent / unresolved, disambiguating a transient
+    // null (unresolved -> safe to re-ask) from a terminal absence (absent -> never
+    // re-ask). Independent of the sibling `*_url` fields, which keep their meaning.
+    it('accepts a result carrying per-service streaming statuses', () => {
+      const withStatus: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        apple_music_url: null,
+        spotify_url: 'https://open.spotify.com/album/abc',
+        streaming_status: {
+          apple_music: 'unresolved',
+          spotify: 'verified',
+          bandcamp: 'absent',
+        },
+      };
+
+      expect(withStatus.streaming_status?.apple_music).toBe('unresolved');
+      expect(withStatus.streaming_status?.spotify).toBe('verified');
+      expect(withStatus.streaming_status?.bandcamp).toBe('absent');
+    });
+
+    it('treats the per-service status as a closed verified/absent/unresolved union', () => {
+      const statuses: NonNullable<
+        NonNullable<DiscogsMatchResult['streaming_status']>['apple_music']
+      >[] = ['verified', 'absent', 'unresolved'];
+      expect(statuses).toHaveLength(3);
+    });
+
+    it('represents a never-consulted service by omitting its key (not `absent`)', () => {
+      const partial: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        streaming_status: {
+          apple_music: 'verified',
+          // bandcamp never probed on the /lookup/bulk path -> key omitted, not `absent`
+        },
+      };
+      expect(partial.streaming_status?.bandcamp).toBeUndefined();
+    });
+
+    it('accepts a result that omits streaming_status entirely', () => {
+      const baseline: DiscogsMatchResult = {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+      };
+      expect(baseline.streaming_status).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Contract head of the BS#1819 local-search-isolation slice — adds a machine-readable **per-service streaming resolution status** to `DiscogsMatchResult` so a lookup consumer can tell a *transient* null streaming URL apart from a *genuine* absence.

## What

- New optional `DiscogsMatchResult.streaming_status`: a per-service object (`spotify` / `apple_music` / `bandcamp`) whose values are a new closed enum `StreamingResolutionStatus`:
  - `verified` — consulted, URL found (accompanies a non-null `*_url`)
  - `absent` — consulted, no match; the null `*_url` is **terminal**, do not re-probe
  - `unresolved` — probe attempted but inconclusive (timeout / shed tail / cold miss); the null `*_url` is **transient**, may resolve on retry
- **Never-consulted** is represented by *omitting* the service key (never by `absent`), so a consumer never negative-caches a service that was simply never asked (e.g. Bandcamp on `/lookup/bulk`).

## Why this shape

Reuses the `/api/v1/streaming-check` per-service vocabulary (LML#376) and mirrors `StreamingCheckSources`. Chosen over a bare `unresolved` list (which cannot separate `absent` from never-consulted) and over mutating the inlined `*_url` fields into `{url,status}` objects (which would break existing `DiscogsMatchResult` consumers). This keeps the `*_url` fields byte-identical and only *annotates* them.

## Compatibility

Purely additive — new optional field + two new schemas, nothing removed or narrowed. `oasdiff breaking` reports **no breaking changes**. Bumps `info.version` 1.25.0 → 1.26.0 and the package 3.0.0 → 3.1.0.

## Downstream (the three-repo dance)

1. **This PR** lands the contract + publishes `@wxyc/shared` (minor).
2. `WXYC/library-metadata-lookup#1053` regenerates `generated/api_models.py` and emits `streaming_status` on `/lookup` and `/lookup/bulk` (LML#681 parity).
3. `WXYC/Backend-Service#1915` regenerates BS types and consumes it for a bounded self-heal of transient streaming nulls — without resurrecting the BS#1747 per-play re-ask amplifier.

Contract prerequisite for WXYC/library-metadata-lookup#1053. Parent PRD: WXYC/Backend-Service#1819.