### PR TITLE
chore(release): @wxyc/shared v3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wxyc/shared",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wxyc/shared",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxyc/shared",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Shared DTOs, validation, test utilities, and E2E tests for WXYC services",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Cuts `@wxyc/shared` v3.3.0. Version-bump only (package.json + lockfile self-ref); no source changes.

Publishes the additive contract already merged to `main` since v3.2.0:
- BS#1964 CTA write-path contract (`c4b9237`)
- BS#1965 catalog-export producer fields + CTA export (`cae6030`, `ad527f8`) — unblocks the Backend-Service PR for #1965, whose parity test binds to the installed SSOT.

Additive-only; oasdiff reported no breaking changes on the source PRs (#291 / #293). After merge, tag `v3.3.0` on the merged commit to trigger `publish.yml`.