### PR TITLE
feat(api): extend CatalogExportRow + add CTA export for the library.db producer (BS#1965)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1374,12 +1374,22 @@ components:
         of the core catalog row. Deliberately NOT AlbumSearchResult: it drops the
         search-only decoration (matched_via, matched_via_alias, album_dist,
         artist_dist) and the fields the export omits (add_date, label_id,
-        rotation_id, album_artist, date_lost, date_found), and instead ships
+        rotation_id, date_lost, date_found), and instead ships
         rotation RAW (rotation_bin + rotation_kill_date) so the client evaluates
         rotation expiry against its own clock. See the rotation_bin description
         for the load-bearing semantic difference from AlbumSearchResult.
+
+        BS#1965 adds the fields the Backend-sourced library.db producer
+        (discogs-etl#351) needs to build a byte-parity library.db over HTTP
+        instead of a direct Postgres read: legacy_release_id (the producer emits
+        it AS the library.db id, since BS serials collide with the tubafrenzy id
+        space), album_artist, alternate_artist_name, and cross_reference_names
+        (pipe-joined artist aliases). label stays in this row but is always null
+        in the produced library.db (the legacy MySQL export omits it), so it is
+        not load-bearing for the producer.
       required:
         - id
+        - legacy_release_id
         - artist_name
         - album_title
         - code_letters
@@ -1390,12 +1400,49 @@ components:
       properties:
         id:
           type: integer
+          description: >
+            BS serial library.id — the existing on-device clone key for the iOS
+            Spotlight consumer. NOT the library.db id: the library.db producer
+            uses legacy_release_id instead (see below), so BS serials never leak
+            into the tubafrenzy id space.
+        legacy_release_id:
+          type: integer
+          description: >
+            The library row's surrogate key (BS#1963), total since the mint +
+            NULL-legacy backfill. The Backend-sourced library.db producer
+            (discogs-etl#351) emits this AS library.db's library.id.
         artist_name:
           type: string
           description: >
             Authoritative artist name. The server COALESCEs the denormalized
             library.artist_name to artists.artist_name (NOT NULL), so this never
             ships as null even before the denormalization backfill completes.
+        alternate_artist_name:
+          type: string
+          nullable: true
+          description: >
+            Secondary artist name curated by the librarians
+            (library.alternate_artist_name); null when unset. Maps to
+            library.db's alternate_artist_name column.
+        album_artist:
+          type: string
+          nullable: true
+          description: >
+            Album-level artist (library.album_artist), distinct from the
+            shelf-filing artist_name; null when unset. Maps to library.db's
+            album_artist column. (Previously omitted from this export; re-added
+            for the library.db producer.)
+        cross_reference_names:
+          type: string
+          nullable: true
+          description: >
+            Pipe-joined (" | ") names of the artists cataloger-cross-referenced
+            to this row's artist, in either FK direction, via
+            artist_crossreference (discogs-etl#334) — e.g. a band filed under its
+            name carries a member's personal name. Deduplicated and
+            alphabetically ordered for a stable string; null when the artist has
+            no cross-references. Maps to library.db's cross_reference_names
+            column.
         album_title:
           type: string
         code_letters:
@@ -1469,6 +1516,40 @@ components:
             expires, or null if it has none. Used with rotation_bin to evaluate
             live rotation client-side. Absent from AlbumSearchResult — a client
             that reuses AlbumSearchResult for this endpoint silently loses it.
+
+    CatalogCompilationTrackRow:
+      type: object
+      description: >
+        One compilation_track_artist (CTA) row as served by
+        GET /library/catalog/compilation-tracks for the Backend-sourced
+        library.db producer (BS#1965 / discogs-etl#351). The sibling of
+        CatalogExportRow: where that endpoint feeds library.db's `library` table,
+        this feeds its `compilation_track_artist` table (3 columns:
+        library_release_id, artist_name, track_title). Keyed on
+        legacy_release_id — the library row's surrogate key that the producer
+        also emits AS library.db's library.id — so the producer maps
+        legacy_release_id -> compilation_track_artist.library_release_id.
+        Deliberately drops the CTA row id and track_position: library.db's
+        3-column CTA table carries neither, so shipping them would break parity.
+        Distinct from CompilationTrack (the BS#1964 dj-site read shape, which
+        keeps id + track_position and is keyed on the BS serial library_id).
+      required:
+        - legacy_release_id
+        - artist_name
+      properties:
+        legacy_release_id:
+          type: integer
+          description: >
+            The owning library row's legacy_release_id (BS#1963). Becomes
+            library.db's compilation_track_artist.library_release_id, which joins
+            to library.db's library.id.
+        artist_name:
+          type: string
+          description: Per-track performing artist (CTA.artist_name).
+        track_title:
+          type: string
+          nullable: true
+          description: Track title; nullable, matching the CTA column.
 
     AddAlbumRequest:
       type: object
@@ -7026,6 +7107,79 @@ paths:
               # path description.
               schema:
                 $ref: '#/components/schemas/CatalogExportRow'
+        '304':
+          description: >
+            Not Modified — catalog unchanged since the client's
+            If-Modified-Since / since watermark. No body.
+
+  /library/catalog/compilation-tracks:
+    get:
+      summary: Bulk compilation-track (CTA) export for the library.db producer (gzipped NDJSON)
+      description: |
+        Stream every compilation_track_artist (CTA) row as one gzipped,
+        newline-delimited JSON (NDJSON) body — one CatalogCompilationTrackRow per
+        line — so the Backend-sourced library.db producer (BS#1965 /
+        discogs-etl#351) can build library.db's compilation_track_artist table
+        over HTTP instead of a direct Postgres read. Sibling of GET
+        /library/catalog: that endpoint feeds library.db's `library` table, this
+        one feeds its `compilation_track_artist` table.
+
+        Each row is keyed on legacy_release_id (the owning library row's
+        surrogate key, which /library/catalog emits AS library.db's library.id),
+        so the producer maps legacy_release_id ->
+        compilation_track_artist.library_release_id. Rows are emitted ordered by
+        legacy_release_id.
+
+        Conditional GET: same middleware and watermark as GET /library/catalog —
+        Last-Modified is set from the library_watermark, echoed back via
+        If-Modified-Since (or ?since=) for a cheap 304. Because CTA freshness
+        rides library_watermark, a new compilation's CTA rows surface as soon as
+        its library add bumps the watermark; a standalone CTA edit to an existing
+        release lags to the next library write — immaterial for the daily
+        producer cadence.
+
+        Transport (not expressible in the element schema): the body is NDJSON —
+        split on newlines and decode per line; it is NOT a JSON array. It is
+        gzip-encoded (Content-Encoding: gzip). See catalog-export.service.ts
+        (serializeCompilationTracksNdjson).
+      security:
+        - BearerAuth: []   # routes enforce requirePermissions({ catalog: ['read'] })
+      parameters:
+        - name: If-Modified-Since
+          in: header
+          required: false
+          schema:
+            type: string
+          description: >
+            HTTP-date previously returned in Last-Modified. Yields 304 if the
+            catalog has not changed since. Echo the server's string verbatim; do
+            not round-trip it through a local date type.
+        - name: since
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Header-free alternative to If-Modified-Since (same semantics).
+      responses:
+        '200':
+          description: All CTA rows as gzipped NDJSON (one CatalogCompilationTrackRow per line).
+          headers:
+            Last-Modified:
+              schema:
+                type: string
+              description: Catalog watermark as an HTTP-date; echo back as If-Modified-Since.
+            Content-Encoding:
+              schema:
+                type: string
+              description: '"gzip" on the gzip-accepting path.'
+          content:
+            application/x-ndjson:
+              # NOTE: the body is newline-delimited CatalogCompilationTrackRow
+              # objects (one per line), NOT a single object or a JSON array.
+              # OpenAPI can't model NDJSON framing; this schema describes ONE
+              # line. See the path description.
+              schema:
+                $ref: '#/components/schemas/CatalogCompilationTrackRow'
         '304':
           description: >
             Not Modified — catalog unchanged since the client's

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.28.0
+  version: 1.29.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -1380,16 +1380,23 @@ components:
         for the load-bearing semantic difference from AlbumSearchResult.
 
         BS#1965 adds the fields the Backend-sourced library.db producer
-        (discogs-etl#351) needs to build a byte-parity library.db over HTTP
-        instead of a direct Postgres read: legacy_release_id (the producer emits
-        it AS the library.db id, since BS serials collide with the tubafrenzy id
-        space), album_artist, alternate_artist_name, and cross_reference_names
-        (pipe-joined artist aliases). label stays in this row but is always null
-        in the produced library.db (the legacy MySQL export omits it), so it is
-        not load-bearing for the producer.
+        (discogs-etl#351) needs to build a library.db over HTTP instead of a
+        direct Postgres read: legacy_release_id (the producer emits it AS the
+        library.db id, since BS serials collide with the tubafrenzy id space),
+        album_artist, alternate_artist_name, and cross_reference_names.
+
+        All four are producer-facing and OPTIONAL on the wire — none is in
+        `required`, so the pre-BS#1965 15-field body still decodes cleanly
+        against a client generated from this spec. That leniency is deliberate
+        and load-bearing: this row is also the iOS Spotlight clone's shape, and
+        wxyc-ios-64 regenerates from this SSOT on its own cadence. A required
+        key the server does not yet emit would not degrade one field — it would
+        fail EVERY NDJSON line and take the whole on-device clone with it. Same
+        reasoning as `popularity` (BS#1486 Phase-2 Track 3). Note that oasdiff
+        does NOT flag adding a required response property, so a green
+        `check:breaking` is not evidence of safety here.
       required:
         - id
-        - legacy_release_id
         - artist_name
         - album_title
         - code_letters
@@ -1407,10 +1414,19 @@ components:
             into the tubafrenzy id space.
         legacy_release_id:
           type: integer
+          nullable: true
           description: >
-            The library row's surrogate key (BS#1963), total since the mint +
-            NULL-legacy backfill. The Backend-sourced library.db producer
-            (discogs-etl#351) emits this AS library.db's library.id.
+            The library row's surrogate key (BS#1963), total in the database
+            since the mint + NULL-legacy backfill. The Backend-sourced
+            library.db producer (discogs-etl#351) emits this AS library.db's
+            library.id.
+
+            Server-side totality does NOT make it a required wire key: it is
+            optional + nullable here so a client regenerated from this spec
+            before BS#1965 ships still decodes the current 15-field body (see
+            the schema description). The producer may treat a null/absent value
+            as "this Backend does not implement BS#1965 yet" and fail loudly
+            rather than emitting a library.db row with a null id.
         artist_name:
           type: string
           description: >
@@ -1433,16 +1449,56 @@ components:
             album_artist column. (Previously omitted from this export; re-added
             for the library.db producer.)
         cross_reference_names:
-          type: string
+          type: array
           nullable: true
+          items:
+            type: string
           description: >
-            Pipe-joined (" | ") names of the artists cataloger-cross-referenced
-            to this row's artist, in either FK direction, via
-            artist_crossreference (discogs-etl#334) — e.g. a band filed under its
-            name carries a member's personal name. Deduplicated and
-            alphabetically ordered for a stable string; null when the artist has
-            no cross-references. Maps to library.db's cross_reference_names
-            column.
+            Names of the artists cataloger-cross-referenced to this row's
+            artist, in either FK direction, via artist_crossreference
+            (discogs-etl#334) — e.g. a band filed under its name carries a
+            member's personal name. Empty array when the artist has no
+            cross-references.
+
+            An ARRAY, not the pipe-joined string library.db stores: the
+            producer does the `" | "` join when it writes the SQLite column.
+            The wire must not carry the delimiter, because nothing constrains
+            artists.artist_name from containing "|" or " | " — a joined string
+            would silently split into phantom aliases on the consumer side
+            (library-metadata-lookup splits this field on the pipe) with no
+            escaping rule to recover from, and the legacy MySQL source has the
+            same latent bug plus GROUP_CONCAT's silent group_concat_max_len
+            truncation. Array-on-the-wire retires both.
+
+            Derivation (pinned, because the legacy query it replaces is
+            load-bearing for the producer — LIBRARY_CODE_CROSS_REFERENCE in
+            discogs-etl/scripts/sync-library.sh):
+              * BOTH FK directions — an artist_crossreference row matching on
+                either source_artist_id or target_artist_id contributes its
+                OTHER side.
+              * EXCLUDES the row's own artist (the legacy query's
+                `AND xlc.ID != lc.ID`). A self-referencing crossreference row
+                must not produce a self-alias — LML would match the artist
+                against itself.
+              * Deduplicated.
+              * Ordered by Unicode code point (Postgres `COLLATE "C"`), NOT the
+                database's default collation. en_US.UTF-8 ignores punctuation
+                and case at the primary level, so it orders the diacritic- and
+                punctuation-bearing names most likely to carry aliases (Nilüfer
+                Yanya, Csillagrablók, Hermanos Gutiérrez, "C. Spencer Yeh")
+                unstably across locales. The legacy GROUP_CONCAT has no ORDER BY
+                at all, so there is no legacy order to match — pick the
+                deterministic one.
+
+            FRESHNESS CAVEAT — BS#1965 MUST land a trigger for this. This
+            endpoint's conditional GET rides library_watermark, and
+            artist_crossreference has NO touch_library_watermark trigger as of
+            migration 0105 (which covers library, artists, genres, format,
+            genre_artist_crossreference, rotation — not this table). Without a
+            new trigger, adding a cross-reference does not advance the
+            watermark, the per-watermark gzip cache is never rebuilt, and the
+            producer 304s against a body that will never contain the new alias.
+            Silent and unbounded, not a lag.
         album_title:
           type: string
         code_letters:
@@ -1457,6 +1513,12 @@ components:
         label:
           type: string
           nullable: true
+          description: >
+            Record label (library.label), projected as its real value — null
+            only when the row genuinely has none. The library.db producer
+            ignores it (the legacy MySQL export it must match has no label
+            column), but every other consumer of this export should treat it as
+            live data.
         genre_name:
           type: string
         format_name:
@@ -1545,11 +1607,19 @@ components:
             to library.db's library.id.
         artist_name:
           type: string
-          description: Per-track performing artist (CTA.artist_name).
+          minLength: 1
+          maxLength: 255
+          description: >
+            Per-track performing artist (CTA.artist_name). Bounds mirror
+            CompilationTrackInput and the underlying varchar(255) NOT NULL — the
+            read and write shapes over the same physical column must not
+            disagree about their own constraints, and the producer needs the
+            width to size its SQLite column.
         track_title:
           type: string
+          maxLength: 255
           nullable: true
-          description: Track title; nullable, matching the CTA column.
+          description: Track title; nullable varchar(255), matching the CTA column.
 
     AddAlbumRequest:
       type: object
@@ -7130,13 +7200,53 @@ paths:
         compilation_track_artist.library_release_id. Rows are emitted ordered by
         legacy_release_id.
 
+        ROW ELIGIBILITY — emit a CTA row only if its owning library row is
+        eligible for GET /library/catalog. That export is not "every library
+        row": it INNER JOINs artists, format, genres, and
+        genre_artist_crossreference (on the artist_id + genre_id pair), so a row
+        whose (artist, genre) pair has no genre_artist_crossreference entry — a
+        shape the ETL preserves, per the schema comment on that table — is
+        silently dropped. An unfiltered CTA export would then ship
+        library_release_id values that join to nothing in library.db's `library`
+        table, and LML's CTA UNION would surface a compilation track whose
+        release row it cannot resolve. Apply the same predicate on both
+        endpoints.
+
         Conditional GET: same middleware and watermark as GET /library/catalog —
         Last-Modified is set from the library_watermark, echoed back via
-        If-Modified-Since (or ?since=) for a cheap 304. Because CTA freshness
-        rides library_watermark, a new compilation's CTA rows surface as soon as
-        its library add bumps the watermark; a standalone CTA edit to an existing
-        release lags to the next library write — immaterial for the daily
-        producer cadence.
+        If-Modified-Since (or ?since=) for a cheap 304.
+
+        FRESHNESS CAVEAT — BS#1965 MUST land a trigger for this.
+        compilation_track_artist has NO touch_library_watermark trigger as of
+        migration 0105 (which covers library, artists, genres, format,
+        genre_artist_crossreference, rotation — not this table). CTA writes
+        therefore do not advance the watermark on their own, and the ordering is
+        NOT the reassuring one: the CTA POST always FOLLOWS the library add it
+        would ride. The real sequence is (1) POST /library bumps the watermark
+        to T, (2) the per-watermark gzip cache builds for T, (3) POST
+        /library/{id}/compilation-tracks lands rows at T+delta with no trigger —
+        so the cached body for T does not contain them and this endpoint 304s
+        until some unrelated write bumps the watermark. Post-tubafrenzy-turndown
+        the daily library sync goes away, so "it'll catch up on the next daily
+        write" stops holding and a CTA-only editing session can stay invisible
+        indefinitely.
+
+        IMPLEMENTATION NOTES for BS#1965:
+          * Route registration order is load-bearing. This literal path is
+            ambiguous with the templated GET /library/{id}/compilation-tracks
+            (same method, same catalog:['read'] permission), so it MUST be
+            registered before the /:id routes — next to the existing '/catalog'
+            literal in library.route.ts, not next to the other
+            compilation-tracks routes. Registered after, Express matches
+            /:id/compilation-tracks with id === 'catalog', Number('catalog') is
+            NaN, and the producer gets a 4xx/5xx with no auth-layer signal
+            (both routes carry the same permission).
+          * The catalog export holds one full gzipped body resident per pod for
+            the life of the watermark (createWatermarkCache<Buffer>). A second
+            such cache for the full CTA table is additive and long-lived on a
+            memory-constrained host. Size it before shipping; if it is material,
+            fold these rows into /library/catalog behind an opt-in
+            ?include=compilation_tracks instead (BS#1965 leaves the shape open).
 
         Transport (not expressible in the element schema): the body is NDJSON —
         split on newlines and decode per line; it is NOT a JSON array. It is

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -646,12 +646,17 @@ describe('OpenAPI Specification', () => {
     };
 
     // The catalog-export projection (Backend-Service catalog-export.service.ts,
-    // CatalogExportRow). The SSOT leads the consumer: this list is 15 fields,
-    // one ahead of that private type until Backend Track 3 (#1493) adds the
-    // 15th, `popularity`.
+    // CatalogExportRow). The SSOT leads the consumer (the private type mirrors
+    // this list under the BS#1477 parity guard). BS#1965 added the four
+    // library.db-producer fields (legacy_release_id, alternate_artist_name,
+    // album_artist, cross_reference_names) — 19 fields total.
     const EXPORT_FIELDS = [
       'id',
+      'legacy_release_id',
       'artist_name',
+      'alternate_artist_name',
+      'album_artist',
+      'cross_reference_names',
       'album_title',
       'code_letters',
       'code_number',
@@ -667,17 +672,18 @@ describe('OpenAPI Specification', () => {
       'rotation_kill_date',
     ];
 
-    it('defines CatalogExportRow with exactly the 15 shipped fields', () => {
+    it('defines CatalogExportRow with exactly the 19 shipped fields', () => {
       const schema = spec.components.schemas.CatalogExportRow as Schema;
       expect(schema).toBeDefined();
       expect(Object.keys(schema.properties ?? {}).sort()).toEqual([...EXPORT_FIELDS].sort());
     });
 
-    it('marks the 8 non-null fields required (deliberate leniency: the nullable keys are omitted)', () => {
+    it('marks the 9 non-null fields required (deliberate leniency: the nullable keys are omitted)', () => {
       const schema = spec.components.schemas.CatalogExportRow as Schema;
       expect((schema.required ?? []).sort()).toEqual(
         [
           'id',
+          'legacy_release_id',
           'artist_name',
           'album_title',
           'code_letters',
@@ -687,6 +693,28 @@ describe('OpenAPI Specification', () => {
           'format_name',
         ].sort()
       );
+    });
+
+    it('ships the four BS#1965 library.db-producer fields (legacy_release_id required int; album_artist/alternate_artist_name/cross_reference_names nullable strings)', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+
+      // legacy_release_id: total since BS#1963 mint + backfill, so REQUIRED and
+      // a plain integer (the producer emits it AS library.db's library.id).
+      const legacy = schema.properties?.legacy_release_id;
+      expect(legacy).toBeDefined();
+      expect(legacy!.type).toBe('integer');
+      expect(legacy!.nullable).toBeUndefined();
+      expect(schema.required ?? []).toContain('legacy_release_id');
+
+      // The three curated free-text fields are nullable and stay OUT of required
+      // (genuine library metadata gaps must not break a strict decoder).
+      for (const key of ['album_artist', 'alternate_artist_name', 'cross_reference_names']) {
+        const prop = schema.properties?.[key];
+        expect(prop, key).toBeDefined();
+        expect(prop!.type, key).toBe('string');
+        expect(prop!.nullable, key).toBe(true);
+        expect(schema.required ?? [], key).not.toContain(key);
+      }
     });
 
     it('ships popularity as a nullable integer alongside plays, not as a replacement (BS#1486 Phase-2 Track 3)', () => {
@@ -774,6 +802,56 @@ describe('OpenAPI Specification', () => {
         expect(path?.get, route).toBeDefined();
         expect(path!.get!.security, route).toEqual([{ BearerAuth: [] }]);
       }
+    });
+
+    // --- BS#1965: sibling CTA export for the library.db producer ---
+
+    it('defines CatalogCompilationTrackRow with exactly {legacy_release_id, artist_name, track_title}', () => {
+      const schema = spec.components.schemas.CatalogCompilationTrackRow as Schema;
+      expect(schema).toBeDefined();
+      expect(Object.keys(schema.properties ?? {}).sort()).toEqual(
+        ['legacy_release_id', 'artist_name', 'track_title'].sort()
+      );
+      // Keyed on legacy_release_id + artist_name; track_title is nullable (the CTA
+      // column is). Deliberately NO `id` / `track_position` — library.db's
+      // 3-column CTA table carries neither, so shipping them would break parity.
+      expect((schema.required ?? []).sort()).toEqual(['legacy_release_id', 'artist_name'].sort());
+      expect(schema.properties?.legacy_release_id?.type).toBe('integer');
+      expect(schema.properties?.artist_name?.type).toBe('string');
+      expect(schema.properties?.track_title?.type).toBe('string');
+      expect(schema.properties?.track_title?.nullable).toBe(true);
+      expect(schema.properties?.id).toBeUndefined();
+      expect(schema.properties?.track_position).toBeUndefined();
+    });
+
+    it('declares GET /library/catalog/compilation-tracks (BearerAuth; If-Modified-Since + ?since=; NDJSON 200 + 304)', () => {
+      const path = spec.paths['/library/catalog/compilation-tracks'] as {
+        get?: {
+          security?: Array<Record<string, unknown[]>>;
+          parameters?: Array<{ name: string; in: string }>;
+          responses?: Record<
+            string,
+            { headers?: Record<string, unknown>; content?: Record<string, { schema?: { $ref?: string } }> }
+          >;
+        };
+      };
+      expect(path?.get).toBeDefined();
+      expect(path.get!.security).toEqual([{ BearerAuth: [] }]);
+
+      const ifModifiedSince = path.get!.parameters?.find((p) => p.name === 'If-Modified-Since');
+      expect(ifModifiedSince?.in).toBe('header');
+      const since = path.get!.parameters?.find((p) => p.name === 'since');
+      expect(since?.in).toBe('query');
+
+      const ok = path.get!.responses?.['200'];
+      expect(ok).toBeDefined();
+      // One NDJSON line is one CatalogCompilationTrackRow (framing isn't expressible in OpenAPI).
+      expect(ok!.content?.['application/x-ndjson']?.schema?.$ref).toBe(
+        '#/components/schemas/CatalogCompilationTrackRow'
+      );
+      expect(ok!.headers?.['Last-Modified']).toBeDefined();
+      expect(ok!.headers?.['Content-Encoding']).toBeDefined();
+      expect(path.get!.responses?.['304']).toBeDefined();
     });
   });
 

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -646,10 +646,17 @@ describe('OpenAPI Specification', () => {
     };
 
     // The catalog-export projection (Backend-Service catalog-export.service.ts,
-    // CatalogExportRow). The SSOT leads the consumer (the private type mirrors
-    // this list under the BS#1477 parity guard). BS#1965 added the four
-    // library.db-producer fields (legacy_release_id, alternate_artist_name,
-    // album_artist, cross_reference_names) — 19 fields total.
+    // CatalogExportRow). The SSOT LEADS the consumer: this list is 19 fields,
+    // four ahead of that private type until BS#1965 adds the library.db-producer
+    // fields (legacy_release_id, alternate_artist_name, album_artist,
+    // cross_reference_names).
+    //
+    // That lead is a live constraint on Backend-Service, not just a note. BS's
+    // parity guard (BS#1477, tests/unit/services/catalog-export.parity.test.ts)
+    // asserts privateKeys == ssotKeys against the INSTALLED @wxyc/shared, so the
+    // first BS PR that bumps this package past this release fails that test —
+    // including an unrelated Dependabot bump. BS#1965 must land in the same bump,
+    // or BS CI stays red. Do not delete this note until the lead is closed.
     const EXPORT_FIELDS = [
       'id',
       'legacy_release_id',
@@ -678,12 +685,11 @@ describe('OpenAPI Specification', () => {
       expect(Object.keys(schema.properties ?? {}).sort()).toEqual([...EXPORT_FIELDS].sort());
     });
 
-    it('marks the 9 non-null fields required (deliberate leniency: the nullable keys are omitted)', () => {
+    it('marks the 8 non-null fields required (deliberate leniency: the nullable keys are omitted)', () => {
       const schema = spec.components.schemas.CatalogExportRow as Schema;
       expect((schema.required ?? []).sort()).toEqual(
         [
           'id',
-          'legacy_release_id',
           'artist_name',
           'album_title',
           'code_letters',
@@ -695,26 +701,47 @@ describe('OpenAPI Specification', () => {
       );
     });
 
-    it('ships the four BS#1965 library.db-producer fields (legacy_release_id required int; album_artist/alternate_artist_name/cross_reference_names nullable strings)', () => {
+    it('keeps ALL FOUR BS#1965 producer fields out of required — a required key the server does not emit yet breaks every NDJSON line', () => {
       const schema = spec.components.schemas.CatalogExportRow as Schema;
 
-      // legacy_release_id: total since BS#1963 mint + backfill, so REQUIRED and
-      // a plain integer (the producer emits it AS library.db's library.id).
-      const legacy = schema.properties?.legacy_release_id;
-      expect(legacy).toBeDefined();
-      expect(legacy!.type).toBe('integer');
-      expect(legacy!.nullable).toBeUndefined();
-      expect(schema.required ?? []).toContain('legacy_release_id');
-
-      // The three curated free-text fields are nullable and stay OUT of required
-      // (genuine library metadata gaps must not break a strict decoder).
-      for (const key of ['album_artist', 'alternate_artist_name', 'cross_reference_names']) {
+      // This row is also the iOS Spotlight clone's shape, and wxyc-ios-64
+      // regenerates from this SSOT on its own cadence. Until BS#1965 ships, the
+      // server emits the 15-field body; a required key absent from it fails the
+      // WHOLE decode, not one field. Same leniency `popularity` shipped with.
+      // oasdiff does NOT flag adding a required response property, so
+      // `check:breaking` cannot catch a regression here — this test is the guard.
+      for (const key of [
+        'legacy_release_id',
+        'album_artist',
+        'alternate_artist_name',
+        'cross_reference_names',
+      ]) {
         const prop = schema.properties?.[key];
         expect(prop, key).toBeDefined();
-        expect(prop!.type, key).toBe('string');
         expect(prop!.nullable, key).toBe(true);
         expect(schema.required ?? [], key).not.toContain(key);
       }
+
+      // legacy_release_id is an integer (the producer emits it AS library.db's
+      // library.id); the two curated free-text fields are plain strings.
+      expect(schema.properties?.legacy_release_id?.type).toBe('integer');
+      expect(schema.properties?.album_artist?.type).toBe('string');
+      expect(schema.properties?.alternate_artist_name?.type).toBe('string');
+    });
+
+    it('ships cross_reference_names as an ARRAY of names, never a pipe-joined string', () => {
+      const schema = spec.components.schemas.CatalogExportRow as Schema;
+      const prop = schema.properties?.cross_reference_names as
+        | { type?: string; items?: { type?: string } }
+        | undefined;
+      expect(prop).toBeDefined();
+
+      // Nothing constrains artists.artist_name from containing "|" or " | ", and
+      // LML splits this field on the pipe. A joined string would silently split
+      // into phantom aliases with no escaping rule to recover from. The producer
+      // does the join when it writes library.db's TEXT column.
+      expect(prop!.type).toBe('array');
+      expect(prop!.items?.type).toBe('string');
     });
 
     it('ships popularity as a nullable integer alongside plays, not as a replacement (BS#1486 Phase-2 Track 3)', () => {
@@ -795,8 +822,14 @@ describe('OpenAPI Specification', () => {
       expect(path.get!.responses?.['304']).toBeDefined();
     });
 
-    it('requires BearerAuth on all four catalog GET reads — no half-fixed SSOT (decision 4)', () => {
-      const reads = ['/library', '/library/query', '/library/rotation', '/library/catalog'];
+    it('requires BearerAuth on all five catalog GET reads — no half-fixed SSOT (decision 4)', () => {
+      const reads = [
+        '/library',
+        '/library/query',
+        '/library/rotation',
+        '/library/catalog',
+        '/library/catalog/compilation-tracks',
+      ];
       for (const route of reads) {
         const path = spec.paths[route] as { get?: { security?: unknown[] } };
         expect(path?.get, route).toBeDefined();
@@ -822,6 +855,27 @@ describe('OpenAPI Specification', () => {
       expect(schema.properties?.track_title?.nullable).toBe(true);
       expect(schema.properties?.id).toBeUndefined();
       expect(schema.properties?.track_position).toBeUndefined();
+    });
+
+    it('pins the same length bounds as CompilationTrackInput — read and write shapes over one column must agree', () => {
+      const read = spec.components.schemas.CatalogCompilationTrackRow as Schema;
+      const write = spec.components.schemas.CompilationTrackInput as Schema;
+
+      // Both project compilation_track_artist.artist_name varchar(255) NOT NULL
+      // and .track_title varchar(255). The write shape pinned minLength on
+      // artist_name so a regression to empty-string writes can't merge green;
+      // the read shape carries the same bounds so the producer can size its
+      // SQLite column from the contract instead of guessing.
+      expect(read.properties?.artist_name?.minLength).toBe(write.properties?.artist_name?.minLength);
+      expect(read.properties?.artist_name?.maxLength).toBe(write.properties?.artist_name?.maxLength);
+      expect(read.properties?.track_title?.maxLength).toBe(write.properties?.track_title?.maxLength);
+      expect(read.properties?.artist_name?.maxLength).toBe(255);
+    });
+
+    // The "current version" sentinel lives with the most recent api.yaml change;
+    // the BS#1965 producer fields + the CTA export path bumped the minor.
+    it('bumps info.version to 1.29.0', () => {
+      expect(spec.info.version).toBe('1.29.0');
     });
 
     it('declares GET /library/catalog/compilation-tracks (BearerAuth; If-Modified-Since + ?since=; NDJSON 200 + 304)', () => {
@@ -989,11 +1043,6 @@ describe('OpenAPI Specification', () => {
       );
     });
 
-    // The "current version" sentinel lives with the most recent api.yaml change;
-    // the CTA write-path paths + schemas bumped the minor.
-    it('bumps info.version to 1.28.0', () => {
-      expect(spec.info.version).toBe('1.28.0');
-    });
   });
 
   describe('Rotation Schemas', () => {


### PR DESCRIPTION
Contract prerequisite for **WXYC/Backend-Service#1965** (extend `GET /library/catalog` for the Backend-sourced `library.db` producer). Additive-only; `oasdiff` reports no breaking changes.

## What / why

Decision D3 (2026-08-03): the Backend-sourced `library.db` producer (WXYC/discogs-etl#351) consumes the catalog **over HTTPS**, not direct Postgres — no prod-DB credentials in GitHub Actions. The substrate is `GET /library/catalog` (WXYC/Backend-Service#1468), but the current export lacks fields the daily-sync `library.db` shape requires. This lands the contract for those fields so the Backend-Service impl (BS#1965) and the producer can build against a governed shape.

## Changes

`CatalogExportRow` gains four library.db-producer fields. **All four are optional + nullable on the wire** — see "Decoder safety" below.

- **`legacy_release_id`** (integer, nullable) — total in the database since the BS#1963 mint + NULL-legacy backfill; the producer emits it AS `library.db`'s `library.id` (BS serials collide with the tubafrenzy id space). The existing serial **`id`** stays, unchanged, for the iOS Spotlight consumer.
- **`album_artist`** (string, nullable) — re-added to the export (it was in the "omitted" list); maps to `library.db`'s `album_artist`.
- **`alternate_artist_name`** (string, nullable) — maps to `library.db`'s `alternate_artist_name`.
- **`cross_reference_names`** (**array of string**, nullable) — artist aliases via `artist_crossreference` (WXYC/discogs-etl#334). The producer joins with `" | "` when it writes `library.db`'s TEXT column; the wire does not carry the delimiter.

New sibling export for `library.db`'s second table:

- **`CatalogCompilationTrackRow`** schema — `{ legacy_release_id, artist_name, track_title? }`, with the same `varchar(255)` bounds `CompilationTrackInput` declares over the same columns. Deliberately drops the CTA row `id` + `track_position` that `library.db`'s 3-column `compilation_track_artist` table doesn't carry. Distinct from `CompilationTrack` (the BS#1964 dj-site read shape).
- **`GET /library/catalog/compilation-tracks`** path — gzipped NDJSON, conditional-GET on `library_watermark`, `catalog:['read']` (service-account JWT). Sibling-endpoint over inline-include was the implementer's call (BS#1965 leaves it open): it maps cleanly to `library.db`'s two tables and the producer's two source queries, and reuses the existing gzip/watermark machinery.

`label` stays in `CatalogExportRow` (nullable) and is documented as live data — the export projects its real value. The library.db producer ignores it (the legacy MySQL export it must match has no label column).

## Decoder safety: none of the new fields is `required`

`CatalogExportRow` is also the iOS Spotlight clone's row shape, and wxyc-ios-64 regenerates from this SSOT on its own cadence. A required key the server does not emit until BS#1965 ships would not degrade one field — it would fail **every** NDJSON line and take the whole on-device catalog clone with it. So all four ship optional + nullable, the same leniency `popularity` shipped with (BS#1486 Phase-2 Track 3).

`oasdiff` does **not** flag adding a required response property, so a green `check:breaking` is not evidence of safety here. `tests/api-spec.test.ts` guards it instead.

## Requirements this contract puts on BS#1965

Stated in the descriptions so the implementer doesn't have to rediscover them:

1. **Two new watermark triggers.** `artist_crossreference` and `compilation_track_artist` have no `touch_library_watermark` trigger as of migration 0105 (which covers `library`, `artists`, `genres`, `format`, `genre_artist_crossreference`, `rotation`). Without them the watermark never advances, the per-watermark gzip cache is never rebuilt, and the producer `304`s forever against a body that will never contain the new rows — silent and unbounded, not a lag. Note the ordering does **not** save the CTA case: the CTA POST always *follows* the library add it would ride, so the rows land after the cache for that watermark is already built.
2. **Same row-eligibility predicate on both endpoints.** `/library/catalog` INNER JOINs `artists`, `format`, `genres`, and `genre_artist_crossreference`, so a library row whose (artist, genre) pair has no `genre_artist_crossreference` entry is silently dropped. An unfiltered CTA export would ship `library_release_id` values that join to nothing in `library.db`'s `library` table.
3. **Route registration order.** The literal `/library/catalog/compilation-tracks` is ambiguous with the templated `GET /library/{id}/compilation-tracks` (same method, same permission). It must register next to the existing `'/catalog'` literal in `library.route.ts`, not next to the other compilation-tracks routes — registered after `/:id`, Express matches with `id === 'catalog'` and the producer gets a 4xx/5xx with no auth-layer signal.
4. **Size the second resident gzip buffer.** The catalog export holds one full gzipped body per pod for the life of the watermark; a second such cache for the full CTA table is additive and long-lived on a memory-constrained host. If material, fold the rows into `/library/catalog` behind `?include=compilation_tracks` instead.

## `cross_reference_names` derivation (pinned)

The legacy query this replaces (`LIBRARY_CODE_CROSS_REFERENCE` in `discogs-etl/scripts/sync-library.sh`) is load-bearing for the producer, so the contract pins the semantics rather than leaving them to prose:

- **Both FK directions** — a row matching on either `source_artist_id` or `target_artist_id` contributes its other side.
- **Excludes the row's own artist** (the legacy `AND xlc.ID != lc.ID`). A self-referencing row must not produce a self-alias — LML would match the artist against itself.
- **Deduplicated.**
- **Ordered by Unicode code point** (`COLLATE "C"`), not the database default. `en_US.UTF-8` ignores punctuation and case at the primary level, so it orders the diacritic- and punctuation-bearing names most likely to carry aliases (Nilüfer Yanya, Csillagrablók, Hermanos Gutiérrez, "C. Spencer Yeh") unstably across locales. The legacy `GROUP_CONCAT` has no `ORDER BY` at all, so there is no legacy order to match.

Array-on-the-wire (rather than the pipe-joined string `library.db` stores) is deliberate: nothing constrains `artists.artist_name` from containing `"|"` or `" | "`, LML splits this field on the pipe, and there is no escaping rule to recover from a phantom split. The legacy `GROUP_CONCAT` has the same latent bug plus silent `group_concat_max_len` truncation.

## Tests

`tests/api-spec.test.ts` extended: `CatalogExportRow` now pins 19 fields / 8 required, with a dedicated guard that all four new fields stay **out** of `required` (the thing `check:breaking` can't catch) and that `cross_reference_names` is an array. New coverage for the `CatalogCompilationTrackRow` shape, its length-bound parity with `CompilationTrackInput`, and the `/library/catalog/compilation-tracks` path (auth, conditional-GET params, NDJSON 200 + 304). The new path joins the shared five-read `BearerAuth` list rather than getting a bespoke assertion. `info.version` -> 1.29.0 with the sentinel test moved onto this change.

Full suite green (602 tests); `lint`, `lint:e2e`, `generate:typescript`, `build`, and `check:breaking` all pass locally.

## Follow-ups (this contract unblocks)

1. A `chore(release)` commit cuts the minor `@wxyc/shared` version (additive → minor).
2. Codegen fan-out: regenerate `generated/api_models.py` in library-metadata-lookup and request-o-matic (workspace codegen-coupling rule).
3. **WXYC/Backend-Service#1965** — the impl: bump `@wxyc/shared`, extend the export query + private `CatalogExportRow`, add the two watermark triggers, add the CTA export endpoint. **BS CI ordering constraint:** the BS#1477 parity guard compares the private type against the *installed* `@wxyc/shared`, so the first BS PR to bump this package past this release fails that test — including an unrelated Dependabot bump — unless BS#1965 lands in the same bump.

## Known follow-ups not addressed here

- The four producer-only fields ride the single shared iOS-facing full-catalog body, and `cross_reference_names` is per-artist data denormalized onto every library row of that artist. A producer-scoped projection or a field selector is the altitude fix; the sibling-vs-`?include=` decision (item 4 above) is the natural place to revisit it.
- The conditional-GET parameter pair and 304 response are now written out verbatim three times (flowsheet export, `/library/catalog`, this). Extracting `components/parameters` + `components/responses` would collapse them, but the api-spec tests read raw path-level `parameters` and would need reworking alongside.

## Related

- WXYC/Backend-Service#1965 (consumer / driving issue)
- WXYC/discogs-etl#351 (the library.db producer, blocked by BS#1965)
- WXYC/discogs-etl#334 (cross_reference_names enrichment)
- WXYC/Backend-Service#1468 (the endpoint being extended)
- WXYC/wiki#89 (Phase 3.5 `/wxycdb` cutover)
