### PR TITLE
feat(api): gate bulk-resolve tracks behind include_tracks + repair BulkResolveTrackIdentity (1.30.0)

### DIFF
--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -35,6 +35,11 @@ jobs:
           base: api-base.yaml
           revision: api.yaml
           fail-on: ERR
+          # Findings whitelisted with a written justification. Each entry is
+          # scoped to a main..PR diff and goes inert once merged; see the file's
+          # header. scripts/check-breaking-changes.sh passes the same file, so a
+          # local `npm run check:breaking` matches this job.
+          err-ignore: oasdiff-err-ignore.txt
 
       - name: Comment on PR (Breaking Changes Found)
         if: failure() && steps.base.outputs.skip != 'true'

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     paths:
       - 'api.yaml'
+      # The whitelist is listed so a PR that touches only that file still runs
+      # this job. oasdiff exits 121 on a missing --err-ignore path, and the file
+      # invites its own deletion ("prune dead entries"). Without this line, the
+      # PR that empties and removes it skips the job and merges green, and the
+      # 121 detonates on an unrelated author's next api.yaml PR as a red
+      # "breaking changes detected" comment about changes that don't exist.
+      # scripts/check-breaking-changes.sh has a matching local preflight, but
+      # this is a CI-only failure and the deleter may never run the script.
+      - 'oasdiff-err-ignore.txt'
 
 jobs:
   check-breaking:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Full history: the breaking-guard bats suite diffs api.yaml against
+      # origin/main to prove the oasdiff whitelist still suppresses real
+      # findings. At the default fetch-depth of 1 that ref does not exist and
+      # those tests skip themselves, which would leave the suite green while
+      # testing nothing — the failure mode the suite was written to close.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v7
         with:
@@ -54,6 +61,20 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # The bats suites guard shell scripts that vitest cannot reach. They were
+      # runnable-but-unrun until now: a regression in check-breaking-changes.sh
+      # merged green here and surfaced later as an unexplained red
+      # breaking-changes job on someone else's PR.
+      #
+      # test:drift-guard is deliberately absent: tests 4 and 5 in
+      # check-corpus-drift.test.sh fail on main today, untouched by this PR.
+      # Wiring it in would redden CI for an unrelated reason; it gets its own
+      # fix and then its own line here.
+      - name: Shell script guards
+        run: |
+          npm run test:breaking-guard
+          npm run test:setup-script
 
       # Cross-service contract suite (see INVARIANTS.md, src/contracts.ts).
       # When $E2E_BASE_URL is unset, every test in the file is `skipIf`-ed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,20 @@ Two gotchas, both verified against the current `api.yaml`:
 1. **`identifiableModels: false` is required, not cosmetic.** Its swift6 default is `true`. Left on, the synthesized oneOf catch-all (e.g. `V2FlowsheetLatestGet200Response`) gets an `extension … : Identifiable {}` with no `id` conformance, and the generated package fails to compile. `swift6.yaml` sets it to `false`, which drops every `Identifiable` extension — verify with `grep -rl ": Identifiable" generated/swift | wc -l` (should be `0`).
 2. **`generateApis: false` does not suppress the `APIs/` directory under `swift6`.** It still emits `Sources/WXYCAPI/APIs/DefaultAPI.swift` (~148KB) and friends even though this repo only wants models. That's harmless for the in-repo reference tree, but any consumer that vendors `generated/swift` (WXYC/wxyc-ios-64#598 and future Swift consumers) must drop `APIs/` themselves — don't rely on the config to keep it out.
 
-Run `npm run check:breaking` before changing `api.yaml` to detect breaking changes.
+### Python codegen drops `nullable` on required fields
+
+`generate:python` runs `datamodel-codegen` **without** `--strict-nullable`, and that flag's absence is not cosmetic: a `required` + `nullable: true` property generates as a plain non-Optional field (`confidence: confloat(ge=0, le=1)`), so the null the contract documents cannot be constructed through the generated model. Only *non-required* nullable properties come out as `str | None = None`.
+
+This bites the required-but-nullable idiom this spec uses whenever a null carries meaning (`BulkResolveProvenanceEntry.confidence`, `BulkResolveTrackIdentity.resolved_artist_name`, `CompilationTrackSuggestions.discogs_release_id`). LML currently works around it by defaulting the None case upstream — i.e. the documented null never reaches the wire. Adding `--strict-nullable` fixes it but rewrites ~200 lines of both Python consumers' committed models, so it needs its own ticket and their review; don't reshape `api.yaml` to route around the generator.
+
+## Breaking-change gate
+
+Run `npm run check:breaking` before changing `api.yaml`. It runs `oasdiff breaking` against `origin/main` with `--fail-on ERR`, mirroring the `breaking-changes.yml` PR job.
+
+Both sides pass `--err-ignore oasdiff-err-ignore.txt`, a whitelist of findings that are breaking by oasdiff's static rules but provably not on the wire (e.g. a property reachable only through an array that has never shipped a non-empty value). Every entry needs a written justification in the file. Two properties to keep in mind:
+
+- **Entries are diff-scoped.** A line matches only while its change is in `main`..PR; once merged it stops matching and is inert. Prune dead entries.
+- **The file is not an escape hatch for real breaks.** A genuine breaking change gets a contract-version conversation, not a line in the whitelist.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ This bites the required-but-nullable idiom this spec uses whenever a null carrie
 
 Run `npm run check:breaking` before changing `api.yaml`. It runs `oasdiff breaking` against `origin/main` with `--fail-on ERR`, mirroring the `breaking-changes.yml` PR job.
 
-Both sides pass `--err-ignore oasdiff-err-ignore.txt`, a whitelist of findings that are breaking by oasdiff's static rules but provably not on the wire (e.g. a property reachable only through an array that has never shipped a non-empty value). Every entry needs a written justification in the file. Two properties to keep in mind:
+Both sides pass `--err-ignore oasdiff-err-ignore.txt`, a whitelist of findings that are breaking by oasdiff's static rules but provably not on the wire (e.g. a property reachable only through an array that has never shipped a non-empty value). Every entry needs a written justification in the file. Three properties to keep in mind:
 
 - **Entries are diff-scoped.** A line matches only while its change is in `main`..PR; once merged it stops matching and is inert. Prune dead *entries* — never the file. Both callers pass the path unconditionally and oasdiff exits 121 when it is missing, so deleting an emptied file turns the next api.yaml PR red with an auto-comment blaming breaking changes that don't exist. An entry-free file of comments is the floor; `scripts/check-breaking-changes.sh` fails fast with that explanation if it goes missing.
 - **Entries are verbatim oasdiff message text.** A substring won't match. An oasdiff release that rewords a finding silently un-matches its entry, so a red job after an oasdiff upgrade means re-pasting the new wording, not re-litigating the change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,8 @@ Run `npm run check:breaking` before changing `api.yaml`. It runs `oasdiff breaki
 
 Both sides pass `--err-ignore oasdiff-err-ignore.txt`, a whitelist of findings that are breaking by oasdiff's static rules but provably not on the wire (e.g. a property reachable only through an array that has never shipped a non-empty value). Every entry needs a written justification in the file. Two properties to keep in mind:
 
-- **Entries are diff-scoped.** A line matches only while its change is in `main`..PR; once merged it stops matching and is inert. Prune dead entries.
+- **Entries are diff-scoped.** A line matches only while its change is in `main`..PR; once merged it stops matching and is inert. Prune dead *entries* — never the file. Both callers pass the path unconditionally and oasdiff exits 121 when it is missing, so deleting an emptied file turns the next api.yaml PR red with an auto-comment blaming breaking changes that don't exist. An entry-free file of comments is the floor; `scripts/check-breaking-changes.sh` fails fast with that explanation if it goes missing.
+- **Entries are verbatim oasdiff message text.** A substring won't match. An oasdiff release that rewords a finding silently un-matches its entry, so a red job after an oasdiff upgrade means re-pasting the new wording, not re-litigating the change.
 - **The file is not an escape hatch for real breaks.** A genuine breaking change gets a contract-version conversation, not a line in the whitelist.
 
 ## Testing

--- a/api.yaml
+++ b/api.yaml
@@ -4294,11 +4294,18 @@ components:
         Per-track resolution for one library row — V/A or not. Returned
         only when the request set `include_tracks: true`; one entry per
         track LML's per-track matcher visited. `sources` reflects the
-        per-source rows LML composed the track identity from; the chosen
-        identifiers are not lifted into a per-track `external_ids` block
-        at this contract version — Backend writes the per-source rows
-        verbatim into `library_track_identity_source` per
-        WXYC/library-metadata-lookup#271's design.
+        per-source rows LML composed the track identity from — audit
+        provenance, not a storage instruction: LML's per-track store is
+        the per-source system of record, and consumers persist only the
+        composed verdict fields on this entry. `1.29.0` said instead that
+        Backend writes these rows verbatim into
+        `library_track_identity_source`; that table was never built —
+        WXYC/library-metadata-lookup#271 closed as a design decision and
+        the schema half never happened, confirmed against prod and all
+        136 migrations in
+        https://github.com/WXYC/Backend-Service/issues/801#issuecomment-5187348795.
+        The chosen identifiers are not lifted into a per-track
+        `external_ids` block at this contract version.
 
 
         The entry is addressable without `track_position`: 78% of

--- a/api.yaml
+++ b/api.yaml
@@ -4129,18 +4129,22 @@ components:
     #     - `kind: "single_artist"` — resolved single-artist library row;
     #                                  `main` carries the composed identity.
     #                                  `tracks` carries per-track identity
-    #                                  when the request asked for it.
+    #                                  when the request asked for it, paired
+    #                                  with `tracks_attempted`.
     #     - `kind: "compilation"`   — V/A row; `main` is null (no album-level
     #                                  artist anchor). `tracks` carries
     #                                  per-track identity when the request
-    #                                  asked for it.
+    #                                  asked for it, paired with
+    #                                  `tracks_attempted`.
     #     - `kind: "unresolved"`    — LML attempted resolution and found
     #                                  nothing actionable; first-class
     #                                  outcome so Backend can cache and
-    #                                  not re-ask. `main` is null and
-    #                                  `tracks` is always absent. Audit
-    #                                  detail lives in `provenance` (empty
-    #                                  means LML tried and nothing resolved).
+    #                                  not re-ask. `main` is null, and
+    #                                  `tracks`/`tracks_attempted` are the
+    #                                  absent-or-NULL state (LML spells both
+    #                                  `null`). Audit detail lives in
+    #                                  `provenance` (empty means LML tried
+    #                                  and nothing resolved).
     #
     # ---- `tracks` is opt-in, and gated on BOTH resolved kinds (#297) ----
     #
@@ -4204,10 +4208,15 @@ components:
             Inputs to resolve. Order preserved in `BulkResolveLibrariesResponse.results`.
         include_tracks:
           type: boolean
-          default: false
           description: >
             Opt in to per-track identity, for every input in the batch
-            (the flag is batch-level, not per-input). When `false` or
+            (the flag is batch-level, not per-input). Omitting the field
+            means `false`; it carries no schema-level `default` on
+            purpose, because `openapi-typescript` emits a
+            default-bearing property as non-optional even when it is
+            absent from `required`, which would force every TypeScript
+            caller to pass the one field whose whole contract is that
+            you need not. When `false` or
             omitted — the default, and what an un-upgraded caller sends —
             `BulkResolveResult.tracks` is absent from every result, so an
             album-identity drain pays nothing for track composition it
