### PR TITLE
docs(api): reconcile catalog-export contract with the shipped BS#1965 implementation

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1490,15 +1490,19 @@ components:
                 at all, so there is no legacy order to match — pick the
                 deterministic one.
 
-            FRESHNESS CAVEAT — BS#1965 MUST land a trigger for this. This
-            endpoint's conditional GET rides library_watermark, and
-            artist_crossreference has NO touch_library_watermark trigger as of
-            migration 0105 (which covers library, artists, genres, format,
-            genre_artist_crossreference, rotation — not this table). Without a
-            new trigger, adding a cross-reference does not advance the
-            watermark, the per-watermark gzip cache is never rebuilt, and the
-            producer 304s against a body that will never contain the new alias.
-            Silent and unbounded, not a lag.
+            FRESHNESS: this endpoint's conditional GET rides library_watermark.
+            Migration 0105 fanned the watermark trigger out to library, artists,
+            genres, format, genre_artist_crossreference, and rotation;
+            artist_crossreference was left uncovered until migration 0138 added
+            touch_library_watermark_from_artist_crossreference (AFTER INSERT OR
+            UPDATE OR DELETE OR TRUNCATE ... FOR EACH STATEMENT). A
+            cross-reference write now advances the watermark, the per-watermark
+            gzip cache rebuilds, and the producer's next fetch carries the new
+            alias. Before 0138 this was silent and unbounded rather than a
+            bounded lag — a write to an uncovered source table changed nothing
+            observable until an unrelated write on a covered table happened to
+            bump the watermark, which is why every table a field on this row is
+            derived from must carry the trigger.
         album_title:
           type: string
         code_letters:
