### PR TITLE
feat(api): add discogsUnavailable to AlbumMetadataResponse, AlbumSearchResult, FlowsheetEntryResponse

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.26.0
+  version: 1.27.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -247,6 +247,21 @@ components:
             release_year:
               type: integer
               nullable: true
+            discogsUnavailable:
+              type: boolean
+              nullable: true
+              description: >-
+                Rides the same MD-set "not on Discogs" flag as the Album
+                surfaces (see `Album.discogsUnavailable`). Deliberately
+                camelCase — unlike its snake_case siblings in this block —
+                to match Backend's `withDiscogsUnavailableCamelCase`
+                serializer, which emits this field on the V2 flowsheet
+                album embed exactly as it does on the other Album surfaces.
+            discogsUnavailableNote:
+              type: string
+              nullable: true
+              maxLength: 500
+              description: Optional free-text reason for `discogsUnavailable`.
             spotify_url:
               type: string
               nullable: true
@@ -1309,6 +1324,26 @@ components:
           type: string
           nullable: true
           description: Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.
+        discogsUnavailable:
+          type: boolean
+          description: |
+            MD-set marker indicating this release is intentionally not on
+            Discogs (embargoed promo, audience-segment release, etc.). When
+            true, the LML runtime-lookup chokepoint does not attempt Discogs
+            resolution for this release. See WXYC/wiki plans/rotation-discogs-unavailable.md.
+        discogsUnavailableNote:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: Optional free-text reason for `discogsUnavailable`.
+        lastDiscogsRecheckAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            Stamped on every recheck attempt by the
+            `library-discogs-unavailable-recheck` cron. Read-only from the
+            client side.
         matched_via:
           type: array
           items:
@@ -5637,6 +5672,26 @@ components:
         soundcloudUrl:
           type: string
           description: SoundCloud search URL
+        discogsUnavailable:
+          type: boolean
+          description: >-
+            True when a music director has marked this release as not on
+            Discogs; downstream render surfaces should suppress
+            Discogs-derived artwork/links/tracklist. Mirrors the `Album`
+            schema's MD-set marker (WXYC/wiki plans/rotation-discogs-unavailable.md).
+        discogsUnavailableNote:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: Optional free-text reason for `discogsUnavailable`.
+        lastDiscogsRecheckAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            Stamped on every recheck attempt by the
+            `library-discogs-unavailable-recheck` cron. Read-only from the
+            client side.
 
     ArtistMetadataResponse:
       type: object

--- a/api.yaml
+++ b/api.yaml
@@ -249,14 +249,15 @@ components:
               nullable: true
             discogsUnavailable:
               type: boolean
-              nullable: true
               description: >-
                 Rides the same MD-set "not on Discogs" flag as the Album
