### PR TITLE
feat(api): tracks_contract_version marker + define the tracks_attempted(false)+populated-tracks reading

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -4183,6 +4183,13 @@ components:
     #                          leg ran" convention as
     #                          `BulkResolveProvenanceEntry.external_id`.
     #
+    # `false` alongside a populated `tracks` is not a fifth state;
+    # producers must not emit it. A consumer that observes it anyway
+    # MUST read it as `true` — the populated array is stronger evidence
+    # of what happened than the flag that disagrees with it, and reading
+    # the row as unattempted would either drop already-resolved tracks
+    # or re-ask a row that already has an answer (WXYC/wxyc-shared#303).
+    #
     # The resolved signal is `tracks_attempted`, not the array's length.
     # Those middle two states are byte-identical in `tracks`, so a consumer
     # reading emptiness as "not visited" re-asks every trackless row on
@@ -4196,10 +4203,16 @@ components:
     # (absent, absent) state identically to a producer that understands the
     # flag and genuinely has nothing to report — both are `null` either way.
     # `BulkResolveLibrariesResponse.tracks_contract_version` is the
-    # response-level marker that separates them: present and equal to 1 only
-    # when the producer understood `include_tracks`, absent otherwise. See
-    # that field, and WXYC/wxyc-shared#303 for why the pair alone can't do
-    # this.
+    # response-level marker that separates them, and it only speaks to a
+    # request that set `include_tracks: true`: present and equal to 1 only
+    # then, when the producer also understood the flag. Absent otherwise —
+    # which covers both the predates-the-flag case above AND the ordinary,
+    # expected response from a fully-upgraded producer to a request where
+    # `include_tracks` was false or omitted. The marker is not a general
+    # "is this producer current" probe; probing it on an ordinary
+    # `include_tracks: false` call and reading the absence as "old
+    # producer" is the exact misreading it exists to prevent. See that
+    # field, and WXYC/wxyc-shared#303 for why the pair alone can't do this.
 
     BulkResolveLibrariesRequest:
       type: object
@@ -8671,7 +8684,11 @@ paths:
         ran off `BulkResolveResult.tracks_attempted`, never off
         `tracks.length`: a row the matcher visited and resolved nothing
         for carries an empty array, indistinguishable from one it has
-        not reached.
+        not reached. `tracks_attempted: false` alongside a populated
+        `tracks` is not a state producers may emit; a consumer that
+        observes it anyway MUST read it as `true` rather than dropping
+        the already-resolved entries or re-asking a row that already has
+        an answer.
 
 
         During the rollout window before every producer implements this
@@ -8679,7 +8696,13 @@ paths:
         is the signal that separates "the producer understood
         `include_tracks` and this batch genuinely has nothing to report"
         from "the producer predates the flag" — both read identically on