@@ -7134,6 +7138,17 @@ paths:
         (~daily); otherwise a 200 with the full body. Same conditionalGet
         middleware as the flowsheet export (BS#902).
 
+        CROSS-ENDPOINT CONSISTENCY: a producer that also reads GET
+        /library/catalog/compilation-tracks (BS#1965 / discogs-etl#351) fetches
+        the two exports as separate HTTP requests that share a library_watermark
+        value but are not one transaction — they form a consistent snapshot only
+        while the watermark stays stable across both fetches. If it advances
+        between them, the producer can pair catalog@T with CTA@T+1 and observe a
+        CTA legacy_release_id with no corresponding row in this body. Treat a
+        Last-Modified change across the two GETs as "re-fetch both"; the pairing
+        self-heals on the producer's next run regardless, so this is a
+        transient-inconsistency rule, not a hard-error condition.
+
         Transport (not expressible in the element schema): the body is NDJSON —
         split on newlines and decode per line; it is NOT a JSON array. It is
         gzip-encoded (Content-Encoding: gzip; most HTTP clients, incl. URLSession,
@@ -7212,41 +7227,76 @@ paths:
         release row it cannot resolve. Apply the same predicate on both
         endpoints.
 
+        CROSS-ENDPOINT CONSISTENCY: this endpoint and GET /library/catalog share
+        a library_watermark value, but the producer (BS#1965 / discogs-etl#351)
+        fetches them as two separate HTTP requests, not one transaction — a
+        consistent snapshot only while the watermark stays stable across both
+        fetches. If it advances between them, the producer can pair catalog@T
+        with CTA@T+1 and observe a legacy_release_id here with no corresponding
+        row in the catalog body — the same dangling-join failure ROW ELIGIBILITY
+        above exists to prevent, arriving by a different route: that predicate
+        guarantees the pairing within a snapshot, this rule is what keeps the
+        producer looking at one. Treat a Last-Modified change across the two
+        GETs as "re-fetch both"; the pairing self-heals on the producer's next
+        run, so a dangling legacy_release_id is evidence to re-fetch, not a hard
+        error.
+
         Conditional GET: same middleware and watermark as GET /library/catalog —
         Last-Modified is set from the library_watermark, echoed back via
         If-Modified-Since (or ?since=) for a cheap 304.
 
-        FRESHNESS CAVEAT — BS#1965 MUST land a trigger for this.
-        compilation_track_artist has NO touch_library_watermark trigger as of
-        migration 0105 (which covers library, artists, genres, format,
-        genre_artist_crossreference, rotation — not this table). CTA writes
-        therefore do not advance the watermark on their own, and the ordering is
-        NOT the reassuring one: the CTA POST always FOLLOWS the library add it
-        would ride. The real sequence is (1) POST /library bumps the watermark
-        to T, (2) the per-watermark gzip cache builds for T, (3) POST
-        /library/{id}/compilation-tracks lands rows at T+delta with no trigger —
-        so the cached body for T does not contain them and this endpoint 304s
-        until some unrelated write bumps the watermark. Post-tubafrenzy-turndown
-        the daily library sync goes away, so "it'll catch up on the next daily
-        write" stops holding and a CTA-only editing session can stay invisible
-        indefinitely.
+        FRESHNESS: this endpoint shares GET /library/catalog's conditional-GET
+        middleware and library_watermark. The intuitive assumption — that a CTA
+        write rides the library add it accompanies — is backwards: the real
+        sequence is (1) POST /library bumps the watermark to T, (2) the
+        per-watermark gzip cache builds for T, (3) POST
+        /library/{id}/compilation-tracks lands rows after that, at T+delta. A
+        CTA-specific trigger was therefore necessary, not merely nice to have:
+        without one, step 3 would leave the cache already built at T unaware of
+        its own rows, and this endpoint would 304 until an unrelated write on a
+        covered table happened to bump the watermark — silent and unbounded, not
+        a lag, and post-tubafrenzy-turndown (once the daily library sync that
+        used to eventually supply that unrelated write goes away) a CTA-only
+        cataloging session could have stayed invisible indefinitely. Migration
+        0138 supplies that trigger:
+        touch_library_watermark_from_compilation_track_artist (AFTER INSERT OR
+        UPDATE OR DELETE OR TRUNCATE ... FOR EACH STATEMENT) on
+        compilation_track_artist advances the watermark on step 3 itself, so the
+        cache rebuilds and the producer's next fetch carries the new rows.
 
-        IMPLEMENTATION NOTES for BS#1965:
-          * Route registration order is load-bearing. This literal path is
-            ambiguous with the templated GET /library/{id}/compilation-tracks
-            (same method, same catalog:['read'] permission), so it MUST be
-            registered before the /:id routes — next to the existing '/catalog'
-            literal in library.route.ts, not next to the other
-            compilation-tracks routes. Registered after, Express matches
+        IMPLEMENTATION NOTES (as-built, BS#1965):
+          * Route registration order is load-bearing, permanently. This literal
+            path is ambiguous with the templated GET
+            /library/{id}/compilation-tracks (same method, same catalog:['read']
+            permission), so it MUST stay registered before the /:id routes —
+            next to the '/catalog' literal in library.route.ts, not next to the
+            other compilation-tracks routes. This binds anyone editing
+            library.route.ts going forward, not just the original
+            implementation: move it after the /:id routes and Express matches
             /:id/compilation-tracks with id === 'catalog', Number('catalog') is
-            NaN, and the producer gets a 4xx/5xx with no auth-layer signal
-            (both routes carry the same permission).
-          * The catalog export holds one full gzipped body resident per pod for
-            the life of the watermark (createWatermarkCache<Buffer>). A second
-            such cache for the full CTA table is additive and long-lived on a
-            memory-constrained host. Size it before shipping; if it is material,
-            fold these rows into /library/catalog behind an opt-in
-            ?include=compilation_tracks instead (BS#1965 leaves the shape open).
+            NaN, and the producer gets a 4xx/5xx with no auth-layer signal to
+            distinguish it from any other failure (both routes carry the
+            identical permission). See the "REGISTRATION ORDER IS LOAD-BEARING"
+            comment in library.route.ts.
+          * Cache sizing (resolved). This endpoint holds a second full gzipped
+            body resident per pod for the life of the watermark
+            (createWatermarkCache<Buffer>), alongside the existing catalog
+            export cache — so it was measured before shipping, against the
+            2026-07-19 prod library.db snapshot's real artist/title strings at
+            the prod CTA row count:
+
+                                 rows      raw  gzipped resident
+              catalog export     64,815  28.5 MB   2.6 MB   2.6 MB
+              CTA export        144,778  13.1 MB   3.2 MB   3.2 MB
+
+            Verdict: not material (~5.8 MB resident for both), so the sibling
+            endpoint was kept rather than folding these rows into
+            /library/catalog behind an opt-in ?include=compilation_tracks.
+            Counterintuitively the CTA buffer is larger than the catalog one
+            despite carrying 3 fields instead of 19 — 2.2x the rows outweighs
+            the narrower shape. Revisit past roughly 1M CTA rows, or sooner if a
+            future consumer needs a payload that can't be built streaming-free;
+            ?include=compilation_tracks remains the documented fallback.
 
         Transport (not expressible in the element schema): the body is NDJSON —
         split on newlines and decode per line; it is NOT a JSON array. It is


### PR DESCRIPTION
## Summary

`api.yaml`'s catalog-export blocks were written as forward-looking instructions to the implementer of WXYC/Backend-Service#1965 (landed in WXYC/wxyc-shared#293), while the implementation was still ahead of the contract. BS#1965 has since shipped (WXYC/Backend-Service#1976, merged 2026-08-04), so three of those blocks now read as false statements about the running system, and one genuine gap discovered during implementation was documented only in a Backend-Service source comment. This PR reconciles all four:

1. **`CatalogExportRow.cross_reference_names` FRESHNESS block** — replaced the "BS#1965 MUST land a trigger" warning with the as-built state: migration 0138 added `touch_library_watermark_from_artist_crossreference`, so a cross-reference write now advances `library_watermark` and the producer sees new aliases on its next fetch. Kept the "silent and unbounded, not a lag" reasoning as the explanation of what an uncovered source table would still cost.
2. **`/library/catalog/compilation-tracks` FRESHNESS block** — same shape: migration 0138's `touch_library_watermark_from_compilation_track_artist` closes the gap. Preserved the worked (1)/(2)/(3) sequence explaining why the intuitive "CTA rides the library add" reasoning is backwards, since that's *why* the CTA table needed its own trigger rather than merely being nice to have.
3. **`IMPLEMENTATION NOTES for BS#1965`** — reframed as `IMPLEMENTATION NOTES (as-built, BS#1965)`. The route-registration-order bullet is kept and reworded from an instruction to the original implementer into a standing invariant binding anyone editing `library.route.ts` (cross-referenced against the "REGISTRATION ORDER IS LOAD-BEARING" comment now in that file). The cache-sizing bullet's open question ("size it before shipping") is replaced with the measured verdict: not material (~5.8 MB resident for both exports), the sizing table, the counterintuitive CTA-buffer-is-larger note, the ~1M-row revisit threshold, and the `?include=compilation_tracks` fallback that stays open.
4. **New: cross-endpoint watermark consistency rule**, added to both `/library/catalog` and `/library/catalog/compilation-tracks` descriptions. The producer (discogs-etl#351) fetches both exports as separate HTTP requests sharing a watermark value but not one transaction, so a watermark advance between the two fetches can pair `catalog@T` with `CTA@T+1` — a dangling `legacy_release_id`. States the rule this binds the producer to: treat a `Last-Modified` change across the two GETs as "re-fetch both." Previously documented only in a Backend-Service source comment (`catalog-export.service.ts`), which is the wrong repo for a rule that binds the consumer.

## Description-only, verified

- `npm run check:breaking` (`oasdiff breaking`): no breaking changes.
- `oasdiff diff` against `origin/main`: the only differences are three `description` fields (two path-level, one property-level) — no field additions/removals/type/nullability changes.
- Generated TypeScript types (`npm run generate:typescript`) diff only in the JSDoc comment text carried from those descriptions; no property or type shape changes.
- `npm run lint`, `npm run lint:e2e`, `npm run build`, `npm test` (602 tests) all pass locally.

## Version bump

None. Per `CLAUDE.md`'s publishing section and the precedent set by commit `40ce0f7` (a prior description-only `api.yaml` fix that also left `info.version` untouched), a docs-only change to `api.yaml` skips the version bump — there's no field-shape change for any consumer to regenerate against.

## Test plan

- [x] `npm run check:breaking` — no breaking changes
- [x] `oasdiff diff` — description-only
- [x] `npm run generate:typescript` — no property/type churn, comment-text only
- [x] `npm run lint` / `npm run lint:e2e` / `npm run build` / `npm test` — all green

Closes #295