-                surfaces (see `Album.discogsUnavailable`). Deliberately
-                camelCase — unlike its snake_case siblings in this block —
-                to match Backend's `withDiscogsUnavailableCamelCase`
-                serializer, which emits this field on the V2 flowsheet
-                album embed exactly as it does on the other Album surfaces.
+                surfaces (see `Album.discogsUnavailable`), non-nullable to
+                match them. Deliberately camelCase — unlike its snake_case
+                siblings in this block — to match Backend's
+                `withDiscogsUnavailableCamelCase` serializer. Contract-first:
+                the V2 flowsheet album embed will carry this field once the
+                BS-emit piece (WXYC/Backend-Service#1908) lands; it is not
+                emitted there yet.
             discogsUnavailableNote:
               type: string
               nullable: true

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -513,6 +513,126 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  // wxyc-shared#285 (AlbumMetadataResponse) and #282 (AlbumSearchResult)
+  // propagate the discogsUnavailable trio Album already carries (#156) to the
+  // two render surfaces that were missing it: GET /proxy/metadata/album and
+  // catalog-search results. FlowsheetEntryResponse gains a partial slice
+  // (discogsUnavailable + discogsUnavailableNote, deliberately camelCase amid
+  // its snake_case metadata siblings, no lastDiscogsRecheckAt) as the api.yaml
+  // piece of Backend-Service#1908 — the BS-emit and dj-site-render pieces stay
+  // open there. All additive/optional; no existing field's shape changes.
+  describe('discogsUnavailable trio on AlbumMetadataResponse / AlbumSearchResult / FlowsheetEntryResponse (#285 / #282 / BS#1908)', () => {
+    type SchemaProp = {
+      type?: string;
+      nullable?: boolean;
+      format?: string;
+      maxLength?: number;
+    };
+    type Schema = {
+      properties?: Record<string, SchemaProp>;
+      required?: string[];
+    };
+
+    describe('AlbumMetadataResponse (#285)', () => {
+      it('gains discogsUnavailable as a boolean', () => {
+        const schema = spec.components.schemas.AlbumMetadataResponse as Schema;
+        const prop = schema.properties?.discogsUnavailable;
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe('boolean');
+        expect(schema.required ?? []).not.toContain('discogsUnavailable');
+      });
+
+      it('gains discogsUnavailableNote as a nullable string capped at 500 chars', () => {
+        const schema = spec.components.schemas.AlbumMetadataResponse as Schema;
+        const prop = schema.properties?.discogsUnavailableNote;
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe('string');
+        expect(prop?.nullable).toBe(true);
+        expect(prop?.maxLength).toBe(500);
+      });
+
+      it('gains lastDiscogsRecheckAt as a nullable date-time string, matching Album verbatim', () => {
+        const schema = spec.components.schemas.AlbumMetadataResponse as Schema;
+        const prop = schema.properties?.lastDiscogsRecheckAt;
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe('string');
+        expect(prop?.format).toBe('date-time');
+        expect(prop?.nullable).toBe(true);
+        expect(schema.required ?? []).not.toContain('lastDiscogsRecheckAt');
+      });
+    });
+
+    describe('AlbumSearchResult (#282)', () => {
+      it('gains discogsUnavailable as a boolean, matching Album shape', () => {
+        const schema = spec.components.schemas.AlbumSearchResult as Schema;
+        const albumSchema = spec.components.schemas.Album as Schema;
+        const prop = schema.properties?.discogsUnavailable;
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe(albumSchema.properties?.discogsUnavailable?.type);
+        expect(prop?.nullable).toBe(albumSchema.properties?.discogsUnavailable?.nullable);
+        expect(schema.required ?? []).not.toContain('discogsUnavailable');
+      });
+
+      it('gains discogsUnavailableNote as a nullable string capped at 500 chars', () => {
+        const schema = spec.components.schemas.AlbumSearchResult as Schema;
+        const prop = schema.properties?.discogsUnavailableNote;
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe('string');
+        expect(prop?.nullable).toBe(true);
+        expect(prop?.maxLength).toBe(500);
+      });
+
+      it('gains lastDiscogsRecheckAt as a nullable date-time string', () => {
+        const schema = spec.components.schemas.AlbumSearchResult as Schema;
+        const prop = schema.properties?.lastDiscogsRecheckAt;
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe('string');
+        expect(prop?.format).toBe('date-time');
+        expect(prop?.nullable).toBe(true);
+      });
+    });
+
+    describe('FlowsheetEntryResponse (api.yaml piece of Backend-Service#1908)', () => {
+      function getProperty(prop: string): SchemaProp | undefined {
+        const schema = spec.components.schemas.FlowsheetEntryResponse as {
+          properties?: Record<string, SchemaProp>;
+          allOf?: Array<{ properties?: Record<string, SchemaProp> }>;
+        };
+        if (schema.properties?.[prop]) return schema.properties[prop];
+        for (const branch of schema.allOf ?? []) {
+          if (branch.properties?.[prop]) return branch.properties[prop];
+        }
+        return undefined;
+      }
+
+      it('gains discogsUnavailable as a nullable boolean, camelCase deliberately unlike its snake_case siblings', () => {
+        const prop = getProperty('discogsUnavailable');
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe('boolean');
+        expect(prop?.nullable).toBe(true);
+      });
+
+      it('gains discogsUnavailableNote as a nullable string capped at 500 chars', () => {
+        const prop = getProperty('discogsUnavailableNote');
+        expect(prop).toBeDefined();
+        expect(prop?.type).toBe('string');
+        expect(prop?.nullable).toBe(true);
+        expect(prop?.maxLength).toBe(500);
+      });
+
+      it('does not add lastDiscogsRecheckAt (BS#1908 tracks the BS-emit + dj-site-render pieces separately)', () => {
+        const prop = getProperty('lastDiscogsRecheckAt');
+        expect(prop).toBeUndefined();
+      });
+    });
+
+    // The "current version" sentinel lives with the most recent api.yaml change;
+    // bundling the three discogsUnavailable additions bumped the minor.
+    it('bumps info.version to 1.27.0', () => {
+      expect(spec.info.version).toBe('1.27.0');
+    });
+  });
+
   // GET /library/catalog (the gzipped-NDJSON bulk export) and its row shape
   // shipped in Backend-Service#1468 (Epic F, parent #1466) but were never
   // propagated to this cross-repo SSOT — only to BS's local Swagger-only
@@ -1364,12 +1484,6 @@ describe('OpenAPI Specification', () => {
       // (e.g. an LML predating the producer rollout). Does not change the meaning
       // of the sibling `*_url` fields — it only annotates why a url is null.
       expect(schema.required ?? []).not.toContain('streaming_status');
-    });
-
-    // The "current version" sentinel lives with the most recent api.yaml change;
-    // adding the per-service streaming_status contract bumped the minor.
-    it('bumps info.version to 1.26.0', () => {
-      expect(spec.info.version).toBe('1.26.0');
     });
   });
 

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -605,11 +605,16 @@ describe('OpenAPI Specification', () => {
         return undefined;
       }
 
-      it('gains discogsUnavailable as a nullable boolean, camelCase deliberately unlike its snake_case siblings', () => {
+      it('gains discogsUnavailable as a non-nullable boolean matching the other Album surfaces, camelCase deliberately unlike its snake_case siblings', () => {
         const prop = getProperty('discogsUnavailable');
+        const albumSchema = spec.components.schemas.Album as Schema;
         expect(prop).toBeDefined();
         expect(prop?.type).toBe('boolean');
-        expect(prop?.nullable).toBe(true);
+        // Non-nullable, exactly as Album/AlbumSearchResult/AlbumMetadataResponse
+        // declare it (the BS `withDiscogsUnavailableCamelCase` serializer types
+        // it as a non-null boolean).
+        expect(prop?.nullable).toBeUndefined();
+        expect(prop?.nullable).toBe(albumSchema.properties?.discogsUnavailable?.nullable);
       });
 
       it('gains discogsUnavailableNote as a nullable string capped at 500 chars', () => {

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -1067,18 +1067,20 @@ describe('Generated TypeScript Types', () => {
       expect(entry.discogsUnavailableNote).toBe('Self-released cassette, never listed');
     });
 
-    it('FlowsheetEntryResponse allows nullable discogsUnavailable to be explicitly null', () => {
+    it('FlowsheetEntryResponse allows omitting non-nullable discogsUnavailable while note is explicitly null', () => {
+      // discogsUnavailable is non-nullable (matching the other Album surfaces),
+      // so a row without the flag omits it rather than sending null;
+      // discogsUnavailableNote stays nullable.
       const entry: FlowsheetEntryResponse = {
         id: 1,
         play_order: 1,
         show_id: 1,
         request_flag: false,
         segue: false,
-        discogsUnavailable: null,
         discogsUnavailableNote: null,
       };
 
-      expect(entry.discogsUnavailable).toBeNull();
+      expect(entry.discogsUnavailable).toBeUndefined();
       expect(entry.discogsUnavailableNote).toBeNull();
     });
   });

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -983,4 +983,103 @@ describe('Generated TypeScript Types', () => {
       expect(baseline.streaming_status).toBeUndefined();
     });
   });
+
+  describe('discogsUnavailable trio on AlbumMetadataResponse / AlbumSearchResult / FlowsheetEntryResponse (#285 / #282 / BS#1908)', () => {
+    it('AlbumMetadataResponse accepts the discogsUnavailable trio', () => {
+      const response: AlbumMetadataResponse = {
+        discogsReleaseId: 12345,
+        artworkUrl: 'https://example.com/art.jpg',
+        discogsUnavailable: true,
+        discogsUnavailableNote: 'Embargoed promo-only pressing',
+        lastDiscogsRecheckAt: '2026-08-01T00:00:00Z',
+      };
+
+      expect(response.discogsUnavailable).toBe(true);
+      expect(response.discogsUnavailableNote).toBe('Embargoed promo-only pressing');
+      expect(response.lastDiscogsRecheckAt).toBe('2026-08-01T00:00:00Z');
+    });
+
+    it('AlbumMetadataResponse allows omitting the discogsUnavailable trio', () => {
+      const response: AlbumMetadataResponse = {
+        discogsReleaseId: 12345,
+        artworkUrl: 'https://example.com/art.jpg',
+      };
+
+      expect(response.discogsUnavailable).toBeUndefined();
+      expect(response.discogsUnavailableNote).toBeUndefined();
+      expect(response.lastDiscogsRecheckAt).toBeUndefined();
+    });
+
+    it('AlbumSearchResult accepts the discogsUnavailable trio', () => {
+      const result: AlbumSearchResult = {
+        id: 60359,
+        add_date: '2026-05-12T00:00:00Z',
+        album_title: 'DOGA',
+        artist_name: 'Juana Molina',
+        code_letters: 'MO',
+        code_number: 8,
+        code_artist_number: 3,
+        format_name: 'CD',
+        genre_name: 'Rock',
+        label: 'Sonamos',
+        discogsUnavailable: true,
+        discogsUnavailableNote: null,
+        lastDiscogsRecheckAt: null,
+      };
+
+      expect(result.discogsUnavailable).toBe(true);
+      expect(result.discogsUnavailableNote).toBeNull();
+      expect(result.lastDiscogsRecheckAt).toBeNull();
+    });
+
+    it('AlbumSearchResult allows omitting the discogsUnavailable trio', () => {
+      const result: AlbumSearchResult = {
+        id: 60359,
+        add_date: '2026-05-12T00:00:00Z',
+        album_title: 'DOGA',
+        artist_name: 'Juana Molina',
+        code_letters: 'MO',
+        code_number: 8,
+        code_artist_number: 3,
+        format_name: 'CD',
+        genre_name: 'Rock',
+        label: 'Sonamos',
+      };
+
+      expect(result.discogsUnavailable).toBeUndefined();
+    });
+
+    it('FlowsheetEntryResponse accepts discogsUnavailable + discogsUnavailableNote', () => {
+      const entry: FlowsheetEntryResponse = {
+        id: 1,
+        play_order: 1,
+        show_id: 1,
+        request_flag: false,
+        segue: false,
+        artist_name: 'Jessica Pratt',
+        track_title: 'Back, Baby',
+        album_title: 'On Your Own Love Again',
+        discogsUnavailable: true,
+        discogsUnavailableNote: 'Self-released cassette, never listed',
+      };
+
+      expect(entry.discogsUnavailable).toBe(true);
+      expect(entry.discogsUnavailableNote).toBe('Self-released cassette, never listed');
+    });
+
+    it('FlowsheetEntryResponse allows nullable discogsUnavailable to be explicitly null', () => {
+      const entry: FlowsheetEntryResponse = {
+        id: 1,
+        play_order: 1,
+        show_id: 1,
+        request_flag: false,
+        segue: false,
+        discogsUnavailable: null,
+        discogsUnavailableNote: null,
+      };
+
+      expect(entry.discogsUnavailable).toBeNull();
+      expect(entry.discogsUnavailableNote).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Bundles three additive `api.yaml` schema additions into one minor release, per the maintainer's decision to ship them together instead of as three separate patch bumps:

- **`AlbumMetadataResponse`** (`GET /proxy/metadata/album`) gains the full `discogsUnavailable` / `discogsUnavailableNote` / `lastDiscogsRecheckAt` trio, defined verbatim against the `Album` schema. Backend already emits `discogsUnavailable` on this endpoint, but the undeclared schema means every codegen consumer silently drops it on decode — the iOS album-detail "Not on Discogs" render gate is inert in production until this lands.
- **`AlbumSearchResult`** (catalog-search rows) gains the same trio, matching `Album`'s shape exactly. Backend already emits these fields via the `library_artist_view` projection; this unblocks dj-site's catalog-card render-gating.
- **`FlowsheetEntryResponse`** (V2 flowsheet album embed) gains a partial slice — `discogsUnavailable` + `discogsUnavailableNote`, no `lastDiscogsRecheckAt`. `discogsUnavailable` is deliberately camelCase amid its snake_case metadata siblings (`artwork_url`, `discogs_url`, `release_year`) to match Backend's `withDiscogsUnavailableCamelCase` serializer, which already emits it that way on this endpoint.

`api.yaml` `info.version` bumped 1.26.0 -> 1.27.0, following the convention set by the most recent api.yaml-adding commit. Purely additive — `npm run check:breaking` (oasdiff) reports no breaking changes. TypeScript codegen regenerated and verified locally; the generated trees are gitignored and not part of this diff. Package version bump and `@wxyc/shared` publish are a separate manual release step performed after merge.

Closes #285
Closes #282

Delivers the `api.yaml` contract slice of WXYC/Backend-Service#1908 (the BS-emit and dj-site-render pieces for the `FlowsheetEntryResponse` field stay open there). Part of epic WXYC/Backend-Service#1280.
