### PR TITLE
feat(library): CTA write-path contract — /library/{id}/compilation-tracks (BS#1964)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1742,8 +1742,11 @@ components:
       type: object
       description: |
         Result of an additive CTA write (BS#1964). `inserted + skipped` equals
-        the number of input rows; `tracks` is the release's full stored set
-        after the write.
+        the number of input rows — a row that duplicates one already inserted
+        earlier in the same request counts toward `skipped` (matched against the
+        just-inserted row on the CTA uniqueness key), so the identity always
+        holds even when the request carries intra-batch duplicates. `tracks` is
+        the release's full stored set after the write.
       required:
         - library_id
         - inserted

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.27.0
+  version: 1.28.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -1663,6 +1663,127 @@ components:
           type: string
         n:
           type: integer
+
+    # ===================
+    # Compilation Track (CTA) Write — BS#1964
+    # ===================
+
+    CompilationTrackInput:
+      type: object
+      description: |
+        A per-track artist entry to write to a compilation (BS#1964). The
+        durable, table-agnostic shape: only the librarian-meaningful free-text
+        fields, so it survives the future compilation_track_artist ->
+        library_track generalization (BS#801), which adds the canonical artist
+        link server-side rather than as a wire field.
+      required:
+        - artist_name
+      properties:
+        artist_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: Per-track performing artist (CTA.artist_name).
+        track_title:
+          type: string
+          maxLength: 255
+          nullable: true
+          description: Track title; nullable, matching the CTA column.
+        track_position:
+          type: string
+          maxLength: 20
+          nullable: true
+          description: Sleeve position label, e.g. "A1", "3".
+
+    CompilationTrack:
+      type: object
+      description: A stored compilation_track_artist row (BS#1964).
+      required:
+        - id
+        - artist_name
+      properties:
+        id:
+          type: integer
+          description: Server-assigned CTA row id.
+        artist_name:
+          type: string
+        track_title:
+          type: string
+          nullable: true
+        track_position:
+          type: string
+          nullable: true
+
+    CompilationTrackList:
+      type: object
+      required:
+        - library_id
+        - tracks
+      properties:
+        library_id:
+          type: integer
+        tracks:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompilationTrack'
+
+    CompilationTracksWriteRequest:
+      type: object
+      required:
+        - tracks
+      properties:
+        tracks:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CompilationTrackInput'
+
+    CompilationTracksWriteResponse:
+      type: object
+      description: |
+        Result of an additive CTA write (BS#1964). `inserted + skipped` equals
+        the number of input rows; `tracks` is the release's full stored set
+        after the write.
+      required:
+        - library_id
+        - inserted
+        - skipped
+        - tracks
+      properties:
+        library_id:
+          type: integer
+        inserted:
+          type: integer
+          description: Rows newly created.
+        skipped:
+          type: integer
+          description: Rows already present (matched on a CTA uniqueness key); left untouched.
+        tracks:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompilationTrack'
+
+    CompilationTrackSuggestions:
+      type: object
+      description: |
+        Proposed (unwritten) compilation tracklist derived from the linked
+        Discogs release (BS#1964). `discogs_release_id: null` + empty `tracks`
+        signals no resolvable upstream release -> manual entry.
+      required:
+        - library_id
+        - discogs_release_id
+        - tracks
+      properties:
+        library_id:
+          type: integer
+        discogs_release_id:
+          type: integer
+          nullable: true
+          description: The resolved Discogs release id, or null if none resolved.
+        tracks:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompilationTrackInput'
 
     # ===================
     # Rotation Types
@@ -7239,6 +7360,135 @@ paths:
                 $ref: '#/components/schemas/AlbumSearchResult'
         '404':
           description: Album not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
+  /library/{id}/compilation-tracks:
+    get:
+      summary: List the per-track artists on a V/A compilation release
+      description: |
+        Return the compilation_track_artist (CTA) rows stored for library
+        release `{id}` — the per-track artist/title/position rows that make a
+        Various-Artists compilation searchable at the track level. Empty when
+        the release has no per-track data. (BS#1964.)
+      tags:
+        - Library
+      # routes enforce requirePermissions({ catalog: ['read'] }) (library.route.ts)
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: The release's stored compilation tracks.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompilationTrackList'
+        '404':
+          description: Library release not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
+    post:
+      summary: Write per-track artists for a V/A compilation release (additive)
+      description: |
+        Append compilation_track_artist rows for library release `{id}` from an
+        explicit list — the manual fallback, and the target the dj-site
+        add-release panel POSTs after the librarian confirms/edits the imported
+        tracklist (see GET .../compilation-tracks/discogs-suggestions).
+
+        Additive-only (BS#1964 / D6): existing CTA rows are never mutated or
+        deleted. Rows already present (matched on the existing uniqueness keys —
+        `(library_id, artist_name, track_title)` and the NULL-track partial
+        unique) are skipped, not duplicated; the response reports `inserted` vs
+        `skipped`. Wholesale replace / release-identity correction is out of
+        scope here and is tracked in BS#801.
+      tags:
+        - Library
+      # routes enforce requirePermissions({ catalog: ['write'] }) (library.route.ts)
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompilationTracksWriteRequest'
+      responses:
+        '200':
+          description: Tracks written; body reports inserted vs skipped and the resulting set.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompilationTracksWriteResponse'
+        '400':
+          description: Invalid track list (e.g. empty, or a track missing artist_name).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Library release not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
+  /library/{id}/compilation-tracks/discogs-suggestions:
+    get:
+      summary: Propose a compilation tracklist from the release's linked Discogs release
+      description: |
+        Autopopulate source (BS#1964). Resolve the Discogs release linked to
+        library `{id}` (its stored discogs_release_id, else the BS->LML lookup
+        path) and return that release's tracklist as write-ready
+        CompilationTrackInput rows — WITHOUT writing anything. The dj-site panel
+        renders these for confirm/edit, then POSTs the (possibly edited) list to
+        POST .../compilation-tracks.
+
+        This is the only Discogs-touching call in the CTA write flow and it is a
+        single release fetch (one LML getRelease), never the per-track
+        N-validation fan-out that BS#1117 warns against; the write path itself
+        does no external I/O. When no Discogs release is resolvable,
+        `discogs_release_id` is null and `tracks` is empty — the caller falls
+        back to manual entry.
+      tags:
+        - Library
+      # routes enforce requirePermissions({ catalog: ['write'] }) (library.route.ts) —
+      # gated as a write helper (it feeds the confirm/edit write UI), not catalog:read.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: >
+            Proposed tracklist. `discogs_release_id: null` + empty `tracks`
+            means no upstream release resolved — use the manual write path.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompilationTrackSuggestions'
+        '404':
+          description: Library release not found.
           content:
             application/json:
               schema:

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -796,6 +796,10 @@ describe('OpenAPI Specification', () => {
       expect((schema.required ?? []).sort()).toEqual(['artist_name']);
       expect(schema.properties?.artist_name?.type).toBe('string');
       expect(schema.properties?.artist_name?.maxLength).toBe(255);
+      // minLength 1 is the sole guard forcing a non-empty per-track artist on
+      // the wire — the constraint the POST's 400 ("a track missing artist_name")
+      // leans on; pin it so a regression to empty-string writes can't merge green.
+      expect(schema.properties?.artist_name?.minLength).toBe(1);
       // The durable free-text triple — no canonical artist_id / confidence /
       // method here; BS#801 adds those server-side, not on the wire.
       expect(schema.properties?.artist_id).toBeUndefined();
@@ -872,6 +876,9 @@ describe('OpenAPI Specification', () => {
       expect(path.get!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
         '#/components/schemas/CompilationTrackList'
       );
+      expect(path.get!.responses?.['404']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/ApiErrorResponse'
+      );
       expect(path?.post).toBeDefined();
       expect(path.post!.security).toEqual([{ BearerAuth: [] }]);
       expect(path.post!.requestBody?.content?.['application/json']?.schema?.$ref).toBe(
@@ -879,6 +886,14 @@ describe('OpenAPI Specification', () => {
       );
       expect(path.post!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
         '#/components/schemas/CompilationTracksWriteResponse'
+      );
+      // Error contract is load-bearing (dj-site distinguishes a bad list from a
+      // missing release); pin both refs so a dropped/mis-pointed response fails CI.
+      expect(path.post!.responses?.['400']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/ApiErrorResponse'
+      );
+      expect(path.post!.responses?.['404']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/ApiErrorResponse'
       );
     });
 
@@ -890,6 +905,9 @@ describe('OpenAPI Specification', () => {
       expect(path.get!.security).toEqual([{ BearerAuth: [] }]);
       expect(path.get!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
         '#/components/schemas/CompilationTrackSuggestions'
+      );
+      expect(path.get!.responses?.['404']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/ApiErrorResponse'
       );
     });
 

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -630,12 +630,6 @@ describe('OpenAPI Specification', () => {
         expect(prop).toBeUndefined();
       });
     });
-
-    // The "current version" sentinel lives with the most recent api.yaml change;
-    // bundling the three discogsUnavailable additions bumped the minor.
-    it('bumps info.version to 1.27.0', () => {
-      expect(spec.info.version).toBe('1.27.0');
-    });
   });
 
   // GET /library/catalog (the gzipped-NDJSON bulk export) and its row shape
@@ -780,6 +774,129 @@ describe('OpenAPI Specification', () => {
         expect(path?.get, route).toBeDefined();
         expect(path!.get!.security, route).toEqual([{ BearerAuth: [] }]);
       }
+    });
+  });
+
+  // Compilation-track (CTA) write path (BS#1964). Adds the compilation-tracks
+  // sub-collection under a library release so V/A per-track artists can be
+  // written after /wxycdb goes dark. Shape A: the server READS Discogs
+  // (discogs-suggestions) but every WRITE carries an explicit, client-confirmed
+  // list — Discogs-agnostic, additive-only (D6: existing rows untouched), and
+  // thin enough to survive the future compilation_track_artist -> library_track
+  // rename (BS#801). The version sentinel travels here as the most recent change.
+  describe('Compilation Track Write (BS#1964)', () => {
+    type Schema = {
+      required?: string[];
+      properties?: Record<string, Record<string, unknown>>;
+    };
+
+    it('defines CompilationTrackInput: only artist_name required; title/position nullable + capped', () => {
+      const schema = spec.components.schemas.CompilationTrackInput as Schema;
+      expect(schema).toBeDefined();
+      expect((schema.required ?? []).sort()).toEqual(['artist_name']);
+      expect(schema.properties?.artist_name?.type).toBe('string');
+      expect(schema.properties?.artist_name?.maxLength).toBe(255);
+      // The durable free-text triple — no canonical artist_id / confidence /
+      // method here; BS#801 adds those server-side, not on the wire.
+      expect(schema.properties?.artist_id).toBeUndefined();
+      const title = schema.properties?.track_title;
+      expect(title?.type).toBe('string');
+      expect(title?.nullable).toBe(true);
+      expect(title?.maxLength).toBe(255);
+      const position = schema.properties?.track_position;
+      expect(position?.type).toBe('string');
+      expect(position?.nullable).toBe(true);
+      expect(position?.maxLength).toBe(20);
+    });
+
+    it('defines CompilationTrack: a stored row keyed by server id', () => {
+      const schema = spec.components.schemas.CompilationTrack as Schema;
+      expect(schema).toBeDefined();
+      expect((schema.required ?? []).sort()).toEqual(['artist_name', 'id']);
+      expect(schema.properties?.id?.type).toBe('integer');
+      expect(schema.properties?.track_title?.nullable).toBe(true);
+      expect(schema.properties?.track_position?.nullable).toBe(true);
+    });
+
+    it('defines CompilationTrackList wrapping stored rows for a release', () => {
+      const schema = spec.components.schemas.CompilationTrackList as Schema;
+      expect(schema).toBeDefined();
+      expect((schema.required ?? []).sort()).toEqual(['library_id', 'tracks']);
+      expect((schema.properties?.tracks as { items?: { $ref?: string } })?.items?.$ref).toBe(
+        '#/components/schemas/CompilationTrack'
+      );
+    });
+
+    it('defines CompilationTracksWriteRequest as a non-empty list of inputs', () => {
+      const schema = spec.components.schemas.CompilationTracksWriteRequest as Schema;
+      expect(schema).toBeDefined();
+      expect((schema.required ?? []).sort()).toEqual(['tracks']);
+      const tracks = schema.properties?.tracks as { minItems?: number; items?: { $ref?: string } };
+      expect(tracks?.minItems).toBe(1);
+      expect(tracks?.items?.$ref).toBe('#/components/schemas/CompilationTrackInput');
+    });
+
+    it('defines CompilationTracksWriteResponse reporting inserted vs skipped (idempotent write)', () => {
+      const schema = spec.components.schemas.CompilationTracksWriteResponse as Schema;
+      expect(schema).toBeDefined();
+      expect((schema.required ?? []).sort()).toEqual(['inserted', 'library_id', 'skipped', 'tracks']);
+      expect(schema.properties?.inserted?.type).toBe('integer');
+      expect(schema.properties?.skipped?.type).toBe('integer');
+    });
+
+    it('defines CompilationTrackSuggestions with a nullable discogs_release_id (no-match => manual fallback)', () => {
+      const schema = spec.components.schemas.CompilationTrackSuggestions as Schema;
+      expect(schema).toBeDefined();
+      // discogs_release_id is REQUIRED-but-nullable so the null carries meaning
+      // (looked, none resolved) rather than being an absent/unknown field.
+      expect((schema.required ?? []).sort()).toEqual(['discogs_release_id', 'library_id', 'tracks']);
+      expect(schema.properties?.discogs_release_id?.type).toBe('integer');
+      expect(schema.properties?.discogs_release_id?.nullable).toBe(true);
+      // Suggestions are write-ready inputs, not stored rows.
+      expect((schema.properties?.tracks as { items?: { $ref?: string } })?.items?.$ref).toBe(
+        '#/components/schemas/CompilationTrackInput'
+      );
+    });
+
+    it('declares GET + POST /library/{id}/compilation-tracks (BearerAuth; list / additive write)', () => {
+      const path = spec.paths['/library/{id}/compilation-tracks'] as {
+        get?: { security?: unknown[]; responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }> };
+        post?: {
+          security?: unknown[];
+          requestBody?: { content?: Record<string, { schema?: { $ref?: string } }> };
+          responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }>;
+        };
+      };
+      expect(path?.get).toBeDefined();
+      expect(path.get!.security).toEqual([{ BearerAuth: [] }]);
+      expect(path.get!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/CompilationTrackList'
+      );
+      expect(path?.post).toBeDefined();
+      expect(path.post!.security).toEqual([{ BearerAuth: [] }]);
+      expect(path.post!.requestBody?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/CompilationTracksWriteRequest'
+      );
+      expect(path.post!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/CompilationTracksWriteResponse'
+      );
+    });
+
+    it('declares GET /library/{id}/compilation-tracks/discogs-suggestions (BearerAuth; suggestions)', () => {
+      const path = spec.paths['/library/{id}/compilation-tracks/discogs-suggestions'] as {
+        get?: { security?: unknown[]; responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }> };
+      };
+      expect(path?.get).toBeDefined();
+      expect(path.get!.security).toEqual([{ BearerAuth: [] }]);
+      expect(path.get!.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/CompilationTrackSuggestions'
+      );
+    });
+
+    // The "current version" sentinel lives with the most recent api.yaml change;
+    // the CTA write-path paths + schemas bumped the minor.
+    it('bumps info.version to 1.28.0', () => {
+      expect(spec.info.version).toBe('1.28.0');
     });
   });
 


### PR DESCRIPTION
Closes #291. Contract prerequisite for WXYC/Backend-Service#1964 (CTA write path); part of the Phase 3.5 `/wxycdb` cutover (WXYC/wiki#89).

## What / why

`compilation_track_artist` (CTA) makes V/A per-track artists searchable, but today CTA rows arrive only via the insert-only `library-etl` MySQL mirror. When `/wxycdb` goes dark at the Phase 3.5 cutover, that mirror stops; without a write API, every compilation added afterwards permanently loses per-track artist search. This adds the api.yaml contract for that write path.

## Shape A — Discogs-read, explicit-write

The server may **read** Discogs to propose a tracklist; every **write** carries an explicit, client-confirmed list.

- `GET /library/{id}/compilation-tracks` — list stored CTA rows → `CompilationTrackList`.
- `POST /library/{id}/compilation-tracks` — **additive** write of an explicit list → `CompilationTracksWriteResponse` (`inserted` vs `skipped`; existing rows matched on the CTA uniqueness keys are skipped, never mutated). Manual fallback + dj-site confirm/edit target.
- `GET /library/{id}/compilation-tracks/discogs-suggestions` — autopopulate source: resolve the linked Discogs release, return its tracklist as write-ready `CompilationTrackInput` rows **without writing** (`discogs_release_id: null` + empty `tracks` ⇒ no upstream release ⇒ manual entry).

New schemas: `CompilationTrackInput`, `CompilationTrack`, `CompilationTrackList`, `CompilationTracksWriteRequest`, `CompilationTracksWriteResponse`, `CompilationTrackSuggestions`.

## Why this shape

- **D6:** additive-only — the contract never expresses replace/delete, so the 4,161-row insert-only residue is untouched. Wholesale replace / release-identity correction stays in WXYC/Backend-Service#801.
- **BS#801 (`library_track` generalization):** every write carries only the durable free-text triple (`artist_name`/`track_title`/`track_position`) — no `artist_id`/confidence/method on the wire (BS#801 adds those server-side). The path survives the table rename without a contract rewrite.
- **BS#1117 (serial per-track validation timeout):** the only Discogs-touching call is the suggestions **read** — a single `getRelease`, not the per-track N-validation fan-out #1117 hit. Write endpoints do zero external I/O; seeding is a separate call from `addAlbum`, so the add request is never blocked.

## Tests

`tests/api-spec.test.ts` gains a `Compilation Track Write (BS#1964)` block pinning the three paths (auth + request/response `$ref`s) and all six schemas (required fields, nullability, the required-but-nullable `discogs_release_id`), and re-homes the version sentinel to `1.28.0`. Local: `generate:typescript` + `build` + `lint` + `lint:e2e` + `test` (597 passed) green; `oasdiff … --fail-on ERR` reports **no breaking changes** (additive-only, minor bump `1.27.0` → `1.28.0`).

## Codegen fan-out (concern:contract-change)

Types here are gitignored + regenerated in CI. After merge, downstream consumers regen their committed Python models:

- **library-metadata-lookup** — `scripts/generate_api_models.sh` → `generated/api_models.py` (datamodel-code-generator 0.56.1).
- **request-o-matic** — `generated/api_models.py` (datamodel-code-generator 0.57.0).

Both additive (new models only).