@@ -4269,11 +4278,12 @@ components:
       description: >
         Discriminator for `BulkResolveResult`. `single_artist` carries a
         composed `main` identity; `compilation` carries none (a V/A row has
-        no album-level artist anchor). Either may carry `tracks` — per-track
-        identity is gated by the request's `include_tracks` flag, not by
-        `kind` (#297). `unresolved` is a first-class outcome — caching it
-        (with TTL) prevents repeated re-asking for unresolvable rows — and
-        never carries `main` or `tracks`.
+        no album-level artist anchor). Either may carry `tracks` and
+        `tracks_attempted` — per-track identity is gated by the request's
+        `include_tracks` flag, not by `kind` (#297). `unresolved` is a
+        first-class outcome — caching it (with TTL) prevents repeated
+        re-asking for unresolvable rows — and never carries `main`,
+        `tracks`, or `tracks_attempted`.
       enum:
         - single_artist
         - compilation
@@ -4306,8 +4316,15 @@ components:
             method range from §3.4.1. NULL when `external_id` is NULL —
             the source ran but produced no candidate, so confidence is
             undefined (not zero). When non-null, equal to or greater than
-            the top-level `confidence` (composition rules either MIN or
-            boost, never lower a per-source row).
+            the `confidence` of the object this entry hangs off — the
+            composition rules either MIN or boost, and never lower a
+            per-source row. That referent is grain-relative, because this
+            schema is reused at two grains: under
+            `BulkResolveResult.provenance` it is the result's own
+            `confidence`, and under `BulkResolveTrackIdentity.sources` it
+            is that track's `confidence`, not the result's. The two are
+            unrelated — a `kind: compilation` result has no result-level
+            `confidence` at all, while its tracks each have their own.
         external_id:
           type: string
           nullable: true
@@ -4570,8 +4587,9 @@ components:
         Response to `POST /api/v1/identity/bulk-resolve-libraries`. Order
         of `results` matches the order of the request's `inputs`. The
         example below is the `include_tracks: true` shape; with the flag
-        false or omitted, every result's `tracks` is the absent/NULL state
-        (LML spells it `"tracks": null`). Per-source `method`/`confidence`
+        false or omitted, every result's `tracks` and `tracks_attempted`
+        are the absent/NULL state (LML spells both `null`). Per-source
+        `method`/`confidence`
         pairs in the example sit inside `IdentityMethod`'s locked bands —
         Backend's writer rejects rows that don't, so an example that
         violated them would hand LML#1021 an unwritable row to copy.
@@ -4652,6 +4670,27 @@ components:
                 external_id: "77889"
             tracks_attempted: true
             tracks: []
+          # The state `tracks_attempted` exists to separate from `(true, [])`
+          # above: the caller asked, and LML's per-track matcher has not
+          # reached this row yet. Re-asking it later is correct; re-asking the
+          # `(true, [])` row above is the loop the flag prevents.
+          - kind: single_artist
+            library_id: 5555
+            main:
+              discogs_artist_id: 33445
+            method: exact_match
+            confidence: 1.0
+            provenance:
+              - source: discogs
+                method: exact_match
+                confidence: 1.0
+                external_id: "33445"
+            tracks_attempted: false
+            tracks: []
+          # Nulls, not omitted keys: LML builds the result with `tracks=None`
+          # and does not set `response_model_exclude_none`, so this is the
+          # shape on the wire. The schema's nullability — and one of the two
+          # oasdiff whitelist entries — rests on exactly that.
           - kind: unresolved
             library_id: 9999
             provenance:
@@ -4659,6 +4698,8 @@ components:
                 method: exact_match
                 confidence: null
                 external_id: null
+            tracks_attempted: null
+            tracks: null
       properties:
         results:
           type: array

--- a/api.yaml
+++ b/api.yaml
@@ -4156,23 +4156,35 @@ components:
     # empty array the V/A arm used to ship — which the sole consumer's
     # compilation branch counts and skips without reading.
     #
-    # Three states for `tracks`, replacing the two-state ("present-array or
-    # absent") rule this contract carried through `1.29.0`:
+    # Four states, read off the PAIR (`tracks_attempted`, `tracks`) — the
+    # two-state ("present-array or absent") rule this contract carried
+    # through `1.29.0` is retired, and so is the three-state rule that
+    # tried to carry the meaning on `tracks` alone:
     #
-    #     absent     — the caller did not ask (`include_tracks` false or
-    #                  omitted), or `kind: "unresolved"`. LML spells this
-    #                  state `"tracks": null` on the wire (it builds the
-    #                  result with `tracks=None` and does not set
-    #                  `response_model_exclude_none`), so the schema marks
-    #                  the field nullable and consumers accept both.
-    #     []         — the caller asked, and LML's per-track matcher has not
-    #                  visited this row yet.
-    #     [entries]  — the matcher ran. Entries whose `resolved_artist_name`
-    #                  is NULL are tracks it tried and failed on, the same
-    #                  "the leg ran" convention as
-    #                  `BulkResolveProvenanceEntry.external_id`. A non-empty
-    #                  array is therefore a resolved signal
-    #                  (WXYC/Backend-Service#1991 / LML#1021).
+    #     (absent, absent)   — the caller did not ask (`include_tracks`
+    #                          false or omitted), or `kind: "unresolved"`.
+    #                          LML spells this `null` on the wire for both
+    #                          fields (it builds the result with `None` and
+    #                          does not set `response_model_exclude_none`),
+    #                          so the schema marks them nullable and
+    #                          consumers accept both spellings.
+    #     (false, [])        — the caller asked, and LML's per-track matcher
+    #                          has not visited this row yet.
+    #     (true, [])         — the matcher ran and resolved no tracks at all.
+    #                          Ordinary, not exceptional: a `single_artist`
+    #                          release LML holds no tracklist for lands here.
+    #     (true, [entries])  — the matcher ran and produced entries. Ones
+    #                          whose `resolved_artist_name` is NULL are
+    #                          tracks it tried and failed on, the same "the
+    #                          leg ran" convention as
+    #                          `BulkResolveProvenanceEntry.external_id`.
+    #
+    # The resolved signal is `tracks_attempted`, not the array's length.
+    # Those middle two states are byte-identical in `tracks`, so a consumer
+    # reading emptiness as "not visited" re-asks every trackless row on
+    # every pass, forever — the pathology `kind: "unresolved"` was made a
+    # first-class outcome to prevent, reintroduced one grain down
+    # (WXYC/Backend-Service#1991 / LML#1021).
 
     BulkResolveLibrariesRequest:
       type: object
@@ -4201,9 +4213,23 @@ components:
             album-identity drain pays nothing for track composition it
             would discard. When `true`, LML composes per-track identity
             for both `kind: single_artist` and `kind: compilation`
-            results; `kind: unresolved` never carries tracks. See
-            `BulkResolveResult.tracks` for the three states the returned
-            array distinguishes.
+            results and sets `tracks_attempted` on each of them;
+            `kind: unresolved` never carries either field. See
+            `BulkResolveResult.tracks_attempted` for the four states the
+            pair distinguishes, and why the array's length is not one of
+            them.
+
+
+            The flag is batch-level by design, and the payload it admits
+            is not bounded by the schema — `inputs` still caps at 1,000
+            either way. A caller that can classify its own rows should
+            partition its drains rather than send a mixed page: Backend
+            holds both signals LML auto-detects on
+            (`library.code_volume_letters LIKE 'Z%'`, `EXISTS
+            compilation_track_artist`), so WXYC/Backend-Service#1991 runs
+            a small-paged V/A drain separately from a full-width non-V/A
+            one. A per-input flag was considered and rejected as
+            mechanism for a problem the one consumer can solve locally.
       example:
         include_tracks: true
         inputs:
@@ -4470,6 +4496,45 @@ components:
             produced a row above the §3.4.1.1 Rule 6 floor.
           items:
             $ref: '#/components/schemas/BulkResolveProvenanceEntry'
+        tracks_attempted:
+          type: boolean
+          nullable: true
+          description: >
+            Whether LML's per-track matcher has visited this row — `true`
+            once it has run, **regardless of how many tracks it
+            resolved**, including none. This is the resolved signal for
+            per-track identity; `tracks.length` is not
+            (WXYC/Backend-Service#1991).
+
+
+            Read it with `tracks` as a pair, four states in total:
+            **absent or NULL** — the caller did not ask (`include_tracks`
+            false or omitted), or the result is `kind: unresolved`, and
+            `tracks` is in the same state;
+            **`false` with an empty `tracks`** — the caller asked and the
+            matcher has not reached this row;
+            **`true` with an empty `tracks`** — the matcher ran and
+            resolved nothing;
+            **`true` with a populated `tracks`** — the matcher ran and
+            produced entries. `false` alongside a populated `tracks` is
+            not a state; producers must not emit it.
+
+
+            The middle two are what this field exists for. They are
+            byte-identical in `tracks`, they are not rare — a
+            `kind: single_artist` release LML holds no tracklist for is
+            the ordinary case, and extending the gate to that kind is the
+            whole point of #297 — and a consumer that reads emptiness as
+            "not yet visited" re-asks every one of them on every pass,
+            forever. That is the re-asking pathology `kind: unresolved`
+            was made a first-class outcome to prevent, reintroduced at
+            track grain. A consumer cannot repair it locally, because the
+            two states are indistinguishable on the wire without this
+            field.
+
+
+            Absent and NULL are one state, for the same producer reason
+            as `tracks` below.
         tracks:
           type: array
           nullable: true
@@ -4478,15 +4543,15 @@ components:
             `include_tracks: true`. That flag — not `kind` — gates the
             field, and it gates it on both `kind: single_artist` and
             `kind: compilation` (#297); `kind: unresolved` never carries
-            tracks. Three states, and the distinction between the last two
-            is load-bearing for WXYC/Backend-Service#1991:
-            **absent or NULL** — the caller did not ask (`include_tracks`
-            false or omitted), or the result is `unresolved`;
-            **empty array** — the caller asked, and LML's per-track matcher
-            has not visited this row yet;
-            **non-empty** — the matcher ran, with a NULL
-            `resolved_artist_name` on each track it failed on ("the leg
-            ran"), so consumers treat non-empty as a resolved signal.
+            tracks. The array carries the entries; **it does not carry
+            the state** — an empty array means the matcher found nothing
+            *or* has not run, and only `tracks_attempted` separates
+            those. See that field for the four states of the pair.
+            Entries whose `resolved_artist_name` is NULL are tracks the
+            matcher tried and failed on ("the leg ran", the same
+            convention as `BulkResolveProvenanceEntry.external_id`), so a
+            populated array is per-track detail rather than a per-track
+            guarantee.
 
 
             Absent and NULL are the same state, deliberately. LML builds
@@ -4531,6 +4596,7 @@ components:
                 method: name_variation
                 confidence: 0.95
                 external_id: "abc-def-12345"
+            tracks_attempted: true
             tracks:
               - track_position: "3"
                 artist_name: "Juana Molina"
@@ -4546,6 +4612,7 @@ components:
           - kind: compilation
             library_id: 5678
             provenance: []
+            tracks_attempted: true
             tracks:
               - track_position: "A1"
                 artist_name: "Chuquimamani-Condori"
@@ -4569,6 +4636,22 @@ components:
                     method: exact_match
                     confidence: null
                     external_id: null
+          # The state `tracks` alone cannot express: the matcher ran and
+          # resolved nothing. Distinguished from "not visited yet" only by
+          # `tracks_attempted`, and ordinary for `kind: single_artist`.
+          - kind: single_artist
+            library_id: 4321
+            main:
+              discogs_artist_id: 77889
+            method: exact_match
+            confidence: 1.0
+            provenance:
+              - source: discogs
+                method: exact_match
+                confidence: 1.0
+                external_id: "77889"
+            tracks_attempted: true
+            tracks: []
           - kind: unresolved
             library_id: 9999
             provenance:
@@ -8498,7 +8581,11 @@ paths:
         defaults to `false`, which keeps album-identity drains off the
         (measurably large) track payload — see the schema notes on
         `BulkResolveLibrariesRequest.include_tracks` and
-        `BulkResolveResult.tracks`.
+        `BulkResolveResult.tracks`. Read whether the per-track matcher
+        ran off `BulkResolveResult.tracks_attempted`, never off
+        `tracks.length`: a row the matcher visited and resolved nothing
+        for carries an empty array, indistinguishable from one it has
+        not reached.
       security:
         - LMLBearerAuth: []
       tags:

--- a/api.yaml
+++ b/api.yaml
@@ -4160,7 +4160,11 @@ components:
     # absent") rule this contract carried through `1.29.0`:
     #
     #     absent     — the caller did not ask (`include_tracks` false or
-    #                  omitted), or `kind: "unresolved"`.
+    #                  omitted), or `kind: "unresolved"`. LML spells this
+    #                  state `"tracks": null` on the wire (it builds the
+    #                  result with `tracks=None` and does not set
+    #                  `response_model_exclude_none`), so the schema marks
+    #                  the field nullable and consumers accept both.
     #     []         — the caller asked, and LML's per-track matcher has not
     #                  visited this row yet.
     #     [entries]  — the matcher ran. Entries whose `resolved_artist_name`
@@ -4339,9 +4343,18 @@ components:
             `track_title` instead.
         artist_name:
           type: string
+          minLength: 1
           description: >
             Join-back echo of the per-track credit, verbatim, and the
-            load-bearing half of the join key — never NULL. Dual-mode:
+            load-bearing half of the join key — never NULL, and never the
+            empty string (`minLength: 1`, matching
+            `CatalogCompilationTrackRow.artist_name`, since an empty join
+            key is indistinguishable from a missing one). No `maxLength`
+            here, unlike the CTA read/write shapes: those bound one
+            physical `varchar(255)` column, while this field is dual-mode
+            and the `kind: single_artist` arm carries a source credit that
+            no WXYC column bounds. A cap the sources don't respect would
+            turn a long credit into a decode failure. Dual-mode:
             for `kind: compilation` it echoes the
             `compilation_track_artist` row as exported in library.db, so
             a consumer can match it to its own CTA row; for
@@ -4392,9 +4405,16 @@ components:
         sources:
           type: array
           description: >
-            One per-source row per source LML composed the track from.
-            Empty array means LML attempted resolution at track grain
-            and found no matches.
+            One per-source row per source LML composed the track from —
+            audit detail, and the track-grain analogue of
+            `BulkResolveResult.provenance`. Empty array means no source
+            produced a row at track grain at all. That is a different
+            statement from a populated array whose entries carry NULL
+            `external_id`: there, the legs ran and reported no candidate.
+            Read the verdict off `resolved_artist_name`, not off this
+            array's length — an empty `sources` and a `sources` full of
+            NULL-`external_id` legs both accompany a NULL
+            `resolved_artist_name`.
           items:
             $ref: '#/components/schemas/BulkResolveProvenanceEntry'
 
@@ -4452,19 +4472,30 @@ components:
             $ref: '#/components/schemas/BulkResolveProvenanceEntry'
         tracks:
           type: array
+          nullable: true
           description: >
             Per-track identity, returned only when the request set
             `include_tracks: true`. That flag — not `kind` — gates the
             field, and it gates it on both `kind: single_artist` and
             `kind: compilation` (#297); `kind: unresolved` never carries
             tracks. Three states, and the distinction between the last two
-            is load-bearing for WXYC/Backend-Service#1991: **absent** — the
-            caller did not ask (`include_tracks` false or omitted), or the
-            result is `unresolved`; **empty array** — the caller asked, and
-            LML's per-track matcher has not visited this row yet;
+            is load-bearing for WXYC/Backend-Service#1991:
+            **absent or NULL** — the caller did not ask (`include_tracks`
+            false or omitted), or the result is `unresolved`;
+            **empty array** — the caller asked, and LML's per-track matcher
+            has not visited this row yet;
             **non-empty** — the matcher ran, with a NULL
             `resolved_artist_name` on each track it failed on ("the leg
             ran"), so consumers treat non-empty as a resolved signal.
+
+
+            Absent and NULL are the same state, deliberately. LML builds
+            every non-track result with `tracks=None` and serves the
+            endpoint through FastAPI's `response_model` without
+            `response_model_exclude_none`, so the wire has always carried
+            `"tracks": null` rather than omitting the key. `nullable: true`
+            documents the shipped producer instead of describing a wire
+            nobody emits; consumers must accept both spellings.
           items:
             $ref: '#/components/schemas/BulkResolveTrackIdentity'
 
@@ -4474,7 +4505,11 @@ components:
         Response to `POST /api/v1/identity/bulk-resolve-libraries`. Order
         of `results` matches the order of the request's `inputs`. The
         example below is the `include_tracks: true` shape; with the flag
-        false or omitted, every `tracks` key is absent.
+        false or omitted, every result's `tracks` is the absent/NULL state
+        (LML spells it `"tracks": null`). Per-source `method`/`confidence`
+        pairs in the example sit inside `IdentityMethod`'s locked bands —
+        Backend's writer rejects rows that don't, so an example that
+        violated them would hand LML#1021 an unwritable row to copy.
       required:
         - results
       example:
@@ -4490,10 +4525,10 @@ components:
             provenance:
               - source: discogs
                 method: exact_match
-                confidence: 0.98
+                confidence: 1.0
                 external_id: "12345"
               - source: musicbrainz
-                method: alias_match
+                method: name_variation
                 confidence: 0.95
                 external_id: "abc-def-12345"
             tracks:
@@ -4501,12 +4536,12 @@ components:
                 artist_name: "Juana Molina"
                 track_title: "la paradoja"
                 resolved_artist_name: "Juana Molina"
-                confidence: 0.98
+                confidence: 1.0
                 method: exact_match
                 sources:
                   - source: discogs
                     method: exact_match
-                    confidence: 0.98
+                    confidence: 1.0
                     external_id: "release/456"
           - kind: compilation
             library_id: 5678
@@ -4517,10 +4552,10 @@ components:
                 track_title: "Call Your Name"
                 resolved_artist_name: "Chuquimamani-Condori"
                 confidence: 0.90
-                method: exact_match
+                method: name_variation
                 sources:
                   - source: discogs
-                    method: exact_match
+                    method: name_variation
                     confidence: 0.90
                     external_id: "release/789"
               - track_position: null

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.29.0
+  version: 1.30.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -4120,24 +4120,55 @@ components:
     # a verdict per input — composed external IDs, the chosen method,
     # confidence, and per-source provenance.
     #
-    # Request shape is uniform: `{library_id, artist_name, album_title}`.
-    # LML auto-detects V/A from the row (per `library.code_volume_letters
-    # LIKE 'Z%'` or `EXISTS compilation_track_artist`) and discriminates
-    # the response on `kind`:
+    # Request shape is uniform: `{library_id, artist_name, album_title}`,
+    # plus the batch-level `include_tracks` flag. LML auto-detects V/A from
+    # the row (per `library.code_volume_letters LIKE 'Z%'` or
+    # `EXISTS compilation_track_artist`) and discriminates the response on
+    # `kind`:
     #
     #     - `kind: "single_artist"` — resolved single-artist library row;
     #                                  `main` carries the composed identity.
-    #     - `kind: "compilation"`   — V/A row; `tracks` carries per-track
-    #                                  identity (empty array if LML has no
-    #                                  track data for it yet). `main` is
-    #                                  null (no album-level artist anchor).
+    #                                  `tracks` carries per-track identity
+    #                                  when the request asked for it.
+    #     - `kind: "compilation"`   — V/A row; `main` is null (no album-level
+    #                                  artist anchor). `tracks` carries
+    #                                  per-track identity when the request
+    #                                  asked for it.
     #     - `kind: "unresolved"`    — LML attempted resolution and found
     #                                  nothing actionable; first-class
     #                                  outcome so Backend can cache and
-    #                                  not re-ask. `main` and `tracks`
-    #                                  are both null. Audit detail lives
-    #                                  in `provenance` (empty means LML
-    #                                  tried and nothing resolved).
+    #                                  not re-ask. `main` is null and
+    #                                  `tracks` is always absent. Audit
+    #                                  detail lives in `provenance` (empty
+    #                                  means LML tried and nothing resolved).
+    #
+    # ---- `tracks` is opt-in, and gated on BOTH resolved kinds (#297) ----
+    #
+    # Per-track identity is not free. WXYC/Backend-Service#1989 measured a
+    # mean of 56 per-track credits per V/A release, p99 483, max 2,364 — a
+    # 1,000-id page of V/A rows is ~11 MB of track identity that an
+    # album-identity drain would parse and discard, on every future pass.
+    # So the payload is gated behind `BulkResolveLibrariesRequest.include_tracks`
+    # (default `false`), and the gate covers the V/A arm too: exempting the
+    # arm with the worst payload pathology would be backwards.
+    #
+    # Omitting the flag reproduces the pre-`1.30.0` wire exactly, minus the
+    # empty array the V/A arm used to ship — which the sole consumer's
+    # compilation branch counts and skips without reading.
+    #
+    # Three states for `tracks`, replacing the two-state ("present-array or
+    # absent") rule this contract carried through `1.29.0`:
+    #
+    #     absent     — the caller did not ask (`include_tracks` false or
+    #                  omitted), or `kind: "unresolved"`.
+    #     []         — the caller asked, and LML's per-track matcher has not
+    #                  visited this row yet.
+    #     [entries]  — the matcher ran. Entries whose `resolved_artist_name`
+    #                  is NULL are tracks it tried and failed on, the same
+    #                  "the leg ran" convention as
+    #                  `BulkResolveProvenanceEntry.external_id`. A non-empty
+    #                  array is therefore a resolved signal
+    #                  (WXYC/Backend-Service#1991 / LML#1021).
 
     BulkResolveLibrariesRequest:
       type: object
@@ -4155,7 +4186,22 @@ components:
             $ref: '#/components/schemas/BulkResolveInput'
           description: >
             Inputs to resolve. Order preserved in `BulkResolveLibrariesResponse.results`.
+        include_tracks:
+          type: boolean
+          default: false
+          description: >
+            Opt in to per-track identity, for every input in the batch
+            (the flag is batch-level, not per-input). When `false` or
+            omitted — the default, and what an un-upgraded caller sends —
+            `BulkResolveResult.tracks` is absent from every result, so an
+            album-identity drain pays nothing for track composition it
+            would discard. When `true`, LML composes per-track identity
+            for both `kind: single_artist` and `kind: compilation`
+            results; `kind: unresolved` never carries tracks. See
+            `BulkResolveResult.tracks` for the three states the returned
+            array distinguishes.
       example:
+        include_tracks: true
         inputs:
           - library_id: 1234
             artist_name: "Juana Molina"
@@ -4192,10 +4238,12 @@ components:
       type: string
       description: >
         Discriminator for `BulkResolveResult`. `single_artist` carries a
-        composed `main` identity. `compilation` carries `tracks` (empty
-        array if LML has no per-track data for the V/A row yet).
-        `unresolved` is a first-class outcome — caching it (with TTL)
-        prevents repeated re-asking for unresolvable rows.
+        composed `main` identity; `compilation` carries none (a V/A row has
+        no album-level artist anchor). Either may carry `tracks` — per-track
+        identity is gated by the request's `include_tracks` flag, not by
+        `kind` (#297). `unresolved` is a first-class outcome — caching it
+        (with TTL) prevents repeated re-asking for unresolvable rows — and
+        never carries `main` or `tracks`.
       enum:
         - single_artist
         - compilation
@@ -4243,20 +4291,97 @@ components:
     BulkResolveTrackIdentity:
       type: object
       description: >
-        Per-track resolution for a V/A library row. One entry per
-        (library_id, track_position) the request resolved. Sources
-        reflect the per-source rows LML composed the track identity
-        from; the chosen identifiers are not lifted into a per-track
-        `external_ids` block at this contract version — Backend writes
-        the per-source rows verbatim into `library_track_identity_source`
-        per WXYC/library-metadata-lookup#271's design.
+        Per-track resolution for one library row — V/A or not. Returned
+        only when the request set `include_tracks: true`; one entry per
+        track LML's per-track matcher visited. `sources` reflects the
+        per-source rows LML composed the track identity from; the chosen
+        identifiers are not lifted into a per-track `external_ids` block
+        at this contract version — Backend writes the per-source rows
+        verbatim into `library_track_identity_source` per
+        WXYC/library-metadata-lookup#271's design.
+
+
+        The entry is addressable without `track_position`: 78% of
+        Backend's `compilation_track_artist` rows carry a NULL position
+        (WXYC/Backend-Service#1989), so `artist_name` + `track_title` are
+        the join-back key a consumer can actually use. `1.29.0` shipped
+        `track_position` as the only row identifier plus per-source legs,
+        with no composed verdict and no canonical artist — unconsumable
+        for WXYC/Backend-Service#1991, which went unnoticed because the
+        array has only ever shipped empty. The four added fields below
+        close that gap.
       required:
         - track_position
+        - artist_name
+        - track_title
+        - resolved_artist_name
+        - confidence
+        - method
         - sources
       properties:
         track_position:
           type: string
-          description: Track position; matches the request input.
+          nullable: true
+          description: >
+            Track position as the source has it ("A1", "3", …).
+            Required-but-nullable: the key is always present, and NULL
+            says "no position is recoverable for this track" rather than
+            "not echoed". Not a usable row identifier on its own — most
+            of Backend's compilation-track rows are position-NULL
+            (WXYC/Backend-Service#1989); join on `artist_name` +
+            `track_title` instead.
+        artist_name:
+          type: string
+          description: >
+            Join-back echo of the per-track credit, verbatim, and the
+            load-bearing half of the join key — never NULL. Dual-mode:
+            for `kind: compilation` it echoes the
+            `compilation_track_artist` row as exported in library.db, so
+            a consumer can match it to its own CTA row; for
+            `kind: single_artist` there is no CTA row and it carries the
+            credit as LML's source has it.
+        track_title:
+          type: string
+          nullable: true
+          description: >
+            Join-back echo of the track title, completing the join key.
+            Dual-mode in the same way as `artist_name` — the library.db
+            CTA row's title for `kind: compilation`, the source's track
+            title for `kind: single_artist`. NULL when that row or source
+            carries no title (the underlying CTA column is nullable).
+        resolved_artist_name:
+          type: string
+          nullable: true
+          description: >
+            The composed canonical artist for this track — the per-track
+            analogue of `BulkResolveResult.main`, carried as a name
+            because LML does not know Backend's artist ids; consumers map
+            it to their own artist tables locally. NULL when the matcher
+            visited this track and resolved nothing: the entry is still
+            returned so consumers see the leg ran (same convention as
+            `BulkResolveProvenanceEntry.external_id`), and `confidence`
+            and `method` are NULL alongside it.
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+          nullable: true
+          description: >
+            Composed track-level confidence in [0, 1] — where LML#1021's
+            per-track composition lands (cross-source agreement boost,
+            MIN-of-confidences fallback), applied at track grain exactly
+            as `BulkResolveResult.confidence` applies at album grain.
+            NULL when `resolved_artist_name` is NULL — the matcher ran
+            and produced no verdict, so confidence is undefined (not
+            zero).
+        method:
+          allOf:
+            - $ref: '#/components/schemas/IdentityMethod'
+          nullable: true
+          description: >
+            The composed track-level method — typically the strongest
+            leg's method, or `cross_source_agreement` when LML#1021's
+            boost fired. NULL when `resolved_artist_name` is NULL.
         sources:
           type: array
           description: >
@@ -4321,9 +4446,18 @@ components:
         tracks:
           type: array
           description: >
-            Set only for `kind: compilation`; absent for every other `kind`.
-            Empty array when LML has no per-track data for the V/A row yet.
-            Two states (present-array or absent), not three.
+            Per-track identity, returned only when the request set
+            `include_tracks: true`. That flag — not `kind` — gates the
+            field, and it gates it on both `kind: single_artist` and
+            `kind: compilation` (#297); `kind: unresolved` never carries
+            tracks. Three states, and the distinction between the last two
+            is load-bearing for WXYC/Backend-Service#1991: **absent** — the
+            caller did not ask (`include_tracks` false or omitted), or the
+            result is `unresolved`; **empty array** — the caller asked, and
+            LML's per-track matcher has not visited this row yet;
+            **non-empty** — the matcher ran, with a NULL
+            `resolved_artist_name` on each track it failed on ("the leg
+            ran"), so consumers treat non-empty as a resolved signal.
           items:
             $ref: '#/components/schemas/BulkResolveTrackIdentity'
 
@@ -4331,7 +4465,9 @@ components:
       type: object
       description: >
         Response to `POST /api/v1/identity/bulk-resolve-libraries`. Order
-        of `results` matches the order of the request's `inputs`.
+        of `results` matches the order of the request's `inputs`. The
+        example below is the `include_tracks: true` shape; with the flag
+        false or omitted, every `tracks` key is absent.
       required:
         - results
       example:
@@ -4353,16 +4489,44 @@ components:
                 method: alias_match
                 confidence: 0.95
                 external_id: "abc-def-12345"
+            tracks:
+              - track_position: "3"
+                artist_name: "Juana Molina"
+                track_title: "la paradoja"
+                resolved_artist_name: "Juana Molina"
+                confidence: 0.98
+                method: exact_match
+                sources:
+                  - source: discogs
+                    method: exact_match
+                    confidence: 0.98
+                    external_id: "release/456"
           - kind: compilation
             library_id: 5678
             provenance: []
             tracks:
               - track_position: "A1"
+                artist_name: "Chuquimamani-Condori"
+                track_title: "Call Your Name"
+                resolved_artist_name: "Chuquimamani-Condori"
+                confidence: 0.90
+                method: exact_match
                 sources:
                   - source: discogs
                     method: exact_match
                     confidence: 0.90
                     external_id: "release/789"
+              - track_position: null
+                artist_name: "Csillagrablók"
+                track_title: null
+                resolved_artist_name: null
+                confidence: null
+                method: null
+                sources:
+                  - source: discogs
+                    method: exact_match
+                    confidence: null
+                    external_id: null
           - kind: unresolved
             library_id: 9999
             provenance:
@@ -8284,6 +8448,15 @@ paths:
         `library_identity_source`. `kind: unresolved` is a first-class
         outcome — Backend caches it (with TTL) so the same input is not
         re-asked.
+
+
+        Per-track identity is opt-in: set `include_tracks: true` on the
+        request to get `BulkResolveResult.tracks` on both
+        `kind: single_artist` and `kind: compilation` results. The flag
+        defaults to `false`, which keeps album-identity drains off the
+        (measurably large) track payload — see the schema notes on
+        `BulkResolveLibrariesRequest.include_tracks` and
+        `BulkResolveResult.tracks`.
       security:
         - LMLBearerAuth: []
       tags:

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -7,6 +7,15 @@
 # Entries here are scoped to a `main`..PR diff, so an entry stops matching the
 # moment its change lands on `main`. Prune dead entries when you notice them;
 # an entry that outlives its diff suppresses nothing but reads as if it does.
+# Prune ENTRIES, never the file: both the CI job and
+# scripts/check-breaking-changes.sh pass this path unconditionally, and oasdiff
+# exits 121 when it is missing. An entry-free file of comments is the floor.
+#
+# Entries must reproduce oasdiff's rendered message verbatim (a substring like
+# "became nullable" matches nothing), so an oasdiff release that rewords a
+# message silently un-matches its entry and turns the job red. If that happens,
+# re-run the check locally and paste the new wording; don't assume the
+# suppression is still in force because the line is still here.
 #
 # Every entry needs a written justification. "oasdiff is being annoying" is not
 # one — a genuine breaking change gets a contract-version conversation, not a
@@ -26,4 +35,23 @@
 # `""` for the 78% of compilation-track rows that carry no position
 # (WXYC/Backend-Service#1989), i.e. encode "unknown" as a value that reads as
 # "known and empty". That is the failure this contract exists to prevent.
+#
+# Caveat on that benefit's timing: `generate:python` runs datamodel-codegen
+# without `--strict-nullable`, which drops `nullable` on required properties, so
+# ALL FIVE nullable fields on `BulkResolveTrackIdentity` (`track_position`,
+# `track_title`, `resolved_artist_name`, `confidence`, `method`) still generate
+# non-Optional for LML. The wire contract is correct as of this change; LML can
+# only honour it once that generator flag lands. See the CLAUDE.md section
+# "Python codegen drops `nullable` on required fields".
 post /api/v1/identity/bulk-resolve-libraries the response property `results/items/tracks/items/track_position` became nullable for the status `200`
+
+# --- wxyc-shared#297 (api.yaml 1.30.0) ---
+# `BulkResolveResult.tracks` gains `nullable: true`. This one corrects the
+# schema toward the wire rather than changing the wire: LML has always built
+# non-track results with `tracks=None` and serves them through FastAPI's
+# `response_model` with no `response_model_exclude_none`, so `"tracks": null`
+# is what every consumer has received since the field shipped. Declaring the
+# nullability cannot break a decoder that survives today's traffic — the
+# undeclared null is the status quo, and the previous schema was the thing
+# describing a wire nobody emits.
+post /api/v1/identity/bulk-resolve-libraries the response property `results/items/tracks` became nullable for the status `200`

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -1,0 +1,29 @@
+# oasdiff error-level ignore list.
+#
+# Format: one line per suppressed finding, `<method> <path> <message>` exactly as
+# oasdiff renders it (case-insensitive, extra spaces collapsed). A line that
+# matches nothing — including a `#` comment — is inert.
+#
+# Entries here are scoped to a `main`..PR diff, so an entry stops matching the
+# moment its change lands on `main`. Prune dead entries when you notice them;
+# an entry that outlives its diff suppresses nothing but reads as if it does.
+#
+# Every entry needs a written justification. "oasdiff is being annoying" is not
+# one — a genuine breaking change gets a contract-version conversation, not a
+# line in this file.
+
+# --- wxyc-shared#297 (api.yaml 1.30.0) ---
+# `BulkResolveTrackIdentity.track_position` goes required-non-null ->
+# required-nullable. oasdiff is right in the abstract: a consumer that decoded
+# the field as non-optional would now break. In fact no such consumer can exist.
+# `BulkResolveResult.tracks` is the only way to reach this property, and it has
+# only ever shipped as an empty array — LML never implemented per-track
+# resolution, and the sole consumer (Backend's `library-identity-consumer`)
+# counts the compilation arm's tracks and skips it without reading an entry.
+# Wire compatibility is therefore total; only the static rule fires.
+#
+# The alternative — keeping the property non-nullable — would force LML to emit
+# `""` for the 78% of compilation-track rows that carry no position
+# (WXYC/Backend-Service#1989), i.e. encode "unknown" as a value that reads as
+# "known and empty". That is the failure this contract exists to prevent.
+post /api/v1/identity/bulk-resolve-libraries the response property `results/items/tracks/items/track_position` became nullable for the status `200`

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:e2e:contracts": "vitest run --config vitest.e2e.config.ts tests/e2e-contracts.test.ts",
     "test:setup-script": "bats scripts/__tests__/setup-dev-environment.test.sh",
     "test:drift-guard": "bats scripts/__tests__/check-corpus-drift.test.sh",
+    "test:breaking-guard": "bats scripts/__tests__/check-breaking-changes.test.sh",
     "test:bs-lml-gate": "bats scripts/__tests__/bs-lml-gate/*.test.sh",
     "lint": "tsc --noEmit --declaration false --declarationMap false",
     "lint:e2e": "tsc -p tsconfig.e2e.json",

--- a/scripts/__tests__/check-breaking-changes.test.sh
+++ b/scripts/__tests__/check-breaking-changes.test.sh
@@ -43,14 +43,23 @@ teardown() {
     done < "$IGNORE_FILE"
 }
 
-@test "runs clean under bash 3.2 semantics (set -u + empty array expansion)" {
-    # macOS ships bash 3.2 at /bin/bash, where `"${arr[@]}"` on an empty array
-    # is an unbound-variable abort under `set -u`. The script must not depend
-    # on the bash 5 behaviour the author's homebrew shell happens to have.
-    if [ -x /bin/bash ]; then
-        run /bin/bash "$SCRIPT_PATH"
-        [[ "$output" != *"unbound variable"* ]]
-    fi
+# The original defect: `--err-ignore` args were held in an array and expanded as
+# `"${IGNORE_ARGS[@]}"`, which under bash 3.2 — what macOS ships at /bin/bash —
+# aborts with "unbound variable" when the array is empty and `set -u` is on. The
+# script exits 1 there, and its own header defines exit 1 as "breaking changes
+# detected". The array is gone, so this is a static guard against reintroducing
+# the construct rather than a behavioural test: a runtime check only catches it
+# on a bash 3.2 host, and CI runs bash 5.
+@test "the script contains no bare array expansion (bash 3.2 + set -u trap)" {
+    run grep -nE '"\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}"' "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+}
+
+@test "runs clean under whatever /bin/bash the platform ships" {
+    [ -x /bin/bash ] || skip "no /bin/bash"
+    run /bin/bash "$SCRIPT_PATH" "$REPO_ROOT/api.yaml"
+    [[ "$output" != *"unbound variable"* ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "exits 2 with an explanation when the whitelist file is missing" {
@@ -62,7 +71,8 @@ teardown() {
 
     run bash "$TEST_TEMP_DIR/scripts/check-breaking-changes.sh"
     [ "$status" -eq 2 ]
-    [[ "$output" == *"oasdiff-err-ignore.txt is missing"* ]]
+    [[ "$output" == *"oasdiff-err-ignore.txt"* ]]
+    [[ "$output" == *"121"* ]]
 }
 
 @test "exits 2 when api.yaml is absent from the project root" {
@@ -78,4 +88,104 @@ teardown() {
     run "$SCRIPT_PATH" "$REPO_ROOT/api.yaml"
     [ "$status" -eq 0 ]
     [[ "$output" == *"No API changes detected"* ]]
+}
+
+# --- the whitelist actually suppressing something ---
+#
+# Every test above either exits at preflight or takes the identical-specs fast
+# path at the top of the script, so none of them reaches oasdiff. The two below
+# are the only end-to-end coverage: they run a real diff (origin/main..HEAD)
+# through the real flag, and they are written as a pair so that neither can pass
+# for the wrong reason. If the whitelist stops matching — a typo, an oasdiff
+# release that rewords a finding — the first goes red. If the whitelist starts
+# matching things it shouldn't, or the diff stops containing any breaking
+# change at all, the second goes red and the first becomes vacuous.
+
+setup_base() {
+    command -v oasdiff > /dev/null || skip "oasdiff not installed"
+    BASE_SPEC="$TEST_TEMP_DIR/base.yaml"
+    git -C "$REPO_ROOT" show origin/main:api.yaml > "$BASE_SPEC" 2>/dev/null \
+        || skip "no origin/main api.yaml to diff against"
+    if diff -q "$BASE_SPEC" "$REPO_ROOT/api.yaml" > /dev/null 2>&1; then
+        skip "api.yaml identical to origin/main; nothing to suppress"
+    fi
+}
+
+@test "the script exits 0 on the current diff, i.e. the whitelist entries match" {
+    setup_base
+    run "$SCRIPT_PATH" "$BASE_SPEC"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No breaking changes detected"* ]]
+}
+
+@test "the same diff is genuinely breaking without the whitelist" {
+    # Proves the previous test is suppressing real ERR findings rather than
+    # passing because the diff happens to be clean.
+    setup_base
+    run oasdiff breaking "$BASE_SPEC" "$REPO_ROOT/api.yaml" --fail-on ERR
+    [ "$status" -eq 1 ]
+}
+
+@test "every whitelist entry corresponds to a finding in the current diff" {
+    # The file's own rule is that entries are diff-scoped and dead ones get
+    # pruned. This fails when an entry outlives the change it was written for.
+    setup_base
+    run oasdiff breaking "$BASE_SPEC" "$REPO_ROOT/api.yaml" --fail-on ERR
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        # Strip the leading "<method> <path> " to get the message text.
+        message="${line#* }"
+        message="${message#* }"
+        [[ "$output" == *"$message"* ]] || {
+            echo "stale whitelist entry, matches nothing in the diff:"
+            echo "  $line"
+            return 1
+        }
+    done < "$IGNORE_FILE"
+}
+
+@test "a non-breaking oasdiff failure is not reported as a breaking change" {
+    # oasdiff exits 121 for a bad --err-ignore path, 2/3 for a malformed spec.
+    # Reporting those as "Breaking changes detected!" with advice to deprecate
+    # rather than remove is a confidently wrong diagnosis of what is really a
+    # file-permission or syntax problem — the same misdiagnosis the preflight
+    # was written to prevent, arriving through a door the preflight left open.
+    command -v oasdiff > /dev/null || skip "oasdiff not installed"
+    mkdir -p "$TEST_TEMP_DIR/scripts"
+    cp "$SCRIPT_PATH" "$TEST_TEMP_DIR/scripts/"
+    cp "$IGNORE_FILE" "$TEST_TEMP_DIR/"
+    # Revision is malformed; base is the real spec, so the two differ and the
+    # identical-specs fast path does not swallow the run before oasdiff sees it.
+    printf 'this is not: openapi: at all\n  - and: [unclosed\n' > "$TEST_TEMP_DIR/api.yaml"
+
+    run bash "$TEST_TEMP_DIR/scripts/check-breaking-changes.sh" "$REPO_ROOT/api.yaml"
+    [ "$status" -ne 0 ]
+    [ "$status" -ne 1 ]
+    [[ "$output" != *"Breaking changes detected"* ]]
+    [[ "$output" != *"Deprecating rather than removing"* ]]
+}
+
+@test "an unreadable whitelist fails preflight rather than exiting 121 from oasdiff" {
+    [ "$(id -u)" -ne 0 ] || skip "running as root; permission bits are advisory"
+    mkdir -p "$TEST_TEMP_DIR/scripts"
+    cp "$SCRIPT_PATH" "$TEST_TEMP_DIR/scripts/"
+    cp "$REPO_ROOT/api.yaml" "$TEST_TEMP_DIR/api.yaml"
+    cp "$IGNORE_FILE" "$TEST_TEMP_DIR/"
+    chmod 000 "$TEST_TEMP_DIR/oasdiff-err-ignore.txt"
+
+    run bash "$TEST_TEMP_DIR/scripts/check-breaking-changes.sh"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"oasdiff-err-ignore.txt"* ]]
+}
+
+@test "a directory named oasdiff-err-ignore.txt fails preflight, not oasdiff" {
+    mkdir -p "$TEST_TEMP_DIR/scripts"
+    cp "$SCRIPT_PATH" "$TEST_TEMP_DIR/scripts/"
+    cp "$REPO_ROOT/api.yaml" "$TEST_TEMP_DIR/api.yaml"
+    mkdir -p "$TEST_TEMP_DIR/oasdiff-err-ignore.txt"
+
+    run bash "$TEST_TEMP_DIR/scripts/check-breaking-changes.sh"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"oasdiff-err-ignore.txt"* ]]
 }

--- a/scripts/__tests__/check-breaking-changes.test.sh
+++ b/scripts/__tests__/check-breaking-changes.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+#
+# BATS tests for check-breaking-changes.sh.
+#
+# Run with: npm run test:breaking-guard
+# Or directly: npx bats scripts/__tests__/check-breaking-changes.test.sh
+#
+# Focus is the oasdiff-err-ignore.txt wiring (#297) and the script's contract
+# with its callers: which exit codes mean what, and whether a local run agrees
+# with the breaking-changes.yml job. The two defects these tests were written
+# against — an empty-array expansion that aborts under bash 3.2's `set -u`, and
+# a `[[ -f ]]` guard that let a missing ignore file pass locally while oasdiff
+# exits 121 in CI — are both invisible to a spec-level test.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/check-breaking-changes.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IGNORE_FILE="$REPO_ROOT/oasdiff-err-ignore.txt"
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+# The ignore file is a hard dependency of both callers, not an optional extra:
+# oasdiff exits 121 on a missing --err-ignore path, and the CI job passes it
+# unconditionally. If this file ever goes away, the next api.yaml PR gets a red
+# "Breaking API Changes Detected" comment describing a file-not-found error.
+@test "the whitelist file the CI job references exists" {
+    [ -f "$IGNORE_FILE" ]
+}
+
+@test "every non-comment line in the whitelist is a real oasdiff finding line" {
+    # Guards against a stray blank-ish or prose line that silently matches
+    # nothing. Entries must name a method + path.
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "$line" =~ ^(get|post|put|patch|delete)\ /.+ ]]
+    done < "$IGNORE_FILE"
+}
+
+@test "runs clean under bash 3.2 semantics (set -u + empty array expansion)" {
+    # macOS ships bash 3.2 at /bin/bash, where `"${arr[@]}"` on an empty array
+    # is an unbound-variable abort under `set -u`. The script must not depend
+    # on the bash 5 behaviour the author's homebrew shell happens to have.
+    if [ -x /bin/bash ]; then
+        run /bin/bash "$SCRIPT_PATH"
+        [[ "$output" != *"unbound variable"* ]]
+    fi
+}
+
+@test "exits 2 with an explanation when the whitelist file is missing" {
+    # Not a silent skip: a local run that passes where CI fails is the exact
+    # divergence the unconditional --err-ignore wiring exists to prevent.
+    cp -R "$REPO_ROOT/api.yaml" "$TEST_TEMP_DIR/api.yaml"
+    mkdir -p "$TEST_TEMP_DIR/scripts"
+    cp "$SCRIPT_PATH" "$TEST_TEMP_DIR/scripts/"
+
+    run bash "$TEST_TEMP_DIR/scripts/check-breaking-changes.sh"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"oasdiff-err-ignore.txt is missing"* ]]
+}
+
+@test "exits 2 when api.yaml is absent from the project root" {
+    mkdir -p "$TEST_TEMP_DIR/scripts"
+    cp "$SCRIPT_PATH" "$TEST_TEMP_DIR/scripts/"
+
+    run bash "$TEST_TEMP_DIR/scripts/check-breaking-changes.sh"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"api.yaml not found"* ]]
+}
+
+@test "reports no breaking changes for an identical base spec (fast path)" {
+    run "$SCRIPT_PATH" "$REPO_ROOT/api.yaml"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No API changes detected"* ]]
+}

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -52,11 +52,14 @@ fi
 # pass here and fail the PR job — the divergence this wiring exists to prevent.
 # Preflight (not just before the oasdiff call) so the failure is reported even
 # on the paths that exit early.
+# Checks readability, not just existence: a directory of that name, or a file
+# with no read bit, both sail past a bare `-f`/`-e` and then make oasdiff exit
+# 121 — which the reporting below would otherwise dress up as a breaking change.
 IGNORE_FILE="$PROJECT_ROOT/oasdiff-err-ignore.txt"
-if [[ ! -f "$IGNORE_FILE" ]]; then
-    echo -e "${red}Error: oasdiff-err-ignore.txt is missing at $IGNORE_FILE${reset}"
+if [[ ! -f "$IGNORE_FILE" || ! -r "$IGNORE_FILE" ]]; then
+    echo -e "${red}Error: oasdiff-err-ignore.txt is not a readable file at $IGNORE_FILE${reset}"
     echo "CI passes this path unconditionally and oasdiff exits 121 without it."
-    echo "Restore the file (an entry-free file of comments is fine)."
+    echo "Restore it as a readable file (an entry-free file of comments is fine)."
     exit 2
 fi
 
@@ -90,14 +93,29 @@ echo ""
 #   mirroring the `err-ignore` input on .github/workflows/breaking-changes.yml.
 #   Passed unconditionally, exactly as CI passes it; existence is checked in the
 #   preflight above. Prune entries, keep the file.
-if oasdiff breaking "$TEMP_BASE" "$PROJECT_ROOT/api.yaml" --fail-on ERR --err-ignore "$IGNORE_FILE"; then
+set +e
+oasdiff breaking "$TEMP_BASE" "$PROJECT_ROOT/api.yaml" --fail-on ERR --err-ignore "$IGNORE_FILE"
+exit_code=$?
+set -e
+
+# Only exit 1 means "breaking changes found". oasdiff also exits 121 for an
+# unusable --err-ignore path and 2/3 for a spec it cannot parse; printing the
+# deprecate-don't-remove advice for those diagnoses a file-permission or syntax
+# problem as an API design problem, and sends the reader looking for a breaking
+# change that is not there.
+if [[ $exit_code -eq 0 ]]; then
     echo -e "\n${green}No breaking changes detected.${reset}"
-else
-    exit_code=$?
+elif [[ $exit_code -eq 1 ]]; then
     echo -e "\n${red}Breaking changes detected!${reset}"
     echo -e "${yellow}Consider:"
     echo "  - Adding new fields/endpoints instead of modifying existing ones"
     echo "  - Deprecating rather than removing"
     echo -e "  - Versioning the API if breaking changes are necessary${reset}"
+    exit 1
+else
+    echo -e "\n${red}oasdiff could not complete the comparison (exit $exit_code).${reset}"
+    echo -e "${yellow}This is a tool or input problem, not a breaking change."
+    echo "  - 121: --err-ignore path unusable ($IGNORE_FILE)"
+    echo -e "  - 2/3: a spec failed to parse${reset}"
     exit $exit_code
 fi

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -46,6 +46,20 @@ if [[ ! -f "$PROJECT_ROOT/api.yaml" ]]; then
     exit 2
 fi
 
+# Check the whitelist exists. It is a hard dependency, not an optional extra:
+# oasdiff exits 121 on a missing --err-ignore path and .github/workflows/
+# breaking-changes.yml passes it unconditionally, so skipping it locally would
+# pass here and fail the PR job — the divergence this wiring exists to prevent.
+# Preflight (not just before the oasdiff call) so the failure is reported even
+# on the paths that exit early.
+IGNORE_FILE="$PROJECT_ROOT/oasdiff-err-ignore.txt"
+if [[ ! -f "$IGNORE_FILE" ]]; then
+    echo -e "${red}Error: oasdiff-err-ignore.txt is missing at $IGNORE_FILE${reset}"
+    echo "CI passes this path unconditionally and oasdiff exits 121 without it."
+    echo "Restore the file (an entry-free file of comments is fine)."
+    exit 2
+fi
+
 echo -e "\n${bold}Checking for Breaking API Changes${reset}"
 
 # Get base spec
@@ -72,14 +86,11 @@ echo ""
 
 # Run oasdiff breaking check
 # --fail-on ERR: exit 1 if breaking changes found
-# --err-ignore: findings whitelisted (with justification) in oasdiff-err-ignore.txt.
-#   Mirrors the `err-ignore` input on .github/workflows/breaking-changes.yml —
-#   keep the two in sync or local and CI disagree.
-IGNORE_FILE="$PROJECT_ROOT/oasdiff-err-ignore.txt"
-IGNORE_ARGS=()
-[[ -f "$IGNORE_FILE" ]] && IGNORE_ARGS=(--err-ignore "$IGNORE_FILE")
-
-if oasdiff breaking "$TEMP_BASE" "$PROJECT_ROOT/api.yaml" --fail-on ERR "${IGNORE_ARGS[@]}"; then
+# --err-ignore: findings whitelisted (with justification) in oasdiff-err-ignore.txt,
+#   mirroring the `err-ignore` input on .github/workflows/breaking-changes.yml.
+#   Passed unconditionally, exactly as CI passes it; existence is checked in the
+#   preflight above. Prune entries, keep the file.
+if oasdiff breaking "$TEMP_BASE" "$PROJECT_ROOT/api.yaml" --fail-on ERR --err-ignore "$IGNORE_FILE"; then
     echo -e "\n${green}No breaking changes detected.${reset}"
 else
     exit_code=$?

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -72,7 +72,14 @@ echo ""
 
 # Run oasdiff breaking check
 # --fail-on ERR: exit 1 if breaking changes found
-if oasdiff breaking "$TEMP_BASE" "$PROJECT_ROOT/api.yaml" --fail-on ERR; then
+# --err-ignore: findings whitelisted (with justification) in oasdiff-err-ignore.txt.
+#   Mirrors the `err-ignore` input on .github/workflows/breaking-changes.yml —
+#   keep the two in sync or local and CI disagree.
+IGNORE_FILE="$PROJECT_ROOT/oasdiff-err-ignore.txt"
+IGNORE_ARGS=()
+[[ -f "$IGNORE_FILE" ]] && IGNORE_ARGS=(--err-ignore "$IGNORE_FILE")
+
+if oasdiff breaking "$TEMP_BASE" "$PROJECT_ROOT/api.yaml" --fail-on ERR "${IGNORE_ARGS[@]}"; then
     echo -e "\n${green}No breaking changes detected.${reset}"
 else
     exit_code=$?

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -2089,15 +2089,35 @@ describe('OpenAPI Specification', () => {
 
     // --- Option (B): opt-in `include_tracks`, gating BOTH kinds ---
 
-    it('adds include_tracks to BulkResolveLibrariesRequest as an optional boolean defaulting to false', () => {
+    it('adds include_tracks to BulkResolveLibrariesRequest as an optional boolean', () => {
       const schema = spec.components.schemas.BulkResolveLibrariesRequest as Schema;
       const flag = schema.properties?.include_tracks;
       expect(flag).toBeDefined();
       expect(flag!.type).toBe('boolean');
-      // Default false is the whole backward-compatibility story: an
-      // un-upgraded Backend that never sends the field keeps today's payload.
-      expect(flag!.default).toBe(false);
       expect(schema.required ?? []).not.toContain('include_tracks');
+    });
+
+    // Omission from `required` is necessary but NOT sufficient for the generated
+    // TypeScript to treat the field as optional. openapi-typescript emits any
+    // property carrying a `default` as non-optional regardless of `required`
+    // (its `defaultNonNullable` option, on by default), on the reasoning that a
+    // server fills the default in — sound for a response, wrong for a request
+    // body the client constructs. With `default: false` present the published
+    // `BulkResolveLibrariesRequest` generated as `include_tracks: boolean` with
+    // no `?`, so `{ inputs }` failed to compile for every TS consumer — for the
+    // one field whose contract is "omitted is the default, and what an
+    // un-upgraded caller sends". The default lives in prose instead; assert on
+    // the spec here, and on the emitted `.d.ts` in the codegen test below.
+    it('does not give include_tracks a schema-level default', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesRequest as Schema;
+      expect(schema.properties?.include_tracks).not.toHaveProperty('default');
+    });
+
+    it('documents in prose that omitting include_tracks means false', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesRequest as Schema;
+      const description = (schema.properties?.include_tracks?.description as string) ?? '';
+      expect(description).toMatch(/omitted/i);
+      expect(description).toMatch(/default/i);
     });
 
     it('documents include_tracks as gating tracks on both single_artist and compilation', () => {
@@ -2307,11 +2327,47 @@ describe('OpenAPI Specification', () => {
       // naming the table has to be the one saying it was never built.
       expect(description).toMatch(/library_track_identity_source[^.]*never built/);
       expect(description).toMatch(/composed verdict/i);
+      // Assert what the retraction is for — that no sentence reintroduces the
+      // table as a live storage instruction — rather than that exactly one
+      // sentence mentions it. Pinning the count made a correct spec go red for
+      // adding a second, also-correct sentence (e.g. a migration note), and the
+      // failure surfaced as an opaque length mismatch.
       const sentencesNamingTheTable = description
         .split(/(?<=\.)\s+/)
         .filter((s) => s.includes('library_track_identity_source'));
-      expect(sentencesNamingTheTable).toHaveLength(1);
-      expect(sentencesNamingTheTable[0]).toMatch(/never built/);
+      expect(sentencesNamingTheTable.length).toBeGreaterThan(0);
+      for (const sentence of sentencesNamingTheTable) {
+        expect(sentence).toMatch(/never built|not built|no such table/i);
+      }
+    });
+
+    // --- the four states have to be legible from the example, not just the prose ---
+
+    const exampleResults = () =>
+      ((spec.components.schemas.BulkResolveLibrariesResponse as Schema).example
+        ?.results ?? []) as Array<Record<string, unknown>>;
+
+    it('spells tracks and tracks_attempted as explicit nulls on the unresolved result', () => {
+      // Both the response description and BulkResolveResult.tracks argue that
+      // LML emits `"tracks": null` rather than omitting the key — that claim is
+      // the justification for marking the field nullable and for one of the two
+      // oasdiff whitelist entries. An example that models the state by omitting
+      // the keys teaches LML#1021 the opposite of what the schema argues.
+      const unresolved = exampleResults().find((r) => r.kind === 'unresolved');
+      expect(unresolved).toBeDefined();
+      expect(unresolved).toHaveProperty('tracks', null);
+      expect(unresolved).toHaveProperty('tracks_attempted', null);
+    });
+
+    it('demonstrates all four tracks_attempted/tracks states', () => {
+      const states = exampleResults()
+        .filter((r) => r.kind !== 'unresolved')
+        .map((r) => `${String(r.tracks_attempted)}/${Array.isArray(r.tracks) && r.tracks.length > 0 ? 'entries' : 'empty'}`);
+      // (false, []) is the state the flag exists to disambiguate from (true, []);
+      // an example that never shows it leaves the distinction abstract.
+      expect(states).toContain('false/empty');
+      expect(states).toContain('true/empty');
+      expect(states).toContain('true/entries');
     });
   });
 

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -2107,7 +2107,7 @@ describe('OpenAPI Specification', () => {
       expect(description).toMatch(/compilation/);
     });
 
-    it('replaces the two-state tracks wording with the three states, on both kinds', () => {
+    it('replaces the two-state tracks wording with the four states, on both kinds', () => {
       const schema = spec.components.schemas.BulkResolveResult as Schema;
       const tracks = schema.properties?.tracks;
       expect(tracks).toBeDefined();
@@ -2115,7 +2115,11 @@ describe('OpenAPI Specification', () => {
       // The superseded contract: V/A-only, and exactly two states.
       expect(description).not.toMatch(/Two states/i);
       expect(description).not.toMatch(/Set only for `kind: compilation`/);
-      // The three states this ticket settled.
+      // Nor the three-state framing that shipped in this PR's first pass — the
+      // empty array turned out to carry two meanings, so `tracks` alone cannot
+      // name the state; it names it jointly with `tracks_attempted`.
+      expect(description).not.toMatch(/Three states/i);
+      // The four states this ticket settled.
       expect(description).toMatch(/absent/i);
       expect(description).toMatch(/empty/i);
       expect(description).toMatch(/include_tracks/);
@@ -2141,6 +2145,50 @@ describe('OpenAPI Specification', () => {
       const description = kind.description ?? '';
       expect(description).toMatch(/include_tracks/);
       expect(kind).toHaveProperty('enum', ['single_artist', 'compilation', 'unresolved']);
+    });
+
+    // --- `tracks_attempted`: the resolved signal, decoupled from array length ---
+    //
+    // Without it, `tracks: []` carries two meanings that a consumer cannot tell
+    // apart: the matcher has not visited this row, and the matcher ran and
+    // resolved nothing. Extending the gate to `kind: single_artist` makes the
+    // second case ordinary rather than theoretical — a release LML holds no
+    // tracklist for. BS#1991 would read every one of them as "not yet visited"
+    // and re-ask forever, which is the pathology `kind: unresolved` was made a
+    // first-class outcome to prevent, reintroduced one grain down.
+
+    it('adds tracks_attempted to BulkResolveResult as an optional nullable boolean', () => {
+      const schema = spec.components.schemas.BulkResolveResult as Schema;
+      const attempted = schema.properties?.tracks_attempted;
+      expect(attempted).toBeDefined();
+      expect(attempted!.type).toBe('boolean');
+      // Optional + nullable, symmetric with `tracks`: an un-upgraded caller that
+      // never sends include_tracks keeps today's payload, and LML spells every
+      // not-asked field `null` rather than omitting the key.
+      expect(attempted!.nullable).toBe(true);
+      expect(schema.required ?? []).not.toContain('tracks_attempted');
+    });
+
+    it('makes tracks_attempted the resolved signal, decoupled from array length', () => {
+      const schema = spec.components.schemas.BulkResolveResult as Schema;
+      const description = (schema.properties?.tracks_attempted?.description as string) ?? '';
+      // The load-bearing sentence: true once the matcher has visited the row,
+      // however many tracks it resolved — including none.
+      expect(description).toMatch(/regardless of how many/i);
+      expect(description).toMatch(/WXYC\/Backend-Service#1991/);
+      // And the pairing has to be spelled out, or a producer can emit the one
+      // combination that means nothing (`false` alongside a populated array).
+      expect(description).toMatch(/`false`[\s\S]*empty/);
+    });
+
+    it('retires "non-empty is the resolved signal" from the tracks description', () => {
+      // The 2026-08-06 settlement read non-empty as resolved. That heuristic is
+      // superseded by the explicit flag; leaving it in the prose would give
+      // consumers two rules that disagree exactly on the zero-track case.
+      const schema = spec.components.schemas.BulkResolveResult as Schema;
+      const description = (schema.properties?.tracks?.description as string) ?? '';
+      expect(description).not.toMatch(/non-empty as a resolved signal/);
+      expect(description).toMatch(/tracks_attempted/);
     });
 
     // --- BulkResolveTrackIdentity repair (BS#1991 / LML#1021) ---

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -2198,6 +2198,24 @@ describe('OpenAPI Specification', () => {
       expect(description).toMatch(/NULL/);
     });
 
+    it('drops the storage instruction naming a table that was never built (BS#801)', () => {
+      // 1.29.0 told Backend to write per-source rows verbatim into a
+      // `library_track_identity_source` sidecar. It does not exist — LML#271
+      // closed as a design decision and the schema half never happened
+      // (verified against prod and all 136 migrations in BS#801). LML's
+      // per-track store is the per-source system of record and Backend
+      // persists composed verdicts only, so the contract must not send a
+      // consumer off to build the sidecar.
+      // The table name still appears, but only inside its own retraction —
+      // a reader migrating off 1.29.0 needs to be told the sidecar isn't
+      // coming, not left to infer it from silence.
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      const description = schema.description ?? '';
+      expect(description).not.toMatch(/writes? the per-source rows verbatim/);
+      expect(description).toMatch(/library_track_identity_source[^.]*never built/);
+      expect(description).toMatch(/composed verdict/i);
+    });
+
     // The "current version" sentinel lives with the most recent api.yaml change;
     // the include_tracks gate + the BulkResolveTrackIdentity repair bumped the minor.
     it('bumps info.version to 1.30.0', () => {

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -872,12 +872,6 @@ describe('OpenAPI Specification', () => {
       expect(read.properties?.artist_name?.maxLength).toBe(255);
     });
 
-    // The "current version" sentinel lives with the most recent api.yaml change;
-    // the BS#1965 producer fields + the CTA export path bumped the minor.
-    it('bumps info.version to 1.29.0', () => {
-      expect(spec.info.version).toBe('1.29.0');
-    });
-
     it('declares GET /library/catalog/compilation-tracks (BearerAuth; If-Modified-Since + ?since=; NDJSON 200 + 304)', () => {
       const path = spec.paths['/library/catalog/compilation-tracks'] as {
         get?: {
@@ -2073,6 +2067,141 @@ describe('OpenAPI Specification', () => {
           '#/components/schemas/ApiErrorResponse',
         );
       }
+    });
+  });
+
+  describe('Bulk-Resolve-Libraries tracks gating + per-track identity (#297)', () => {
+    type Schema = {
+      type?: string;
+      required?: string[];
+      description?: string;
+      properties?: Record<string, Record<string, unknown>>;
+    };
+
+    // --- Option (B): opt-in `include_tracks`, gating BOTH kinds ---
+
+    it('adds include_tracks to BulkResolveLibrariesRequest as an optional boolean defaulting to false', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesRequest as Schema;
+      const flag = schema.properties?.include_tracks;
+      expect(flag).toBeDefined();
+      expect(flag!.type).toBe('boolean');
+      // Default false is the whole backward-compatibility story: an
+      // un-upgraded Backend that never sends the field keeps today's payload.
+      expect(flag!.default).toBe(false);
+      expect(schema.required ?? []).not.toContain('include_tracks');
+    });
+
+    it('documents include_tracks as gating tracks on both single_artist and compilation', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesRequest as Schema;
+      const description = (schema.properties?.include_tracks?.description as string) ?? '';
+      expect(description).toMatch(/single_artist/);
+      expect(description).toMatch(/compilation/);
+    });
+
+    it('replaces the two-state tracks wording with the three states, on both kinds', () => {
+      const schema = spec.components.schemas.BulkResolveResult as Schema;
+      const tracks = schema.properties?.tracks;
+      expect(tracks).toBeDefined();
+      const description = (tracks!.description as string) ?? '';
+      // The superseded contract: V/A-only, and exactly two states.
+      expect(description).not.toMatch(/Two states/i);
+      expect(description).not.toMatch(/Set only for `kind: compilation`/);
+      // The three states this ticket settled.
+      expect(description).toMatch(/absent/i);
+      expect(description).toMatch(/empty/i);
+      expect(description).toMatch(/include_tracks/);
+      expect(description).toMatch(/single_artist/);
+      // Still optional — the absent state is what an un-upgraded caller sees.
+      expect(schema.required ?? []).not.toContain('tracks');
+    });
+
+    it('corrects BulkResolveResultKind so compilation no longer owns tracks alone', () => {
+      const kind = spec.components.schemas.BulkResolveResultKind as Schema;
+      const description = kind.description ?? '';
+      expect(description).toMatch(/include_tracks/);
+      expect(kind).toHaveProperty('enum', ['single_artist', 'compilation', 'unresolved']);
+    });
+
+    // --- BulkResolveTrackIdentity repair (BS#1991 / LML#1021) ---
+
+    it('ships the join-back echoes, composed verdict, and canonical artist on BulkResolveTrackIdentity', () => {
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      expect(Object.keys(schema.properties ?? {}).sort()).toEqual(
+        [
+          'artist_name',
+          'confidence',
+          'method',
+          'resolved_artist_name',
+          'sources',
+          'track_position',
+          'track_title',
+        ].sort(),
+      );
+
+      // artist_name is the join-back key BS actually has (78% of CTA rows are
+      // position-NULL per BS#1989), so it is required and non-nullable.
+      expect(schema.properties?.artist_name?.type).toBe('string');
+      expect(schema.properties?.artist_name?.nullable).toBeUndefined();
+      expect(schema.required ?? []).toContain('artist_name');
+
+      // track_title completes the join key; nullable because the CTA column is.
+      expect(schema.properties?.track_title?.type).toBe('string');
+      expect(schema.properties?.track_title?.nullable).toBe(true);
+    });
+
+    it('makes track_position nullable but keeps the key present (positions are unrecoverable for some V/A rows)', () => {
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      const position = schema.properties?.track_position;
+      expect(position?.type).toBe('string');
+      expect(position?.nullable).toBe(true);
+      // Required-but-nullable: the null says "no position for this row",
+      // which an absent key could not distinguish from "not echoed".
+      expect(schema.required ?? []).toContain('track_position');
+    });
+
+    it('lands the composed per-track verdict as required-but-nullable resolved_artist_name / confidence / method', () => {
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      const required = schema.required ?? [];
+
+      const resolved = schema.properties?.resolved_artist_name;
+      expect(resolved?.type).toBe('string');
+      expect(resolved?.nullable).toBe(true);
+      expect(required).toContain('resolved_artist_name');
+
+      const confidence = schema.properties?.confidence;
+      expect(confidence?.type).toBe('number');
+      expect(confidence?.nullable).toBe(true);
+      expect(confidence?.minimum).toBe(0);
+      expect(confidence?.maximum).toBe(1);
+      expect(required).toContain('confidence');
+
+      // method is a nullable $ref, so it has to be wrapped in allOf.
+      const method = schema.properties?.method as { allOf?: Array<{ $ref?: string }>; nullable?: boolean };
+      expect(method?.allOf?.[0]?.$ref).toBe('#/components/schemas/IdentityMethod');
+      expect(method?.nullable).toBe(true);
+      expect(required).toContain('method');
+    });
+
+    it('documents artist_name and track_title as dual-mode (CTA echo for V/A, source credit for non-V/A)', () => {
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      for (const key of ['artist_name', 'track_title']) {
+        const description = (schema.properties?.[key]?.description as string) ?? '';
+        expect(description, key).toMatch(/compilation/);
+        expect(description, key).toMatch(/single_artist/);
+      }
+    });
+
+    it('states the null-resolved_artist_name convention so non-empty tracks reads as attempted', () => {
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      const description = (schema.properties?.resolved_artist_name?.description as string) ?? '';
+      // Same "the leg ran" convention as BulkResolveProvenanceEntry.external_id.
+      expect(description).toMatch(/NULL/);
+    });
+
+    // The "current version" sentinel lives with the most recent api.yaml change;
+    // the include_tracks gate + the BulkResolveTrackIdentity repair bumped the minor.
+    it('bumps info.version to 1.30.0', () => {
+      expect(spec.info.version).toBe('1.30.0');
     });
   });
 

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -39,6 +39,15 @@ describe('OpenAPI Specification', () => {
       expect(spec.info.version).toBeDefined();
     });
 
+    // The contract-version sentinel. It used to be re-planted inside whichever
+    // feature block bumped it last (BS#1468's, then #297's), so every api.yaml
+    // change edited a describe named for an unrelated ticket — and a forgotten
+    // move filed the assertion under a ticket that didn't bump anything. It
+    // lives here permanently now; update the literal, leave the location.
+    it('pins info.version to the released contract version', () => {
+      expect(spec.info.version).toBe('1.30.0');
+    });
+
     it('should have components section', () => {
       expect(spec.components).toBeDefined();
       expect(spec.components.schemas).toBeDefined();
@@ -2115,6 +2124,18 @@ describe('OpenAPI Specification', () => {
       expect(schema.required ?? []).not.toContain('tracks');
     });
 
+    it('declares tracks nullable, because LML spells the absent state `"tracks": null`', () => {
+      // LML builds every non-track result with `tracks=None` and serves the
+      // endpoint through FastAPI's `response_model` with no
+      // `response_model_exclude_none`, so the wire has always carried an
+      // explicit null. Optional-but-not-nullable would generate a TS type
+      // (`tracks?: T[]`) that every live response already violates.
+      const schema = spec.components.schemas.BulkResolveResult as Schema;
+      expect(schema.properties?.tracks?.nullable).toBe(true);
+      const description = (schema.properties?.tracks?.description as string) ?? '';
+      expect(description).toMatch(/NULL/);
+    });
+
     it('corrects BulkResolveResultKind so compilation no longer owns tracks alone', () => {
       const kind = spec.components.schemas.BulkResolveResultKind as Schema;
       const description = kind.description ?? '';
@@ -2139,9 +2160,16 @@ describe('OpenAPI Specification', () => {
       );
 
       // artist_name is the join-back key BS actually has (78% of CTA rows are
-      // position-NULL per BS#1989), so it is required and non-nullable.
+      // position-NULL per BS#1989), so it is required and non-nullable — and
+      // minLength 1, since an empty join key is no more usable than a missing
+      // one (same guard CatalogCompilationTrackRow.artist_name carries over
+      // the physical column). No maxLength: the single_artist arm echoes a
+      // source credit no WXYC column bounds, so a cap would decode-fail rather
+      // than protect.
       expect(schema.properties?.artist_name?.type).toBe('string');
       expect(schema.properties?.artist_name?.nullable).toBeUndefined();
+      expect(schema.properties?.artist_name?.minLength).toBe(1);
+      expect(schema.properties?.artist_name?.maxLength).toBeUndefined();
       expect(schema.required ?? []).toContain('artist_name');
 
       // track_title completes the join key; nullable because the CTA column is.
@@ -2194,8 +2222,24 @@ describe('OpenAPI Specification', () => {
     it('states the null-resolved_artist_name convention so non-empty tracks reads as attempted', () => {
       const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
       const description = (schema.properties?.resolved_artist_name?.description as string) ?? '';
-      // Same "the leg ran" convention as BulkResolveProvenanceEntry.external_id.
-      expect(description).toMatch(/NULL/);
+      // Same "the leg ran" convention as BulkResolveProvenanceEntry.external_id:
+      // the null must be tied to the matcher having run and resolved nothing,
+      // not merely mentioned somewhere in the prose.
+      expect(description).toMatch(/NULL when the matcher visited this track/);
+      expect(description).toMatch(/`confidence`[\s\S]*`method` are NULL/);
+    });
+
+    it('keeps `sources` from claiming the verdict that now lives on resolved_artist_name', () => {
+      // `sources: []` (no leg produced a row) and a populated `sources` whose
+      // entries carry NULL external_id (legs ran, no candidate) are different
+      // statements that both accompany a NULL verdict. Before this ticket the
+      // field's own description said an empty array meant "found no matches",
+      // which collided with the new convention and gave a producer two ways to
+      // encode one state.
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      const description = (schema.properties?.sources?.description as string) ?? '';
+      expect(description).not.toMatch(/found no matches/);
+      expect(description).toMatch(/resolved_artist_name/);
     });
 
     it('drops the storage instruction naming a table that was never built (BS#801)', () => {
@@ -2211,15 +2255,15 @@ describe('OpenAPI Specification', () => {
       // coming, not left to infer it from silence.
       const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
       const description = schema.description ?? '';
-      expect(description).not.toMatch(/writes? the per-source rows verbatim/);
+      // Pin the retraction, not one phrasing of the instruction: any sentence
+      // naming the table has to be the one saying it was never built.
       expect(description).toMatch(/library_track_identity_source[^.]*never built/);
       expect(description).toMatch(/composed verdict/i);
-    });
-
-    // The "current version" sentinel lives with the most recent api.yaml change;
-    // the include_tracks gate + the BulkResolveTrackIdentity repair bumped the minor.
-    it('bumps info.version to 1.30.0', () => {
-      expect(spec.info.version).toBe('1.30.0');
+      const sentencesNamingTheTable = description
+        .split(/(?<=\.)\s+/)
+        .filter((s) => s.includes('library_track_identity_source'));
+      expect(sentencesNamingTheTable).toHaveLength(1);
+      expect(sentencesNamingTheTable[0]).toMatch(/never built/);
     });
   });
 

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -52,3 +52,36 @@ describe("codegen output paths (#197)", () => {
     );
   });
 });
+
+// A property carrying an OpenAPI `default` is emitted non-optional by
+// openapi-typescript (its `defaultNonNullable` option, on by default) even when
+// the property is absent from `required`. That reasoning holds for a response —
+// the server fills the default in — and is wrong for a request body the client
+// constructs. `include_tracks` shipped briefly with `default: false` and
+// generated as `include_tracks: boolean`, which made `{ inputs }` a compile
+// error in every TS consumer, for the one field whose contract is "omitted is
+// the default". The spec-level guard lives in api-spec.test.ts; this one pins
+// the artifact that consumers actually import, because the spec assertion alone
+// cannot see what the generator did with it.
+describe("generated request types stay constructible (#297)", () => {
+  const dts = readFileSync(
+    join(__dirname, "..", "src", "generated", "openapi-types.d.ts"),
+    "utf-8",
+  );
+
+  const requestBlock = () => {
+    const start = dts.indexOf("BulkResolveLibrariesRequest: {");
+    expect(start, "BulkResolveLibrariesRequest missing from generated types").toBeGreaterThan(-1);
+    return dts.slice(start, dts.indexOf("\n        };", start));
+  };
+
+  it("emits include_tracks as optional", () => {
+    expect(requestBlock()).toMatch(/\binclude_tracks\?:/);
+  });
+
+  it("keeps inputs required", () => {
+    // Guards the assertion above against passing for the wrong reason — e.g. a
+    // regex that matches because the whole block vanished.
+    expect(requestBlock()).toMatch(/\n\s+inputs: /);
+  });
+});


### PR DESCRIPTION
Closes #297.

## What this settles

**The fork: option (B).** `BulkResolveLibrariesRequest.include_tracks` (boolean, default `false`) gates `BulkResolveResult.tracks` — and gates it on **both** `kind: single_artist` and `kind: compilation`, not just the new arm. Reasoning is recorded [on the issue](https://github.com/WXYC/wxyc-shared/issues/297#issuecomment-5206996568); in brief, the V/A arm has the worst payload pathology (BS#1989: mean 56 credits/release, p99 483, max 2,364 — a 1,000-id V/A page is ~11 MB), so exempting it would have been backwards, and option (A)'s only advantage (no three-state docs) evaporated once the BS#1991 semantics required the three states anyway.

**Three-state `tracks`**, replacing "two states (present-array or absent), not three":

| state | meaning |
|---|---|
| absent | caller didn't ask (`include_tracks` false/omitted), or `kind: unresolved` |
| `[]` | caller asked; LML's per-track matcher hasn't visited this row |
| `[…]` | matcher ran — entries with NULL `resolved_artist_name` are the tracks it failed on ("the leg ran", same convention as `BulkResolveProvenanceEntry.external_id`) |

So a non-empty array is a resolved signal, which is what BS#1991 / LML#1021 needed to coordinate on.

**`BulkResolveTrackIdentity` repair.** As shipped in 1.29.0 the per-track shape was unconsumable by its intended consumer — no join-back key that survives a NULL position, no field for LML#1021's composed verdict, no canonical artist name. Nobody noticed because the array has only ever shipped empty. Added:

| field | purpose |
|---|---|
| `artist_name` (required, non-null) | join-back echo. Dual-mode: the library.db `compilation_track_artist` row for `kind: compilation`; the source's own credit for `kind: single_artist`, which has no CTA row |
| `track_title` (nullable) | completes the join key; dual-mode the same way |
| `resolved_artist_name` (nullable) | the composed canonical artist — consumers map it to their own artist ids locally |
| `confidence`, `method` (nullable) | the composed track-level verdict — where LML#1021's composition lands |
| `track_position` → **nullable** | 78% of BS's CTA rows are position-NULL (BS#1989); the alternative was forcing LML to encode "unknown" as `""` |

`BulkResolveResult.tracks` is also declared `nullable: true`. That one corrects the schema toward the wire rather than the reverse: LML builds every non-track result with `tracks=None` (`identity/bulk_resolve.py:336/354/367`) and serves through FastAPI's `response_model` with no `response_model_exclude_none`, so `"tracks": null` is what consumers have always received. The old declaration generated `tracks?: T[]` — a type every live response violates. Absent and NULL are one state.

Second commit retracts a stale instruction found while writing this: the 1.29.0 description told Backend to write per-source rows verbatim into `library_track_identity_source`, a table [that was never built](https://github.com/WXYC/Backend-Service/issues/801#issuecomment-5187348795). It's now named only inside its own retraction.

`info.version` → **1.30.0**.

## Backward compatibility: what an un-upgraded Backend sees

**No change, verified rather than assumed.** BS's `jobs/library-identity-consumer` doesn't consume `@wxyc/shared` for this endpoint at all — it hand-mirrors the contract in `jobs/library-identity-consumer/lml-types.ts` (deliberately, to keep the job's build graph off GitHub Packages) and posts `JSON.stringify({ inputs })`. Concretely:

- It never sends `include_tracks` → the flag defaults to `false` → `tracks` is absent from every result. Its local mirror already types `tracks?:` optional.
- Its compilation arm (`orchestrate.ts:306-309`) increments `rows_skipped.compilation` and never reads `result.tracks`, so the field going absent is unobservable.
- Every other field on `BulkResolveResult` is untouched.

Net: today's response minus an empty array nobody read.

## The one oasdiff ERR, and why it's whitelisted rather than fixed

`track_position` going required-non-null → required-nullable trips `response-property-became-nullable`. oasdiff is right in the abstract — a consumer decoding it as non-optional would break — but no such consumer can exist: the property is reachable only through `tracks`, which has only ever shipped empty (LML never implemented per-track resolution), and the sole consumer counts-and-skips as above.

A second entry covers `tracks` becoming nullable, which is the same shape of non-break for a stronger reason: the undeclared null is the status quo, so declaring it cannot break a decoder that survives today's traffic.

New `oasdiff-err-ignore.txt` carries both findings with the justifications written out, wired into both `npm run check:breaking` and the `breaking-changes.yml` job so local and CI agree. Two properties documented in the file and in CLAUDE.md: entries are diff-scoped (a line goes inert once its change is on `main` — prune it), and the file is not an escape hatch for real breaks.

## Known issue this surfaces for LML#1138 (not fixed here)

`generate:python` runs `datamodel-codegen` **without** `--strict-nullable`, which silently drops `nullable: true` on *required* properties. That hits **all five** nullable per-track fields (`track_position`, `track_title`, `resolved_artist_name`, `confidence`, `method`) — every one generates non-Optional, so **LML cannot construct the NULLs the three-state semantics depend on**, nor the spec's own failed-track example. This is pre-existing — `BulkResolveProvenanceEntry.confidence` has the same shape, and LML works around it by defaulting the None case upstream, i.e. the documented null never reaches the wire.

Adding the flag is the right fix but rewrites ~200 lines of both Python consumers' committed models, so it needs its own ticket and their review rather than riding this contract PR. Documented in CLAUDE.md; filed as a follow-up and linked from LML#1138.

## Follow-ups

- Regenerate + commit `generated/api_models.py` in `library-metadata-lookup` (datamodel-code-generator pinned `0.56.1`) and `request-o-matic` (pinned `0.57.0`) after the package release.
- `--strict-nullable` on `generate:python` (above), blocking LML#1138's null emission.
- The replace-tracklist contract for BS#1992 stays out of scope by design.

## Review round (commit 3)

`/code-review` found two live defects in the whitelist wiring, both now fixed and covered by a new bats suite (`npm run test:breaking-guard`, 6 tests):

- **`"${IGNORE_ARGS[@]}"` on an empty array aborts under `set -u` on bash 3.2** — the `/bin/bash` on every stock macOS. Reproduced: `unbound variable`, exit 1, which this script's own header defines as "breaking changes detected". Passes on bash 5, so it would have failed only for people who didn't write it.
- **A missing ignore file passed locally and exits 121 in CI** — the exact divergence the wiring exists to prevent, made likelier by the "prune dead entries" instruction. The file is now a preflight-checked hard dependency; prune entries, never the file.

Also from that round: the `tracks` nullability above, `minLength: 1` on `artist_name` (with the deliberate absence of `maxLength` explained), a `sources` description that no longer collides with the NULL-verdict convention, example method/confidence pairs moved inside `IdentityMethod`'s locked bands, and the `info.version` sentinel given a permanent home instead of migrating into each new feature block.

Two findings were recorded rather than fixed in that round, because both would unilaterally change coordination settled between BS#1991 and LML#1021. **Both are now decided — see commit 4.**

## Review round (commit 4) — the two open questions, resolved

### 1. `tracks: []` meant two things. Fixed with `tracks_attempted`.

The empty array could not distinguish *the matcher has not visited this row* from *the matcher ran and resolved nothing*, and the three-state rule commit 1 shipped pinned it to the first meaning only. Extending the gate to `kind: single_artist` — the point of #297 — makes the second case the ordinary one, not an edge: a single-artist release LML holds no tracklist for lands there. BS#1991 would read every such row as unvisited and re-ask it forever, which is the re-asking pathology `kind: unresolved` exists to prevent, reintroduced one grain down. No consumer can repair it locally, because the two states are byte-identical on the wire.

`BulkResolveResult.tracks_attempted` (optional, nullable boolean) carries the signal explicitly. **Four** states, read off the pair:

| `tracks_attempted` | `tracks` | meaning |
|---|---|---|
| absent / NULL | absent / NULL | caller didn't ask, or `kind: unresolved` |
| `false` | `[]` | asked; matcher hasn't reached this row |
| `true` | `[]` | matcher ran, resolved nothing |
| `true` | `[…]` | matcher ran, produced entries (NULL `resolved_artist_name` = the leg ran and failed) |

`false` alongside a populated array is not a state; producers must not emit it.

**The resolved signal moves from "non-empty array" to the flag**, superseding the convention settled in BS#801's 2026-08-06 addendum (D10). Two reasons a boolean beats the alternative of redefining `[]` and pushing "unvisited" onto NULL: it doesn't overload the absent state that already means "didn't ask", and — decisively — this repo's `generate:python` runs without `--strict-nullable` and already drops `nullable` on required properties, so a state encoded in the null-vs-empty-array gap is precisely what these generators mangle. A boolean survives codegen; the gap doesn't.

### 2. The batch-level gate stays, because the one consumer can partition locally.

The finding was that `include_tracks` is batch-level with `maxItems` unchanged at 1,000, so BS#1991 — the only caller that must opt in — receives the ~11 MB V/A page the flag was created to avoid. Its premise was that a caller can't pre-partition V/A from non-V/A "without already knowing the classification it is calling LML to learn."

That premise is true generically and **false for Backend specifically**. LML auto-detects V/A from `library.code_volume_letters LIKE 'Z%'` or `EXISTS compilation_track_artist` — and Backend owns both. `code_volume_letters` is `schema.ts:500`; `compilation_track_artist` is a Backend table with 144,778 prod rows. BS#1991 can run a small-paged V/A drain and a full-width non-V/A drain against the same predicate LML uses, today, with no contract change.

So no per-input flag and no conditional cap. The guidance is written onto `include_tracks` instead, naming the two predicates, so the next consumer meets the cliff in the field's own documentation rather than in production. Recorded as a requirement on BS#1991.

## Verification

`npm test` (617 passing, 18 new for this contract), `npm run test:breaking-guard` (6 new bats tests), `npm run lint`, `npm run lint:e2e`, `npm run build`, `npm run check:breaking` — all green locally. Generated TS confirms `tracks?: BulkResolveTrackIdentity[]` and the nullable per-track fields; generated Python confirms the `--strict-nullable` gap above.

