### PR TITLE
docs: correct the LML#271 citation in api.yaml and the generated/python/ consumer table in CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,21 @@
 name: CI
 
+# Markdown is NOT ignored. `tests/codegen-output-paths.test.ts` asserts facts
+# about CLAUDE.md and README.md — that neither tells a reader `generate:python`
+# feeds a consuming service — and `paths-ignore: '**.md'` skipped this entire
+# job for a docs-only PR, so those guards could never fire on the one change
+# class they guard. The false claim they now pin got into both files exactly
+# that way. GitHub's path filters have no negation, so the choice is ignore
+# markdown and lose the guards, or run a ~1-minute job on docs PRs. Cheaper to
+# run it.
 on:
   push:
     branches: [main]
     paths-ignore:
-      - '**.md'
       - 'LICENSE'
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**.md'
       - 'LICENSE'
 
 # Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,16 +110,18 @@ The TypeScript codegen script (`scripts/generate-models.js`) produces:
 - `src/generated/openapi-types.d.ts` -- raw openapi-typescript output
 - `src/generated/models/index.ts` -- re-export layer with const objects for enums
 
-All four output trees are **in-repo and gitignored** (`src/generated/`, `generated/`) — they're regenerated artifacts, never committed here. TypeScript is the only output consumed by this package's own build (it ships the DTOs); Python/Swift/Kotlin are produced for downstream consumers.
+All four output trees are **in-repo and gitignored** (`src/generated/`, `generated/`) — they're regenerated artifacts, never committed here. TypeScript is the only output any consumer actually receives (it ships the DTOs in the published package); Python, Swift, and Kotlin are local reference trees a maintainer regenerates and diffs against when hand-updating a consumer.
 
 ### Output locations and consumers
 
 | Script | Output (gitignored) | Consumer(s) | How the consumer uses it today |
 |---|---|---|---|
 | `generate:typescript` | `src/generated/` | Backend-Service, dj-site (via `@wxyc/shared/dtos`) | Imported from the published package |
-| `generate:python` | `generated/python/` | request-o-matic, library-metadata-lookup | Pydantic models |
+| `generate:python` | `generated/python/` | **Nobody** — reference/diff aid only | Both Python services generate their own models from `api.yaml` (see below) |
 | `generate:swift` | `generated/swift/` | wxyc-dj-ios (DJ tool / device-auth), wxyc-ios-64 (listener) | **Hand-maintained** — reference/diff aid only |
 | `generate:kotlin` | `generated/kotlin/` | WXYC-Android | **Hand-maintained** — reference/diff aid only |
