### PR TITLE
fix(scripts): correct stale PINNED_SHA256 in drift-guard bats suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,15 +72,11 @@ jobs:
       # runnable-but-unrun until now: a regression in check-breaking-changes.sh
       # merged green here and surfaced later as an unexplained red
       # breaking-changes job on someone else's PR.
-      #
-      # test:drift-guard is deliberately absent: tests 4 and 5 in
-      # check-corpus-drift.test.sh fail on main today, untouched by this PR.
-      # Wiring it in would redden CI for an unrelated reason; it gets its own
-      # fix and then its own line here.
       - name: Shell script guards
         run: |
           npm run test:breaking-guard
           npm run test:setup-script
+          npm run test:drift-guard
 
       # Cross-service contract suite (see INVARIANTS.md, src/contracts.ts).
       # When $E2E_BASE_URL is unset, every test in the file is `skipIf`-ed

--- a/scripts/__tests__/check-corpus-drift.test.sh
+++ b/scripts/__tests__/check-corpus-drift.test.sh
@@ -12,7 +12,7 @@ CORPUS_PATH="$REPO_ROOT/src/test-utils/charset-torture.json"
 
 # Pinned hash of the in-tree corpus. Bumped in lockstep with the test in
 # tests/charset-torture.test.ts.
-PINNED_SHA256='75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a'
+PINNED_SHA256='41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66'
 
 setup() {
     TEST_TEMP_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Closes #301

`scripts/__tests__/check-corpus-drift.test.sh:15` pinned `75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a`, the pre-`cc3002f` hash of `src/test-utils/charset-torture.json`. That commit (2026-05-05, "corpus: NFC storage form + populate bidi_marks match form (v0.12.0)") bumped the pin in three other places — `tests/charset-torture.test.ts`, `README.md`, and the doc comment in `.github/workflows/check-charset-corpus-drift.yml` — but missed this file, because the bats suite has never run in CI (it was runnable-but-unrun since it was written, and PR #300 explicitly excluded it when wiring the other two bats suites into `ci.yml`).

Root cause confirmed independently rather than trusting the ticket's stated value:

```
$ shasum -a 256 src/test-utils/charset-torture.json
41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66  src/test-utils/charset-torture.json
```

This matches the other three pin sites and the value #301 identifies as correct.

## Changes

- `scripts/__tests__/check-corpus-drift.test.sh` — corrected `PINNED_SHA256` to `41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66`.
- `.github/workflows/ci.yml` — added `npm run test:drift-guard` to the "Shell script guards" step and removed the now-obsolete four-line comment explaining its exclusion. The surrounding paragraph about the bats suites having been runnable-but-unrun is left as-is; that history is still accurate.

`src/test-utils/charset-torture.json` and `.github/workflows/check-charset-corpus-drift.yml` are both untouched, per the ticket. Per the repo's tag stability policy, neither the bats test nor `ci.yml` is part of the `workflow_call` contract, so there's no `gha/v1` re-point and no `gha/v2` cut here — #301 verified all org consumers are unaffected (the published workflow path never reads the bats file).

## Test plan

- [x] `npm run test:drift-guard` reproduced red before the fix (tests 4 and 5 failed for the expected reason: script correctly reports drift/exits against the stale pin).
- [x] `npm run test:drift-guard` now reports 7 tests, 0 failures.
- [x] `npm run generate:typescript`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run lint:e2e`
- [x] `npm test` (628 passed)
- [x] `npm run test:breaking-guard` (14 passed)
- [x] `npm run test:setup-script` (45 passed)

## Follow-up (not in scope here)

#301 notes the pin is now written down in four places (bats test, TS test, README, workflow doc comment) and that this bug is what that duplication produces. Collapsing them onto a single source of truth (e.g. a checked-in `charset-torture.json.sha256` the other three read or are checked against) would remove the failure mode rather than just detect it — worth its own ticket if it looks like more than a small diff.