-        `tracks_attempted`/`tracks` alone (WXYC/wxyc-shared#303).
+        `tracks_attempted`/`tracks` alone (WXYC/wxyc-shared#303). The
+        marker only speaks to a request that set `include_tracks: true`:
+        it is present and equal to 1 only then, when the producer also
+        understood the flag. It is absent, and normally absent, on the
+        ordinary request where `include_tracks` was false or omitted —
+        that absence is the expected response from a fully-upgraded
+        producer too, not evidence the producer predates the flag.
       security:
         - LMLBearerAuth: []
       tags:

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.30.0
+  version: 1.31.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -4189,6 +4189,17 @@ components:
     # every pass, forever — the pathology `kind: "unresolved"` was made a
     # first-class outcome to prevent, reintroduced one grain down
     # (WXYC/Backend-Service#1991 / LML#1021).
+    #
+    # For the rollout window before every producer implements this contract,
+    # the PAIR has a second ambiguity the four states above don't cover: a
+    # producer that predates `include_tracks` entirely spells the
+    # (absent, absent) state identically to a producer that understands the
+    # flag and genuinely has nothing to report — both are `null` either way.
+    # `BulkResolveLibrariesResponse.tracks_contract_version` is the
+    # response-level marker that separates them: present and equal to 1 only
+    # when the producer understood `include_tracks`, absent otherwise. See
+    # that field, and WXYC/wxyc-shared#303 for why the pair alone can't do
+    # this.
 
     BulkResolveLibrariesRequest:
       type: object
@@ -4538,7 +4549,13 @@ components:
             resolved nothing;
             **`true` with a populated `tracks`** — the matcher ran and
             produced entries. `false` alongside a populated `tracks` is
-            not a state; producers must not emit it.
+            not a state; producers must not emit it. A consumer that
+            observes `tracks_attempted: false` alongside a populated
+            `tracks` anyway MUST read it as `true` — the populated array
+            is stronger evidence of what happened than the flag that
+            disagrees with it, and reading the row as unattempted would
+            either drop already-resolved tracks or re-ask a row that
+            already has an answer (WXYC/wxyc-shared#303).
 
 
             The middle two are what this field exists for. They are
@@ -4596,10 +4613,14 @@ components:
         `method`/`confidence`
         pairs in the example sit inside `IdentityMethod`'s locked bands —
         Backend's writer rejects rows that don't, so an example that
-        violated them would hand LML#1021 an unwritable row to copy.
+        violated them would hand LML#1021 an unwritable row to copy. The
+        example also carries `tracks_contract_version: 1`, echoing that the
+        producer that emitted it understood `include_tracks`; see that
+        field for the rollout-window ambiguity it exists to resolve.
       required:
         - results
       example:
+        tracks_contract_version: 1
         results:
           - kind: single_artist
             library_id: 1234
@@ -4705,6 +4726,26 @@ components:
             tracks_attempted: null
             tracks: null
       properties:
+        tracks_contract_version:
+          type: integer
+          enum:
+            - 1
+          description: >
+            Present and equal to 1 only when the request set
+            `include_tracks: true` and the producer understands the flag.
+            Absent otherwise — both when `include_tracks` was false or
+            omitted, and when the producer predates this field entirely
+            and does not implement `include_tracks` at all. Same
+            precedent as `LookupResponse.api_version`
+            (`LookupRequest.include_identity`): a producer-echoed
+            capability marker that lets a consumer distinguish "the
+            producer understood my flag and the answer is genuinely
+            nothing" from "the producer predates my flag" — a
+            distinction `tracks_attempted`/`tracks` cannot make alone,
+            because both are spelled `null` in either case
+            (WXYC/wxyc-shared#303). No schema-level `default`, for the
+            same `openapi-typescript` `defaultNonNullable` reason
+            documented on `BulkResolveLibrariesRequest.include_tracks`.
         results:
           type: array
           items:
@@ -8631,6 +8672,14 @@ paths:
         `tracks.length`: a row the matcher visited and resolved nothing
         for carries an empty array, indistinguishable from one it has
         not reached.
+
+
+        During the rollout window before every producer implements this
+        contract, `BulkResolveLibrariesResponse.tracks_contract_version`
+        is the signal that separates "the producer understood
+        `include_tracks` and this batch genuinely has nothing to report"
+        from "the producer predates the flag" — both read identically on
+        `tracks_attempted`/`tracks` alone (WXYC/wxyc-shared#303).
       security:
         - LMLBearerAuth: []
       tags:

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -2304,6 +2304,61 @@ describe('OpenAPI Specification', () => {
       expect(opBlock).toMatch(/tracks_contract_version/);
     });
 
+    // The `tracks_contract_version.description` states the marker's full
+    // precondition: present only when the request set `include_tracks: true`
+    // AND the producer understood it; absent otherwise, and "otherwise"
+    // explicitly includes the ordinary `include_tracks: false`-or-omitted
+    // request from a fully-upgraded producer, not only the predates-the-flag
+    // case. A reader who works only from the four-state block comment or the
+    // endpoint description — not the property description three schemas
+    // away — has to learn the same precondition, or an ordinary
+    // `include_tracks: false` call reads as "this producer predates the
+    // flag" against a fully-upgraded LML.
+
+    it('states the include_tracks: true precondition for tracks_contract_version in the four-state block comment, not just that the marker exists', () => {
+      const commentBlock = specText.slice(
+        specText.indexOf('# Four states, read off the PAIR'),
+        specText.indexOf('BulkResolveLibrariesRequest:'),
+      );
+      expect(commentBlock).toMatch(/include_tracks: true/);
+      expect(commentBlock).toMatch(/false or omitted/i);
+    });
+
+    it('states the include_tracks: true precondition for tracks_contract_version in the bulk-resolve-libraries endpoint description too', () => {
+      const opBlock = specText.slice(
+        specText.indexOf('/api/v1/identity/bulk-resolve-libraries:'),
+        specText.indexOf('/api/v1/artists/search-aliases/bulk:'),
+      );
+      expect(opBlock).toMatch(/include_tracks: true/);
+      expect(opBlock).toMatch(/false or omitted/i);
+    });
+
+    // The Q2 MUST rule (`tracks_attempted: false` + populated `tracks` reads
+    // as `true`) was added only to the tracks_attempted property description
+    // in this PR's first pass. The four-state block comment is the canonical
+    // table an implementer works from ("Four states, read off the PAIR"), and
+    // the endpoint description is the other prose surface a Backend-Service
+    // implementer reads before ever opening the schema — both need the same
+    // repaired reading, or an implementer working from either one reproduces
+    // the un-repaired retry loop the mitigation exists to make survivable.
+
+    it('adds the #303 Q2 consumer reading to the four-state block comment', () => {
+      const commentBlock = specText.slice(
+        specText.indexOf('# Four states, read off the PAIR'),
+        specText.indexOf('BulkResolveLibrariesRequest:'),
+      );
+      expect(commentBlock).toMatch(/producers must not emit it/);
+      expect(commentBlock).toMatch(/MUST read it as `true`/);
+    });
+
+    it('adds the #303 Q2 consumer reading to the bulk-resolve-libraries endpoint description', () => {
+      const opBlock = specText.slice(
+        specText.indexOf('/api/v1/identity/bulk-resolve-libraries:'),
+        specText.indexOf('/api/v1/artists/search-aliases/bulk:'),
+      );
+      expect(opBlock).toMatch(/MUST read it as `true`/);
+    });
+
     // --- BulkResolveTrackIdentity repair (BS#1991 / LML#1021) ---
 
     it('ships the join-back echoes, composed verdict, and canonical artist on BulkResolveTrackIdentity', () => {

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -50,7 +50,7 @@ describe('OpenAPI Specification', () => {
     // move filed the assertion under a ticket that didn't bump anything. It
     // lives here permanently now; update the literal, leave the location.
     it('pins info.version to the released contract version', () => {
-      expect(spec.info.version).toBe('1.30.0');
+      expect(spec.info.version).toBe('1.31.0');
     });
 
     it('should have components section', () => {
@@ -2216,6 +2216,94 @@ describe('OpenAPI Specification', () => {
       expect(description).toMatch(/tracks_attempted/);
     });
 
+    // --- #303 Q2: the forbidden (false, populated tracks) pairing gets a
+    // defined consumer reading instead of staying merely prohibited ---
+    //
+    // The schema cannot enforce that a producer never emits `false` alongside
+    // a populated `tracks` — both are independent optional properties, no
+    // oneOf/dependentRequired. Mitigation (2) from #303: keep the "producers
+    // must not emit it" prohibition, and additionally define what a consumer
+    // does if a producer bug emits it anyway, so the violation is survivable
+    // rather than undefined behavior on the pairing that gates a retry loop.
+
+    it('keeps the existing "producers must not emit it" prohibition on tracks_attempted', () => {
+      const schema = spec.components.schemas.BulkResolveResult as Schema;
+      const description = (schema.properties?.tracks_attempted?.description as string) ?? '';
+      expect(description).toMatch(/producers must not emit it/);
+    });
+
+    it('adds the #303 Q2 consumer reading: false alongside populated tracks MUST be read as true', () => {
+      const schema = spec.components.schemas.BulkResolveResult as Schema;
+      const description = (schema.properties?.tracks_attempted?.description as string) ?? '';
+      expect(description).toMatch(
+        /observes `tracks_attempted: false`[\s\S]*MUST read it as `true`/,
+      );
+      expect(description).toMatch(/wxyc-shared#303/);
+    });
+
+    // --- #303 Q1 option A: tracks_contract_version, the producer-echoed
+    // capability marker ---
+    //
+    // Follows the precedent already in this spec: LookupResponse.api_version
+    // answers LookupRequest.include_identity the same way. Without a marker,
+    // (absent, absent) on `tracks_attempted`/`tracks` is one wire spelling for
+    // two different facts during the LML rollout window — "the producer
+    // understood include_tracks and genuinely has nothing to report" and "the
+    // producer predates include_tracks entirely" — and a consumer cannot tell
+    // them apart. `tracks_contract_version` is the positive signal that closes
+    // the gap.
+
+    it('adds tracks_contract_version to BulkResolveLibrariesResponse as an optional integer pinned to 1', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      const marker = schema.properties?.tracks_contract_version;
+      expect(marker).toBeDefined();
+      expect(marker!.type).toBe('integer');
+      expect(marker!.enum).toEqual([1]);
+      // Optional and additive — an old producer that never heard of this
+      // field simply omits it, which is exactly the state the marker exists
+      // to name.
+      expect(schema.required ?? []).not.toContain('tracks_contract_version');
+    });
+
+    // A property carrying an OpenAPI `default` is emitted non-optional by
+    // openapi-typescript regardless of `required` (its `defaultNonNullable`
+    // option). `include_tracks` was bitten by exactly this; the marker's
+    // whole job is to be distinguishably absent, so a default would defeat it.
+    it('does not give tracks_contract_version a schema-level default', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      expect(schema.properties?.tracks_contract_version).not.toHaveProperty('default');
+    });
+
+    it('documents tracks_contract_version as present only when the producer understood include_tracks', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      const description = (schema.properties?.tracks_contract_version?.description as string) ?? '';
+      expect(description).toMatch(/present and equal to 1/i);
+      expect(description).toMatch(/include_tracks/);
+      expect(description).toMatch(/absent/i);
+    });
+
+    it('ties tracks_contract_version to the api_version / include_identity precedent this spec already set', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      const description = (schema.properties?.tracks_contract_version?.description as string) ?? '';
+      expect(description).toMatch(/api_version/);
+    });
+
+    it('mentions tracks_contract_version in the four-state block comment, so a reader of the table learns how to tell an old producer from a new one', () => {
+      const commentBlock = specText.slice(
+        specText.indexOf('# Four states, read off the PAIR'),
+        specText.indexOf('BulkResolveLibrariesRequest:'),
+      );
+      expect(commentBlock).toMatch(/tracks_contract_version/);
+    });
+
+    it('mentions tracks_contract_version in the bulk-resolve-libraries endpoint description', () => {
+      const opBlock = specText.slice(
+        specText.indexOf('/api/v1/identity/bulk-resolve-libraries:'),
+        specText.indexOf('/api/v1/artists/search-aliases/bulk:'),
+      );
+      expect(opBlock).toMatch(/tracks_contract_version/);
+    });
+
     // --- BulkResolveTrackIdentity repair (BS#1991 / LML#1021) ---
 
     it('ships the join-back echoes, composed verdict, and canonical artist on BulkResolveTrackIdentity', () => {
@@ -2423,6 +2511,17 @@ describe('OpenAPI Specification', () => {
       expect(states).toContain('false/empty');
       expect(states).toContain('true/empty');
       expect(states).toContain('true/entries');
+    });
+
+    it('shows tracks_contract_version: 1 in the flag-on response example', () => {
+      // The example is `include_tracks: true` throughout (per the response
+      // description above), so it's the producer-understood-the-flag case —
+      // the marker belongs on the example precisely because it is response-
+      // level, not per-result.
+      const example = (spec.components.schemas.BulkResolveLibrariesResponse as Schema).example as
+        | Record<string, unknown>
+        | undefined;
+      expect(example).toHaveProperty('tracks_contract_version', 1);
     });
   });
 

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -146,3 +146,34 @@ describe("generated request types stay constructible (#297)", () => {
     expect(requestBlock()).toMatch(/\n\s+inputs: /);
   });
 });
+
+// Same trap, same guard, for the #303 response-side marker. `include_tracks`
+// was bitten by `default: false` forcing a non-optional emit despite being
+// absent from `required`; `tracks_contract_version` carries the identical
+// risk because its whole job is to be distinguishably *absent* for a
+// producer that predates it. api.yaml deliberately gives it no schema-level
+// `default` (mirroring `LookupResponse.api_version`'s precedent) — this pins
+// the artifact consumers actually import, because the spec-level assertion
+// in api-spec.test.ts cannot see what the generator did with it.
+describe("generated tracks_contract_version marker stays optional (#303)", () => {
+  const dts = readFileSync(
+    join(__dirname, "..", "src", "generated", "openapi-types.d.ts"),
+    "utf-8",
+  );
+
+  const responseBlock = () => {
+    const start = dts.indexOf("BulkResolveLibrariesResponse: {");
+    expect(start, "BulkResolveLibrariesResponse missing from generated types").toBeGreaterThan(-1);
+    return dts.slice(start, dts.indexOf("\n        };", start));
+  };
+
+  it("emits tracks_contract_version as optional", () => {
+    expect(responseBlock()).toMatch(/\btracks_contract_version\?:/);
+  });
+
+  it("keeps results required", () => {
+    // Guards the assertion above against passing for the wrong reason — e.g.
+    // a regex that matches because the whole block vanished.
+    expect(responseBlock()).toMatch(/\n\s+results: /);
+  });
+});

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -114,6 +114,23 @@ describe("no doc claims generate:python feeds a consumer (#302, #304)", () => {
   });
 });
 
+// Shared by both `.d.ts`-reading guards below (#297 and #303): each pins a
+// different generated interface within the same 323KB generated file, and
+// each slices out one top-level interface block the same way. Read the file
+// once, and share the slicing logic, rather than each describe re-reading
+// the whole file and re-implementing the same `indexOf`/`slice` pair.
+const dts = readFileSync(
+  join(__dirname, "..", "src", "generated", "openapi-types.d.ts"),
+  "utf-8",
+);
+
+/** Slice one top-level interface block (e.g. `BulkResolveLibrariesRequest: { ... };`) out of the generated `.d.ts`. */
+function schemaBlock(name: string): string {
+  const start = dts.indexOf(`${name}: {`);
+  expect(start, `${name} missing from generated types`).toBeGreaterThan(-1);
+  return dts.slice(start, dts.indexOf("\n        };", start));
+}
+
 // A property carrying an OpenAPI `default` is emitted non-optional by
 // openapi-typescript (its `defaultNonNullable` option, on by default) even when
 // the property is absent from `required`. That reasoning holds for a response —
@@ -125,16 +142,7 @@ describe("no doc claims generate:python feeds a consumer (#302, #304)", () => {
 // the artifact that consumers actually import, because the spec assertion alone
 // cannot see what the generator did with it.
 describe("generated request types stay constructible (#297)", () => {
-  const dts = readFileSync(
-    join(__dirname, "..", "src", "generated", "openapi-types.d.ts"),
-    "utf-8",
-  );
-
-  const requestBlock = () => {
-    const start = dts.indexOf("BulkResolveLibrariesRequest: {");
-    expect(start, "BulkResolveLibrariesRequest missing from generated types").toBeGreaterThan(-1);
-    return dts.slice(start, dts.indexOf("\n        };", start));
-  };
+  const requestBlock = () => schemaBlock("BulkResolveLibrariesRequest");
 
   it("emits include_tracks as optional", () => {
     expect(requestBlock()).toMatch(/\binclude_tracks\?:/);
@@ -156,16 +164,7 @@ describe("generated request types stay constructible (#297)", () => {
 // the artifact consumers actually import, because the spec-level assertion
 // in api-spec.test.ts cannot see what the generator did with it.
 describe("generated tracks_contract_version marker stays optional (#303)", () => {
-  const dts = readFileSync(
-    join(__dirname, "..", "src", "generated", "openapi-types.d.ts"),
-    "utf-8",
-  );
-
-  const responseBlock = () => {
-    const start = dts.indexOf("BulkResolveLibrariesResponse: {");
-    expect(start, "BulkResolveLibrariesResponse missing from generated types").toBeGreaterThan(-1);
-    return dts.slice(start, dts.indexOf("\n        };", start));
-  };
+  const responseBlock = () => schemaBlock("BulkResolveLibrariesResponse");
 
   it("emits tracks_contract_version as optional", () => {
     expect(responseBlock()).toMatch(/\btracks_contract_version\?:/);


### PR DESCRIPTION
## Decision

Implements the decision recorded on #303: Q1 -> option A, Q2 -> mitigation (2).

**Q1 (option A).** `BulkResolveLibrariesResponse` gains `tracks_contract_version`, an optional integer pinned to `1`, present only when the producer understood `include_tracks: true`. This follows the precedent this spec already sets with `LookupResponse.api_version` answering `LookupRequest.include_identity`. The problem it solves: `api.yaml` declares absent and NULL to be one wire state, so `(tracks_attempted, tracks)` at `(null, null)` is indistinguishable between "the producer understood `include_tracks` and genuinely has nothing to report" and "the producer predates `include_tracks` entirely". That ambiguity is live today, not hypothetical — verified against `library-metadata-lookup` `main` post [WXYC/library-metadata-lookup#1150](https://github.com/WXYC/library-metadata-lookup/pull/1150): its committed models carry `tracks_attempted: bool | None = None` with nothing setting it, served through FastAPI's `response_model` without `response_model_exclude_none`, so `"tracks_attempted": null` is already on the wire.

Rejected alternatives (from #303, restated for the record): (B) `response_model_exclude_none` doesn't solve it, since absent and NULL are already one state by contract; (C) making `tracks_attempted` required is breaking and does nothing during the rollout window; (D) a consumer-side prose rule alone depends on a guaranteed LML-before-Backend-Service deploy order that isn't guaranteed.

**Q2 (mitigation 2).** One sentence added to `tracks_attempted`'s description: a consumer that observes `tracks_attempted: false` alongside a populated `tracks` MUST read it as `true`. This does not make the pairing schema-enforceable — no `oneOf`/`dependentRequired`, per #303's own assessment that the codegen fallout across four languages isn't worth it here — it makes a producer bug survivable on the pairing that gates a retry loop. The existing "producers must not emit it" prohibition is kept, not replaced.

## What changed

- `BulkResolveLibrariesResponse.tracks_contract_version` — new optional integer property, `enum: [1]`, no schema-level `default` (same `openapi-typescript` `defaultNonNullable` trap `include_tracks` hit — a default forces the emitted TS property non-optional regardless of `required`, which would defeat the marker's whole "absent means old producer" semantics).
- `BulkResolveResult.tracks_attempted` description — added the Q2 consumer-reading sentence.
- Four-state block comment and the `bulk-resolve-libraries` endpoint description — both now mention the marker, so a reader of either learns how to tell an old producer from a new one.
- Response example extended with `tracks_contract_version: 1` alongside the existing four `tracks_attempted`/`tracks` states.
- `info.version`: `1.30.0` -> `1.31.0` (additive, minor).
- `tests/api-spec.test.ts` — new tests pinning the marker's shape (optional integer, `enum: [1]`, not in `required`, no `default`), its present-only-when-asked description, the Q2 sentence, the example, and the two prose mentions. Updated the `info.version` pin.
- `tests/codegen-output-paths.test.ts` — extended with a guard mirroring the existing `include_tracks` one, pinning that the generated `.d.ts` emits `tracks_contract_version?:` (optional) rather than non-optional.

## Verification

- `npm run check:breaking` — clean, no breaking changes, no `oasdiff-err-ignore.txt` entry needed (purely additive).
- `npm run generate:typescript` — confirmed `tracks_contract_version?: 1;` in the emitted `.d.ts`, mirroring `api_version?: 2;`.
- `npm run build`, `npm run lint`, `npm run lint:e2e`, `npm test` (639 tests), `npm run test:breaking-guard`, `npm run test:setup-script` — all green.
- `npm run test:drift-guard` intentionally not run — it fails on `main` today for an unrelated stale-SHA reason being fixed in parallel under #301.

Closes #303