+
+**Nothing consumes `generated/python/`.** Both Python services run their *own* copy of `scripts/generate_api_models.sh` against `api.yaml` — resolved from a sibling `wxyc-shared/` checkout, or downloaded from `raw.githubusercontent.com` when there isn't one — and commit the result as `generated/api_models.py` in their own repo ([library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup/blob/main/scripts/generate_api_models.sh), [request-o-matic](https://github.com/WXYC/request-o-matic/blob/main/scripts/generate_api_models.sh)). So `npm run generate:python` here is a reference/diff aid like Swift and Kotlin, not a build step for anyone. Two consequences worth holding onto: **a codegen-flag change made here reaches no consumer** — it has to land in all three invocations (that's the scope correction in #302), or #107 has to consolidate them first; and the three invocations can drift, as they already have on the generator version — LML pins `datamodel-code-generator[http]==0.56.1`, request-o-matic pins `datamodel-code-generator==0.57.0` in `requirements-dev.txt`, and this repo pins nothing at all. Regenerate against a consumer's pin when you're producing output to diff against that consumer.
 
 The Swift/Kotlin consumers **do not yet consume the generated output** — they hand-author types that mirror `api.yaml` (e.g. `wxyc-dj-ios`'s `Packages/WXYCAPI/Sources/WXYCAPI/DTOs/`). So `generated/swift` and `generated/kotlin` are a local reference a maintainer regenerates and diffs against when hand-updating a consumer after an `api.yaml` change — not a tree any consumer checks in. (`library-scanner`, formerly a Swift consumer, is now an archived/read-only repo.)
 
@@ -138,7 +140,7 @@ Two gotchas, both verified against the current `api.yaml`:
 
 `generate:python` runs `datamodel-codegen` **without** `--strict-nullable`, and that flag's absence is not cosmetic: a `required` + `nullable: true` property generates as a plain non-Optional field (`confidence: confloat(ge=0, le=1)`), so the null the contract documents cannot be constructed through the generated model. Only *non-required* nullable properties come out as `str | None = None`.
 
-This bites the required-but-nullable idiom this spec uses whenever a null carries meaning (`BulkResolveProvenanceEntry.confidence`, `BulkResolveTrackIdentity.resolved_artist_name`, `CompilationTrackSuggestions.discogs_release_id`). LML currently works around it by defaulting the None case upstream — i.e. the documented null never reaches the wire. Adding `--strict-nullable` fixes it but rewrites ~200 lines of both Python consumers' committed models, so it needs its own ticket and their review; don't reshape `api.yaml` to route around the generator.
+This bites the required-but-nullable idiom this spec uses whenever a null carries meaning (`BulkResolveProvenanceEntry.confidence`, `BulkResolveTrackIdentity.resolved_artist_name`, `CompilationTrackSuggestions.discogs_release_id`). LML currently works around it by defaulting the None case upstream — i.e. the documented null never reaches the wire. Adding `--strict-nullable` fixes it but rewrites ~200 lines of both Python consumers' committed models, so it needs their review; don't reshape `api.yaml` to route around the generator. Tracked in #302, which also carries the measured blast radius (72 changed field declarations, 36 widened / 36 narrowed) and the reason the flag has to land in all three invocations rather than only in `package.json`.
 
 ## Breaking-change gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,20 +110,22 @@ The TypeScript codegen script (`scripts/generate-models.js`) produces:
 - `src/generated/openapi-types.d.ts` -- raw openapi-typescript output
 - `src/generated/models/index.ts` -- re-export layer with const objects for enums
 
-All four output trees are **in-repo and gitignored** (`src/generated/`, `generated/`) — they're regenerated artifacts, never committed here. TypeScript is the only output any consumer actually receives (it ships the DTOs in the published package); Python, Swift, and Kotlin are local reference trees a maintainer regenerates and diffs against when hand-updating a consumer.
+All four output trees are **in-repo and gitignored** (`src/generated/`, `generated/`) — they're regenerated artifacts, never committed here.
 
 ### Output locations and consumers
 
-| Script | Output (gitignored) | Consumer(s) | How the consumer uses it today |
+**Only `generate:typescript` produces output anyone consumes.** It ships the DTOs in the published package. The other three are local reference trees: a maintainer regenerates one and diffs it against a consumer's hand-written or independently-generated types. Editing this repo's codegen flags therefore changes nothing for any Python, Swift, or Kotlin consumer — the "Who'd notice a change here" column is the one to read before assuming otherwise.
+
+| Script | Output (gitignored) | Who'd notice a change here | Where those types actually come from |
 |---|---|---|---|
-| `generate:typescript` | `src/generated/` | Backend-Service, dj-site (via `@wxyc/shared/dtos`) | Imported from the published package |
-| `generate:python` | `generated/python/` | **Nobody** — reference/diff aid only | Both Python services generate their own models from `api.yaml` (see below) |
-| `generate:swift` | `generated/swift/` | wxyc-dj-ios (DJ tool / device-auth), wxyc-ios-64 (listener) | **Hand-maintained** — reference/diff aid only |
-| `generate:kotlin` | `generated/kotlin/` | WXYC-Android | **Hand-maintained** — reference/diff aid only |
+| `generate:typescript` | `src/generated/` | **Backend-Service, dj-site** | Imported from the published `@wxyc/shared/dtos` |
+| `generate:python` | `generated/python/` | Nobody | Each service runs its own `scripts/generate_api_models.sh` (see below) |
+| `generate:swift` | `generated/swift/` | Nobody | wxyc-dj-ios, wxyc-ios-64 hand-author types mirroring `api.yaml` |
+| `generate:kotlin` | `generated/kotlin/` | Nobody | WXYC-Android hand-authors types mirroring `api.yaml` |
 
-**Nothing consumes `generated/python/`.** Both Python services run their *own* copy of `scripts/generate_api_models.sh` against `api.yaml` — resolved from a sibling `wxyc-shared/` checkout, or downloaded from `raw.githubusercontent.com` when there isn't one — and commit the result as `generated/api_models.py` in their own repo ([library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup/blob/main/scripts/generate_api_models.sh), [request-o-matic](https://github.com/WXYC/request-o-matic/blob/main/scripts/generate_api_models.sh)). So `npm run generate:python` here is a reference/diff aid like Swift and Kotlin, not a build step for anyone. Two consequences worth holding onto: **a codegen-flag change made here reaches no consumer** — it has to land in all three invocations (that's the scope correction in #302), or #107 has to consolidate them first; and the three invocations can drift, as they already have on the generator version — LML pins `datamodel-code-generator[http]==0.56.1`, request-o-matic pins `datamodel-code-generator==0.57.0` in `requirements-dev.txt`, and this repo pins nothing at all. Regenerate against a consumer's pin when you're producing output to diff against that consumer.
+**Where the Python models really come from.** Both services run their *own* copy of `scripts/generate_api_models.sh` against `api.yaml` — resolved from a sibling `wxyc-shared/` checkout, or downloaded from `raw.githubusercontent.com` when there isn't one — and commit the result as `generated/api_models.py` in their own repo ([library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup/blob/main/scripts/generate_api_models.sh), [request-o-matic](https://github.com/WXYC/request-o-matic/blob/main/scripts/generate_api_models.sh)). Two consequences worth holding onto: **a codegen-flag change made here reaches no consumer** — it has to land in all three invocations (that's the scope correction in #302), or #107 has to consolidate them first; and the three invocations can drift, as they already have on the generator version — LML pins `datamodel-code-generator[http]==0.56.1`, request-o-matic pins `datamodel-code-generator==0.57.0` in `requirements-dev.txt`, and this repo pins nothing at all. Regenerate against a consumer's pin when you're producing output to diff against that consumer.
 
-The Swift/Kotlin consumers **do not yet consume the generated output** — they hand-author types that mirror `api.yaml` (e.g. `wxyc-dj-ios`'s `Packages/WXYCAPI/Sources/WXYCAPI/DTOs/`). So `generated/swift` and `generated/kotlin` are a local reference a maintainer regenerates and diffs against when hand-updating a consumer after an `api.yaml` change — not a tree any consumer checks in. (`library-scanner`, formerly a Swift consumer, is now an archived/read-only repo.)
+For Swift/Kotlin the hand-authored types live in the consumer repo (e.g. `wxyc-dj-ios`'s `Packages/WXYCAPI/Sources/WXYCAPI/DTOs/`). (`library-scanner`, formerly a Swift consumer, is now an archived/read-only repo.)
 
 Migrating each consumer onto the generated output is tracked separately, blocked by this output-path fix (#197): WXYC/wxyc-dj-ios#75, WXYC/WXYC-Android#25, WXYC/wxyc-ios-64#412 — all sub-issues of the codegen umbrella #106. Once a consumer migrates, its `-o` path (or its own build step) should point at wherever that repo checks the generated client in; until then these stay in-repo.
 
@@ -141,6 +143,8 @@ Two gotchas, both verified against the current `api.yaml`:
 `generate:python` runs `datamodel-codegen` **without** `--strict-nullable`, and that flag's absence is not cosmetic: a `required` + `nullable: true` property generates as a plain non-Optional field (`confidence: confloat(ge=0, le=1)`), so the null the contract documents cannot be constructed through the generated model. Only *non-required* nullable properties come out as `str | None = None`.
 
 This bites the required-but-nullable idiom this spec uses whenever a null carries meaning (`BulkResolveProvenanceEntry.confidence`, `BulkResolveTrackIdentity.resolved_artist_name`, `CompilationTrackSuggestions.discogs_release_id`). LML currently works around it by defaulting the None case upstream — i.e. the documented null never reaches the wire. Adding `--strict-nullable` fixes it but rewrites ~200 lines of both Python consumers' committed models, so it needs their review; don't reshape `api.yaml` to route around the generator. Tracked in #302, which also carries the measured blast radius (72 changed field declarations, 36 widened / 36 narrowed) and the reason the flag has to land in all three invocations rather than only in `package.json`.
+
+**As of api.yaml 1.30.0 this means part of the shipped contract cannot currently be honoured.** `BulkResolveTrackIdentity` defines a failed per-track resolution as NULL `resolved_artist_name` (with NULL `confidence` and `method` alongside it) — "the leg ran and produced no verdict". Five of its seven fields are required-and-nullable, and on LML's `main` today all five generate non-`Optional`, so the producer cannot emit the state the contract defines. Until #302 lands, treat every nullable field on that schema as documentation of intent rather than something a Python consumer can currently produce or a reader can expect to see on the wire.
 
 ## Breaking-change gate
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ TypeScript types are generated from `api.yaml` using [`openapi-typescript`](http
 npm run generate:typescript  # TypeScript types (openapi-typescript)
 npm run generate:swift       # iOS types (openapi-generator-cli, requires Java)
 npm run generate:kotlin      # Android types (openapi-generator-cli, requires Java)
-npm run generate:python      # Python models (datamodel-codegen)
+npm run generate:python      # Python models (datamodel-codegen) — reference/diff aid; no repo consumes this output
 ```
 
 ## E2E Tests
@@ -649,4 +649,4 @@ See [`railway/`](./railway/) for the Railway service topology, environment varia
 3. Export them from `src/dtos/index.ts`
 4. Add corresponding test fixtures/factories
 5. Run `npm run lint` to verify types
-6. If Python services consume the new types, run `npm run generate:python` to update the generated Python models
+6. Nothing here updates the Python services. `generated/python/` is a local reference tree that no repo imports — library-metadata-lookup and request-o-matic each run their own `scripts/generate_api_models.sh` against `api.yaml` and commit the result in their own repo. If your change affects them, open a regen ticket there; running `npm run generate:python` locally only produces something to diff against.

--- a/api.yaml
+++ b/api.yaml
@@ -4346,13 +4346,17 @@ components:
         the per-source system of record, and consumers persist only the
         composed verdict fields on this entry. `1.29.0` said instead that
         Backend writes these rows verbatim into
-        `library_track_identity_source`; that table was never built —
-        WXYC/library-metadata-lookup#271 closed as a design decision and
-        the schema half never happened, confirmed against prod and all
-        136 migrations in
+        `library_track_identity_source`; that table was never built.
+        WXYC/Backend-Service#792 — the Backend-side ticket that would
+        have created it — closed as a design decision and the schema
+        half never happened, confirmed against prod and all 136
+        migrations in
         https://github.com/WXYC/Backend-Service/issues/801#issuecomment-5187348795.
-        The chosen identifiers are not lifted into a per-track
-        `external_ids` block at this contract version.
+        (`1.29.0` attributed that instruction to
+        WXYC/library-metadata-lookup#271, which is open and scopes LML's
+        own per-track identity work, not Backend storage.) The chosen
+        identifiers are not lifted into a per-track `external_ids` block
+        at this contract version.
 
 
         The entry is addressable without `track_position`: 78% of

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -21,7 +21,14 @@
 # one — a genuine breaking change gets a contract-version conversation, not a
 # line in this file.
 #
-# There are currently no live entries. The two wxyc-shared#297 suppressions
+# Worked example of the pruning rule, kept because the rule reads abstractly
+# until you have seen it applied once: the two wxyc-shared#297 suppressions
 # (`BulkResolveTrackIdentity.track_position` and `BulkResolveResult.tracks`
 # becoming nullable) landed on `main` in api.yaml 1.30.0, stopped appearing in
-# any `main`..PR diff, and were pruned per the rule above.
+# any `main`..PR diff, and were pruned.
+#
+# Deliberately not recorded here: how many entries are currently live. A comment
+# claiming a count is wrong the moment someone appends an entry below it, and no
+# test can catch that — the checks in
+# scripts/__tests__/check-breaking-changes.test.sh skip comment lines by
+# construction. Read the entries.

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -20,38 +20,8 @@
 # Every entry needs a written justification. "oasdiff is being annoying" is not
 # one — a genuine breaking change gets a contract-version conversation, not a
 # line in this file.
-
-# --- wxyc-shared#297 (api.yaml 1.30.0) ---
-# `BulkResolveTrackIdentity.track_position` goes required-non-null ->
-# required-nullable. oasdiff is right in the abstract: a consumer that decoded
-# the field as non-optional would now break. In fact no such consumer can exist.
-# `BulkResolveResult.tracks` is the only way to reach this property, and it has
-# only ever shipped as an empty array — LML never implemented per-track
-# resolution, and the sole consumer (Backend's `library-identity-consumer`)
-# counts the compilation arm's tracks and skips it without reading an entry.
-# Wire compatibility is therefore total; only the static rule fires.
 #
-# The alternative — keeping the property non-nullable — would force LML to emit
-# `""` for the 78% of compilation-track rows that carry no position
-# (WXYC/Backend-Service#1989), i.e. encode "unknown" as a value that reads as
-# "known and empty". That is the failure this contract exists to prevent.
-#
-# Caveat on that benefit's timing: `generate:python` runs datamodel-codegen
-# without `--strict-nullable`, which drops `nullable` on required properties, so
-# ALL FIVE nullable fields on `BulkResolveTrackIdentity` (`track_position`,
-# `track_title`, `resolved_artist_name`, `confidence`, `method`) still generate
-# non-Optional for LML. The wire contract is correct as of this change; LML can
-# only honour it once that generator flag lands. See the CLAUDE.md section
-# "Python codegen drops `nullable` on required fields".
-post /api/v1/identity/bulk-resolve-libraries the response property `results/items/tracks/items/track_position` became nullable for the status `200`
-
-# --- wxyc-shared#297 (api.yaml 1.30.0) ---
-# `BulkResolveResult.tracks` gains `nullable: true`. This one corrects the
-# schema toward the wire rather than changing the wire: LML has always built
-# non-track results with `tracks=None` and serves them through FastAPI's
-# `response_model` with no `response_model_exclude_none`, so `"tracks": null`
-# is what every consumer has received since the field shipped. Declaring the
-# nullability cannot break a decoder that survives today's traffic — the
-# undeclared null is the status quo, and the previous schema was the thing
-# describing a wire nobody emits.
-post /api/v1/identity/bulk-resolve-libraries the response property `results/items/tracks` became nullable for the status `200`
+# There are currently no live entries. The two wxyc-shared#297 suppressions
+# (`BulkResolveTrackIdentity.track_position` and `BulkResolveResult.tracks`
+# becoming nullable) landed on `main` in api.yaml 1.30.0, stopped appearing in
+# any `main`..PR diff, and were pruned per the rule above.

--- a/scripts/__tests__/check-breaking-changes.test.sh
+++ b/scripts/__tests__/check-breaking-changes.test.sh
@@ -98,8 +98,10 @@ teardown() {
 # through the real flag, and they are written as a pair so that neither can pass
 # for the wrong reason. If the whitelist stops matching — a typo, an oasdiff
 # release that rewords a finding — the first goes red. If the whitelist starts
-# matching things it shouldn't, or the diff stops containing any breaking
-# change at all, the second goes red and the first becomes vacuous.
+# matching things it shouldn't, the second goes red and the first becomes
+# vacuous. The pair only has something to say while the whitelist carries a
+# live entry; with an empty whitelist the second skips (see below), because
+# "this diff is breaking" is a claim about the entries, not about api.yaml.
 
 setup_base() {
     command -v oasdiff > /dev/null || skip "oasdiff not installed"
@@ -109,6 +111,21 @@ setup_base() {
     if diff -q "$BASE_SPEC" "$REPO_ROOT/api.yaml" > /dev/null 2>&1; then
         skip "api.yaml identical to origin/main; nothing to suppress"
     fi
+}
+
+# Count the whitelist's live entries — every line that is neither a comment nor
+# blank. Zero is a legitimate steady state (the file's own header calls an
+# entry-free file of comments the floor), and it is what the file looks like
+# between the merge of one suppressed change and the next one that needs a
+# suppression.
+live_entry_count() {
+    local count=0 line
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        count=$((count + 1))
+    done < "$IGNORE_FILE"
+    echo "$count"
 }
 
 @test "the script exits 0 on the current diff, i.e. the whitelist entries match" {
@@ -122,6 +139,14 @@ setup_base() {
     # Proves the previous test is suppressing real ERR findings rather than
     # passing because the diff happens to be clean.
     setup_base
+    # ...but only when there is something to suppress. An empty whitelist has
+    # nothing to prove, and a PR that edits api.yaml without breaking anything
+    # (a description fix, say) is the ordinary case, not a suspicious one. Left
+    # unconditional, this assertion demanded that every api.yaml PR be breaking
+    # — the exact inversion of what the gate is for, and a red CI job with no
+    # actionable defect behind it.
+    [ "$(live_entry_count)" -gt 0 ] \
+        || skip "whitelist has no live entries; nothing to suppress on this diff"
     run oasdiff breaking "$BASE_SPEC" "$REPO_ROOT/api.yaml" --fail-on ERR
     [ "$status" -eq 1 ]
 }

--- a/scripts/__tests__/check-breaking-changes.test.sh
+++ b/scripts/__tests__/check-breaking-changes.test.sh
@@ -37,10 +37,8 @@ teardown() {
     # Guards against a stray blank-ish or prose line that silently matches
     # nothing. Entries must name a method + path.
     while IFS= read -r line; do
-        [[ "$line" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "${line//[[:space:]]/}" ]] && continue
         [[ "$line" =~ ^(get|post|put|patch|delete)\ /.+ ]]
-    done < "$IGNORE_FILE"
+    done < <(live_entries)
 }
 
 # The original defect: `--err-ignore` args were held in an array and expanded as
@@ -93,15 +91,21 @@ teardown() {
 # --- the whitelist actually suppressing something ---
 #
 # Every test above either exits at preflight or takes the identical-specs fast
-# path at the top of the script, so none of them reaches oasdiff. The two below
+# path at the top of the script, so none of them reaches oasdiff. The ones below
 # are the only end-to-end coverage: they run a real diff (origin/main..HEAD)
-# through the real flag, and they are written as a pair so that neither can pass
-# for the wrong reason. If the whitelist stops matching — a typo, an oasdiff
-# release that rewords a finding — the first goes red. If the whitelist starts
-# matching things it shouldn't, the second goes red and the first becomes
-# vacuous. The pair only has something to say while the whitelist carries a
-# live entry; with an empty whitelist the second skips (see below), because
-# "this diff is breaking" is a claim about the entries, not about api.yaml.
+# through the real flag.
+#
+# They express the invariant directly — "the whitelist only ever removes
+# findings" — rather than via the whitelist's entry count. An earlier pair
+# asserted "this diff is breaking without the whitelist", which read as a claim
+# about the entries but was written as a claim about api.yaml: unconditional, it
+# demanded that *every* api.yaml PR be breaking, so the first description-only
+# change went red with no defect behind it. Guarding that with an entry count
+# fixed the false red but bought a test that skips on main's steady state (an
+# empty whitelist), in the one suite whose CI wiring exists precisely to stop
+# tests skipping themselves — and bats reports a skip as `ok`, so the suite
+# would have read green while asserting nothing. The subset formulation needs
+# neither the skip nor a parser for the file's syntax.
 
 setup_base() {
     command -v oasdiff > /dev/null || skip "oasdiff not installed"
@@ -113,19 +117,40 @@ setup_base() {
     fi
 }
 
-# Count the whitelist's live entries — every line that is neither a comment nor
-# blank. Zero is a legitimate steady state (the file's own header calls an
-# entry-free file of comments the floor), and it is what the file looks like
-# between the merge of one suppressed change and the next one that needs a
-# suppression.
-live_entry_count() {
-    local count=0 line
-    while IFS= read -r line; do
+# The whitelist's live entries — every line that is neither a comment nor blank.
+# Single definition: the format check, the staleness check and any future reader
+# all go through here, so the entry syntax is described in exactly one place.
+#
+# The `|| [[ -n "$line" ]]` is load-bearing, not defensive. A bare `read` returns
+# non-zero on a final line with no trailing newline and the loop body never runs
+# for it, so an entry pasted in as the last line — routine, since entries are
+# pasted verbatim from oasdiff output — was invisible to every check here while
+# oasdiff itself (Go, bufio.Scanner) still honoured it. That is the worst
+# direction for the bug to run: a live, silently unguarded suppression.
+live_entries() {
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
         [[ -z "${line//[[:space:]]/}" ]] && continue
-        count=$((count + 1))
+        printf '%s\n' "$line"
     done < "$IGNORE_FILE"
-    echo "$count"
+}
+
+@test "live_entries sees a final entry that has no trailing newline" {
+    # Regression guard. Entries are pasted verbatim from oasdiff output, which
+    # is exactly how a file ends up without a terminating newline. A bare
+    # `while read` drops that last line, so the entry would be honoured by
+    # oasdiff and invisible to every check in this file at once.
+    local saved="$IGNORE_FILE"
+    IGNORE_FILE="$TEST_TEMP_DIR/no-trailing-newline.txt"
+    printf '# a comment\n\npost /api/v1/x the response property `y` became nullable for the status `200`' \
+        > "$IGNORE_FILE"
+
+    run live_entries
+    IGNORE_FILE="$saved"
+
+    [ "${#lines[@]}" -eq 1 ]
+    [[ "${lines[0]}" == post\ /api/v1/x* ]]
 }
 
 @test "the script exits 0 on the current diff, i.e. the whitelist entries match" {
@@ -135,39 +160,52 @@ live_entry_count() {
     [[ "$output" == *"No breaking changes detected"* ]]
 }
 
-@test "the same diff is genuinely breaking without the whitelist" {
-    # Proves the previous test is suppressing real ERR findings rather than
-    # passing because the diff happens to be clean.
+@test "the whitelist only ever removes findings, never adds or rewrites them" {
+    # Non-vacuous at every whitelist size, so it never skips. With entries, it
+    # proves they suppress real findings rather than inventing suppression;
+    # with none, both runs agree and it still exercises the full oasdiff path.
+    # An over-broad or malformed entry that made oasdiff report something new
+    # fails here.
     setup_base
-    # ...but only when there is something to suppress. An empty whitelist has
-    # nothing to prove, and a PR that edits api.yaml without breaking anything
-    # (a description fix, say) is the ordinary case, not a suspicious one. Left
-    # unconditional, this assertion demanded that every api.yaml PR be breaking
-    # — the exact inversion of what the gate is for, and a red CI job with no
-    # actionable defect behind it.
-    [ "$(live_entry_count)" -gt 0 ] \
-        || skip "whitelist has no live entries; nothing to suppress on this diff"
-    run oasdiff breaking "$BASE_SPEC" "$REPO_ROOT/api.yaml" --fail-on ERR
-    [ "$status" -eq 1 ]
+    run oasdiff breaking "$BASE_SPEC" "$REPO_ROOT/api.yaml" -f json
+    [ "$status" -eq 0 ]
+    local unignored="$output"
+    run oasdiff breaking "$BASE_SPEC" "$REPO_ROOT/api.yaml" -f json --err-ignore "$IGNORE_FILE"
+    [ "$status" -eq 0 ]
+    local ignored="$output"
+
+    python3 - "$unignored" "$ignored" <<'PY'
+import json, sys
+key = lambda f: (f.get("id"), f.get("operation"), f.get("path"), f.get("text"))
+before = {key(f) for f in json.loads(sys.argv[1] or "[]")}
+after = {key(f) for f in json.loads(sys.argv[2] or "[]")}
+added = after - before
+if added:
+    print("whitelist introduced findings that oasdiff does not report without it:")
+    for f in sorted(map(str, added)):
+        print("  " + f)
+    sys.exit(1)
+PY
 }
 
 @test "every whitelist entry corresponds to a finding in the current diff" {
     # The file's own rule is that entries are diff-scoped and dead ones get
     # pruned. This fails when an entry outlives the change it was written for.
+    # Correctly vacuous at zero entries: it quantifies over entries, and there
+    # are none. The test above is what stays non-vacuous in that state.
     setup_base
     run oasdiff breaking "$BASE_SPEC" "$REPO_ROOT/api.yaml" --fail-on ERR
+    local findings="$output" line message
     while IFS= read -r line; do
-        [[ "$line" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "${line//[[:space:]]/}" ]] && continue
         # Strip the leading "<method> <path> " to get the message text.
         message="${line#* }"
         message="${message#* }"
-        [[ "$output" == *"$message"* ]] || {
+        [[ "$findings" == *"$message"* ]] || {
             echo "stale whitelist entry, matches nothing in the diff:"
             echo "  $line"
             return 1
         }
-    done < "$IGNORE_FILE"
+    done < <(live_entries)
 }
 
 @test "a non-breaking oasdiff failure is not reported as a breaking change" {

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -21,10 +21,15 @@ interface OpenAPISpec {
 
 describe('OpenAPI Specification', () => {
   let spec: OpenAPISpec;
+  // Raw source alongside the parsed tree, for assertions that must hold across
+  // the whole document rather than inside one schema — e.g. a false citation
+  // that could be copy-pasted into any description.
+  let specText: string;
 
   beforeAll(() => {
     const specPath = join(__dirname, '..', 'api.yaml');
     const content = readFileSync(specPath, 'utf-8');
+    specText = content;
     spec = parse(content) as OpenAPISpec;
   });
 
@@ -2354,16 +2359,27 @@ describe('OpenAPI Specification', () => {
       //
       // Pin the fact (no clause anywhere asserts #271 closed), not a phrasing.
       // The description is free to cite #271 accurately, or to leave it out
-      // entirely; either passes. The clause bound (`[^.;]`) keeps a correct
-      // adjacent sentence about BS#792 closing from tripping this.
+      // entirely; either passes.
+      //
+      // Scope is the whole spec text, not one schema's description. The false
+      // attribution is copy-paste-shaped — the same feature is discussed in
+      // BulkResolveResult, BulkResolveProvenanceEntry and the operation
+      // description, all of which already cite LML#1021 — and a guard that
+      // reads one schema would watch it reappear anywhere else in silence.
+      //
+      // Proximity is measured in words rather than with a `[^.;]*` clause
+      // bound. This description is saturated with periods that are not
+      // sentence ends (`1.29.0`, `https://github.com/...`), so a dot-excluding
+      // bound stops early and misses exactly the citation-carried-forward
+      // wording that caused the defect — e.g. "#271 (as of `1.29.0`) closed as
+      // a design decision".
+      const nearbyClosure = /library-metadata-lookup#271(?:\W+\w+){0,12}\W+\bclos(?:e|ed|es|ing|ure)\b/i;
+      const nearbyClosureBefore = /\bclos(?:e|ed|es|ing|ure)\b(?:\W+\w+){0,12}\W+library-metadata-lookup#271/i;
+      expect(specText).not.toMatch(nearbyClosure);
+      expect(specText).not.toMatch(nearbyClosureBefore);
+
       const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
       const description = schema.description ?? '';
-      expect(description).not.toMatch(
-        /library-metadata-lookup#271[^.;]*\bclos(?:ed|ure|es)\b/i,
-      );
-      expect(description).not.toMatch(
-        /\bclos(?:ed|ure|es)\b[^.;]*library-metadata-lookup#271/i,
-      );
       // The retraction's evidence has to survive the citation fix: the "never
       // built" claim rests entirely on the BS#801 comment that measured prod
       // and all 136 migrations. Losing the permalink would leave an
@@ -2371,6 +2387,13 @@ describe('OpenAPI Specification', () => {
       expect(description).toContain(
         'Backend-Service/issues/801#issuecomment-5187348795',
       );
+      // And the positive half of the correction: the ticket that actually
+      // closed as a design decision has to be named, or the withdrawn 1.29.0
+      // instruction stops being traceable. Without this, deleting the BS#792
+      // attribution and writing "the ticket that would have created it closed
+      // as a design decision" passes every assertion above while losing the
+      // fact the fix exists to record.
+      expect(description).toMatch(/Backend-Service#792/);
     });
 
     // --- the four states have to be legible from the example, not just the prose ---

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -2312,12 +2312,13 @@ describe('OpenAPI Specification', () => {
 
     it('drops the storage instruction naming a table that was never built (BS#801)', () => {
       // 1.29.0 told Backend to write per-source rows verbatim into a
-      // `library_track_identity_source` sidecar. It does not exist — LML#271
-      // closed as a design decision and the schema half never happened
-      // (verified against prod and all 136 migrations in BS#801). LML's
-      // per-track store is the per-source system of record and Backend
-      // persists composed verdicts only, so the contract must not send a
-      // consumer off to build the sidecar.
+      // `library_track_identity_source` sidecar. It does not exist — BS#792,
+      // the Backend-side design ticket that would have created it, closed as
+      // a design decision and the schema half never happened (verified
+      // against prod and all 136 migrations in BS#801). LML's per-track
+      // store is the per-source system of record and Backend persists
+      // composed verdicts only, so the contract must not send a consumer off
+      // to build the sidecar.
       // The table name still appears, but only inside its own retraction —
       // a reader migrating off 1.29.0 needs to be told the sidecar isn't
       // coming, not left to infer it from silence.
@@ -2339,6 +2340,37 @@ describe('OpenAPI Specification', () => {
       for (const sentence of sentencesNamingTheTable) {
         expect(sentence).toMatch(/never built|not built|no such table/i);
       }
+    });
+
+    it('never states that LML#271 is closed — it is open, and BS#792 is the ticket that closed', () => {
+      // 1.29.0 cited WXYC/library-metadata-lookup#271 as the design behind the
+      // `library_track_identity_source` sidecar, and the retraction that
+      // replaced it carried that citation forward as "#271 closed as a design
+      // decision". #271 is OPEN: it is LML's own per-track identity work,
+      // still being implemented under LML#1021. The ticket that closed as a
+      // design decision without ever growing its schema half is
+      // WXYC/Backend-Service#792 — which is what the cited BS#801 comment
+      // actually says.
+      //
+      // Pin the fact (no clause anywhere asserts #271 closed), not a phrasing.
+      // The description is free to cite #271 accurately, or to leave it out
+      // entirely; either passes. The clause bound (`[^.;]`) keeps a correct
+      // adjacent sentence about BS#792 closing from tripping this.
+      const schema = spec.components.schemas.BulkResolveTrackIdentity as Schema;
+      const description = schema.description ?? '';
+      expect(description).not.toMatch(
+        /library-metadata-lookup#271[^.;]*\bclos(?:ed|ure|es)\b/i,
+      );
+      expect(description).not.toMatch(
+        /\bclos(?:ed|ure|es)\b[^.;]*library-metadata-lookup#271/i,
+      );
+      // The retraction's evidence has to survive the citation fix: the "never
+      // built" claim rests entirely on the BS#801 comment that measured prod
+      // and all 136 migrations. Losing the permalink would leave an
+      // unsourced assertion about a table nobody can check.
+      expect(description).toContain(
+        'Backend-Service/issues/801#issuecomment-5187348795',
+      );
     });
 
     // --- the four states have to be legible from the example, not just the prose ---

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -53,6 +53,38 @@ describe("codegen output paths (#197)", () => {
   });
 });
 
+// `generated/python/` is gitignored and imported by nothing, here or anywhere
+// in the org: both Python consumers run their own copy of
+// `scripts/generate_api_models.sh` against `api.yaml` and commit
+// `generated/api_models.py` in their own repo. CLAUDE.md's consumer table said
+// otherwise, which is how #302 nearly landed a `--strict-nullable` fix in
+// `package.json` alone and changed nothing for either consumer.
+describe("CLAUDE.md's codegen consumer table (#302)", () => {
+  const claudeMd = readFileSync(join(__dirname, "..", "CLAUDE.md"), "utf-8");
+
+  /** The `| generate:python | ... |` row of the "Output locations and consumers" table. */
+  const pythonRow = () => {
+    const row = claudeMd
+      .split("\n")
+      .find((line) => /^\|\s*`generate:python`\s*\|/.test(line));
+    expect(row, "generate:python row missing from the consumer table").toBeDefined();
+    return row as string;
+  };
+
+  it("does not name either Python service as a consumer of generated/python/", () => {
+    // The fact, not a phrasing: whatever the row says, it must not send a
+    // reader to change this repo's output expecting a consumer to see it.
+    expect(pythonRow()).not.toMatch(/request-o-matic|library-metadata-lookup/);
+  });
+
+  it("points at the script the Python consumers actually run", () => {
+    // A reader who learns the table row is empty still needs to know where
+    // Python models do come from, or the correction just relocates the
+    // confusion.
+    expect(claudeMd).toContain("scripts/generate_api_models.sh");
+  });
+});
+
 // A property carrying an OpenAPI `default` is emitted non-optional by
 // openapi-typescript (its `defaultNonNullable` option, on by default) even when
 // the property is absent from `required`. That reasoning holds for a response —

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -85,6 +85,35 @@ describe("CLAUDE.md's codegen consumer table (#302)", () => {
   });
 });
 
+// The same claim lived in README.md's Contributing checklist, where a
+// contributor is more likely to meet it than in CLAUDE.md's reference table —
+// and a guard that reads only CLAUDE.md leaves the more-trafficked copy
+// unguarded. Both files are checked here for the same reason: the belief that
+// `generate:python` feeds a consumer is what scoped #302 wrong, and it does not
+// matter which document plants it.
+describe("no doc claims generate:python feeds a consumer (#302, #304)", () => {
+  const docs = ["CLAUDE.md", "README.md"] as const;
+
+  it.each(docs)("%s does not tell the reader to regenerate for a Python service", (doc) => {
+    const text = readFileSync(join(__dirname, "..", doc), "utf-8");
+    // Pin the misleading *instruction*, not co-occurrence. Naming the two
+    // services near `generate:python` is fine and in fact necessary — the
+    // corrected CLAUDE.md paragraph does exactly that to explain where the
+    // models really come from. (This repo writes each paragraph as one long
+    // line, so a co-occurrence filter flags whole explanatory paragraphs.)
+    // What must not survive is a sentence telling the reader that running this
+    // script updates models a Python service uses.
+    const claimsItFeedsAConsumer = [
+      /Python services consume/i,
+      /generate:python`?\s*(?:\S+\s+){0,6}?to update the generated Python models/i,
+    ];
+    const offending = text
+      .split("\n")
+      .filter((line) => claimsItFeedsAConsumer.some((re) => re.test(line)));
+    expect(offending, `${doc} still ties generate:python to a consumer`).toEqual([]);
+  });
+});
+
 // A property carrying an OpenAPI `default` is emitted non-optional by
 // openapi-typescript (its `defaultNonNullable` option, on by default) even when
 // the property is absent from `required`. That reasoning holds for a response —


### PR DESCRIPTION
Closes #304.

Two false statements in this repo's documentation, plus the CI guard that reddens on any `api.yaml` edit and therefore had to be handled in the same PR. No schema, endpoint, field, or generated artifact changes; nothing on the wire moves.

## 1. `api.yaml` said WXYC/library-metadata-lookup#271 closed. It is open.

`BulkResolveTrackIdentity`'s description carried "WXYC/library-metadata-lookup#271 closed as a design decision and the schema half never happened". #271 is **open** — "[V/A] Compilation track identity support in bulk-resolve-libraries", LML's own per-track identity work, still being implemented under WXYC/library-metadata-lookup#1021, which is the consumer this schema exists to serve. A reader sent there to confirm a retraction gets a live feature ticket.

The ticket that closed as a design decision without ever growing its schema half is **WXYC/Backend-Service#792** ("[E2] Compilations / Various Artists treatment under `library_identity` (§3.2 design decision)", closed 2026-05-10). That is what the already-cited [BS#801 comment](https://github.com/WXYC/Backend-Service/issues/801#issuecomment-5187348795) says in as many words: "#792 is titled '(§3.2 design decision)' and closed as exactly that; the schema half of step 1 never happened." #271's own body says the same, and has already been struck through on that point.

Origin of the error: `1.29.0` cited #271 for a *different* claim — that Backend writes per-source rows into `library_track_identity_source` "per #271's design". The retraction in 86f7edd correctly withdrew the instruction but carried the citation forward and grafted #792's closure onto it. One transposed reference, not a wrong conclusion.

**What did not change.** The load-bearing claim — `library_track_identity_source` was never built — is true and its BS#801 permalink still supports it (re-verified: the comment resolves and says what it is cited for). The retraction keeps its shape, naming the dead table inside its own withdrawal so a reader migrating off `1.29.0` is told the sidecar isn't coming rather than inferring it from silence. #271 is now named accurately (open, LML-side, not Backend storage) so the withdrawn instruction stays traceable.

## 2. CLAUDE.md named consumers for `generated/python/` that don't exist

The "Output locations and consumers" table listed request-o-matic and library-metadata-lookup against `generated/python/`. Neither reads it — the directory is gitignored, and grepping every WXYC clone for `generated/python` returns hits only inside this repo. Both services run their own copy of `scripts/generate_api_models.sh` against `api.yaml` and commit `generated/api_models.py` in their own tree.

This is the documentation half of a finding #302 made from the other direction: its "Scope correction" section exists because `--strict-nullable` has to land in all three invocations, since fixing only `package.json` "changes nothing for any consumer". The table was the document that would have told an implementer otherwise.

The correction also records the pin divergence, which is a consequence of the same fact rather than trivia — LML pins `datamodel-code-generator[http]==0.56.1`, request-o-matic pins `datamodel-code-generator==0.57.0` in `requirements-dev.txt`, and this repo pins nothing, so output generated here isn't comparable with a consumer's committed models unless you match their version first. The Python codegen section's "it needs its own ticket" is stale now that the ticket exists, and points at #302.

## 3. `test:breaking-guard` reddened on any `api.yaml` edit (pre-existing)

Not part of the two errors, but a fix for either trips it, so it lands here.

The suite's three end-to-end tests skip while `api.yaml` matches `origin/main` — which is why `main` is green and why this was invisible. Editing the spec wakes them up, and two failed:

- **stale whitelist.** Both `oasdiff-err-ignore.txt` entries were written for #297, which shipped in 1.30.0. Their changes are now in the base *and* the head, so oasdiff reports neither and "every whitelist entry corresponds to a finding in the current diff" fails. Entries are diff-scoped; pruned per the file's own rule, header comments kept (the file calls an entry-free file of comments the floor).
- **"the same diff is genuinely breaking without the whitelist"** asserted `oasdiff breaking` exits 1 unconditionally. Its job is to stop its partner test from passing vacuously, but as written it demanded that *every* `api.yaml` PR be breaking — the inversion of what the gate is for. It now skips when the whitelist has no live entries, because "this diff is breaking" is a claim about the entries, not about `api.yaml`. With an entry present the pair behaves exactly as before: the entry must match a finding, and the finding must be real.

## Version decision: no `info.version` bump

`api.yaml` stays at `1.30.0` and its pinning test is untouched.

Repo precedent is unambiguous. Across the last 60 commits touching `api.yaml`, every prose-only `docs(api):` commit left `info.version` alone: 86f7edd (the commit that introduced the very sentence being corrected here), 19fdd6f, 40ce0f7, 8ddecf0, 3368e4d, 0fd2cdf, cdf90d7, 01dfaf2. Every commit that *did* bump it changed the wire — a new field, a new endpoint, a nullability change.

That split is the right one on the merits too. `@wxyc/shared@3.4.0` published `1.30.0` minutes ago; bumping to `1.30.1` for a corrected issue number would tell every consumer that gates on `info.version` that the contract moved when nothing generated from it changes by a byte. The TypeScript output is identical before and after — verified by regenerating.

## TDD

Red first, in all three cases:

- `tests/api-spec.test.ts` — a new assertion that **no clause, in either order, asserts #271 closed**, plus one that the BS#801 permalink survives so the "never built" claim keeps its source. Deliberately fact-shaped, not phrase-shaped: the description stays free to cite #271 accurately or drop it entirely, and both pass. The neighbouring retraction guard was already rewritten once away from a brittle `toHaveLength(1)` sentence count that went red on a harmless rewording — no sentence-count or exact-prose pinning is reintroduced here. (Its stale comment, which repeated the same false claim about #271, is corrected too.)
- `tests/codegen-output-paths.test.ts` — the `generate:python` row may not name either Python service, *and* CLAUDE.md must still name `scripts/generate_api_models.sh`, so the correction can't degrade into a blank cell that just relocates the confusion.
- The breaking-guard failures were themselves the failing tests.

## Local gate

All green on `3919fb0`:

```
npm run generate:typescript && npm run build && npm run lint && npm run lint:e2e && npm test   # 626 passed (15 files)
npm run test:breaking-guard      # 13 ok, 0 failures
npm run test:setup-script        # 0 failures
npm run check:breaking           # no breaking changes detected
```

`npm run test:drift-guard` is not run: it fails on `main` for an unrelated, already-ticketed reason (#301) and is deliberately absent from `ci.yml` for that reason.

## Related

- #302 — independently established that `generated/python/` has no consumers; remains the tracked fix for the `--strict-nullable` flag itself. This PR only corrects the documentation.
- #297 — shipped 1.30.0 and the current `BulkResolveTrackIdentity` shape; source of the two pruned whitelist entries.
- WXYC/library-metadata-lookup#271 (open), WXYC/library-metadata-lookup#1021, WXYC/Backend-Service#792 (closed), WXYC/Backend-Service#801.
- #301 — the unrelated `test:drift-guard` failure on `main`.
