### PR TITLE
fix(api): make tracks_contract_version nullable and fix its probe

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.31.0
+  version: 1.32.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -4204,15 +4204,30 @@ components:
     # flag and genuinely has nothing to report — both are `null` either way.
     # `BulkResolveLibrariesResponse.tracks_contract_version` is the
     # response-level marker that separates them, and it only speaks to a
-    # request that set `include_tracks: true`: present and equal to 1 only
-    # then, when the producer also understood the flag. Absent otherwise —
-    # which covers both the predates-the-flag case above AND the ordinary,
+    # request that set `include_tracks: true`: equal to 1 only once the
+    # producer understands the flag AND emits `tracks_attempted` for both
+    # `kind: single_artist` and `kind: compilation` — the two producer arms
+    # ship independently (LML#1138, LML#1021), and setting the marker ahead
+    # of either one tells a consumer to trust `tracks_attempted` on rows
+    # where it is still meaningless. Absent or NULL otherwise — covering
+    # the predates-the-flag case, the one-arm-only case, AND the ordinary,
     # expected response from a fully-upgraded producer to a request where
-    # `include_tracks` was false or omitted. The marker is not a general
-    # "is this producer current" probe; probing it on an ordinary
-    # `include_tracks: false` call and reading the absence as "old
-    # producer" is the exact misreading it exists to prevent. See that
-    # field, and WXYC/wxyc-shared#303 for why the pair alone can't do this.
+    # `include_tracks` was false or omitted.
+    #
+    # LML serves this endpoint without `response_model_exclude_none` and
+    # sets this field nowhere yet, so `tracks_contract_version` ships
+    # `null` — never an omitted key — on every production response today
+    # (WXYC/wxyc-shared#310); `nullable: true` documents that wire instead
+    # of describing one nobody emits, the same treatment as `tracks` above.
+    # That also means a presence probe reads TRUE against the producer
+    # that implements none of this — the inverse of what the marker exists
+    # to signal. A consumer MUST test for the value `1` and
+    # must never test for key presence: absent, `null`, and a producer
+    # that predates this field must all read "not supported", and only
+    # the literal value `1` reads "supported" — which keeps the check
+    # immune to whether any given producer omits or nulls its unset
+    # optionals. See that field, and WXYC/wxyc-shared#303 / #310 for the
+    # two rollout-window defects this closes.
 
     BulkResolveLibrariesRequest:
       type: object
@@ -4743,13 +4758,39 @@ components:
           type: integer
           enum:
             - 1
+          nullable: true
           description: >
             Present and equal to 1 only when the request set
-            `include_tracks: true` and the producer understands the flag.
-            Absent otherwise — both when `include_tracks` was false or
-            omitted, and when the producer predates this field entirely
-            and does not implement `include_tracks` at all. Same
-            precedent as `LookupResponse.api_version`
+            `include_tracks: true`, the producer understands the flag,
+            AND the producer has emitted `tracks_attempted` for both
+            `kind: single_artist` and `kind: compilation` results — see
+            `BulkResolveResult.tracks_attempted`. The two producer arms
+            ship independently (LML#1138, LML#1021); setting the marker
+            with one arm unimplemented tells a consumer to trust
+            `tracks_attempted` on rows where it is still meaningless.
+
+
+            Absent or NULL otherwise: both when `include_tracks` was
+            false or omitted, and when the producer predates this field
+            entirely, or has implemented only one of the two arms above.
+            LML does not set this field anywhere yet and serves this
+            endpoint without `response_model_exclude_none`, so it ships
+            `null` — never an omitted key — on every response in
+            production today (WXYC/wxyc-shared#310); `nullable: true`
+            documents that wire instead of describing one nobody emits,
+            the same treatment as `tracks` / `tracks_attempted` above.
+
+
+            Because of that, a consumer MUST test for the value `1` and
+            must never test for key presence — `!== undefined` against
+            the generated TypeScript reads TRUE for a producer that
+            implements none of this, the inverse of what the marker
+            exists to signal. Absent, `null`, and a producer that
+            predates this field must all read "not supported", and only
+            the literal value `1` reads "supported" — which keeps the
+            check immune to whether any given producer omits or nulls
+            its unset optionals. Same precedent as
+            `LookupResponse.api_version`
             (`LookupRequest.include_identity`): a producer-echoed
             capability marker that lets a consumer distinguish "the
             producer understood my flag and the answer is genuinely
@@ -8698,11 +8739,27 @@ paths:
         from "the producer predates the flag" — both read identically on
         `tracks_attempted`/`tracks` alone (WXYC/wxyc-shared#303). The
         marker only speaks to a request that set `include_tracks: true`:
-        it is present and equal to 1 only then, when the producer also
-        understood the flag. It is absent, and normally absent, on the
+        it is equal to 1 only once the producer understands the flag AND
+        emits `tracks_attempted` for both `kind: single_artist` and
+        `kind: compilation` — the two producer arms ship independently
+        (LML#1138, LML#1021), and setting the marker ahead of either one
+        tells a consumer to trust `tracks_attempted` on rows where it is
+        still meaningless. It is absent, and normally absent, on the
         ordinary request where `include_tracks` was false or omitted —
         that absence is the expected response from a fully-upgraded
         producer too, not evidence the producer predates the flag.
+
+
+        LML does not set this field anywhere yet and serves this endpoint
+        without `response_model_exclude_none`, so `tracks_contract_version`
+        ships `null` — never an omitted key — on every response in
+        production today (WXYC/wxyc-shared#310). A presence check
+        therefore reads TRUE against the producer that implements none
+        of this, the inverse of what the marker exists to signal. A
+        consumer MUST test for the value `1` and
+        must never test for key presence: absent, `null`, and a producer
+        that predates this field must all read "not supported", and only
+        the literal value `1` reads "supported".
       security:
         - LMLBearerAuth: []
       tags:

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -32,3 +32,18 @@
 # test can catch that — the checks in
 # scripts/__tests__/check-breaking-changes.test.sh skip comment lines by
 # construction. Read the entries.
+
+# --- wxyc-shared#310 (api.yaml 1.32.0) ---
+# `BulkResolveLibrariesResponse.tracks_contract_version` gains `nullable: true`.
+# This one corrects the schema toward the wire rather than changing the wire:
+# the field was added in api.yaml 1.31.0 one day before this entry, no producer
+# has ever set it, and LML serves this endpoint through FastAPI's
+# `response_model` with no `response_model_exclude_none` and never assigns the
+# field, so `"tracks_contract_version": null` is what every bulk-resolve
+# response has carried since the field shipped. No consumer reads it yet
+# (WXYC/Backend-Service#1991 has not started), so there is no decoder in
+# production for this to break. Declaring the nullability cannot break a
+# decoder that survives today's traffic — the undeclared null is the status
+# quo, same reasoning as the `tracks`/`track_position` entries this file
+# already pruned.
+post /api/v1/identity/bulk-resolve-libraries the response property `tracks_contract_version` became nullable for the status `200`

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -50,7 +50,7 @@ describe('OpenAPI Specification', () => {
     // move filed the assertion under a ticket that didn't bump anything. It
     // lives here permanently now; update the literal, leave the location.
     it('pins info.version to the released contract version', () => {
-      expect(spec.info.version).toBe('1.31.0');
+      expect(spec.info.version).toBe('1.32.0');
     });
 
     it('should have components section', () => {
@@ -2357,6 +2357,91 @@ describe('OpenAPI Specification', () => {
         specText.indexOf('/api/v1/artists/search-aliases/bulk:'),
       );
       expect(opBlock).toMatch(/MUST read it as `true`/);
+    });
+
+    // --- #310: tracks_contract_version ships `null` on every response, and
+    // its presence-probe description was the exact inverse of a working
+    // check ---
+    //
+    // LML serves this endpoint through FastAPI's `response_model` without
+    // `response_model_exclude_none` and never sets the marker, so the wire
+    // carries `"tracks_contract_version": null` on 100% of bulk-resolve
+    // responses today — including from a producer that does not implement
+    // `include_tracks` at all. `null` is not a valid instance of
+    // `enum: [1]`, so the field needs the same `nullable: true` treatment
+    // its siblings `tracks` / `tracks_attempted` already carry. And because
+    // it is always null in practice, a presence probe reads TRUE against
+    // exactly the producer that predates the flag — the inverse of the
+    // marker's purpose — so the description has to mandate a
+    // value-equality check instead.
+
+    it('declares tracks_contract_version nullable, because LML ships `"tracks_contract_version": null` on every response today', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      expect(schema.properties?.tracks_contract_version?.nullable).toBe(true);
+    });
+
+    it('keeps tracks_contract_version out of required after the nullable fix', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      expect(schema.required ?? []).not.toContain('tracks_contract_version');
+    });
+
+    it('mandates a value-equality check on tracks_contract_version and forbids a presence check', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      const description = (schema.properties?.tracks_contract_version?.description as string) ?? '';
+      expect(description).toMatch(/MUST test for the value `1`/);
+      expect(description).toMatch(/must never test for key presence/);
+    });
+
+    it('explains why the value probe is required: absent, null, and a pre-#310 producer must all read "not supported"', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      const description = (schema.properties?.tracks_contract_version?.description as string) ?? '';
+      expect(description).toMatch(/not supported/);
+      expect(description).toMatch(/only the literal value `1` reads "supported"/);
+    });
+
+    it('states the partial-rollout producer rule: the marker requires tracks_attempted on both single_artist and compilation', () => {
+      const schema = spec.components.schemas.BulkResolveLibrariesResponse as Schema;
+      const description = (schema.properties?.tracks_contract_version?.description as string) ?? '';
+      expect(description).toMatch(/`kind: single_artist`/);
+      expect(description).toMatch(/`kind: compilation`/);
+      expect(description).toMatch(/LML#1021/);
+      expect(description).toMatch(/LML#1138/);
+    });
+
+    it('carries the value-probe rule in the four-state block comment, not just the property description', () => {
+      const commentBlock = specText.slice(
+        specText.indexOf('# Four states, read off the PAIR'),
+        specText.indexOf('BulkResolveLibrariesRequest:'),
+      );
+      expect(commentBlock).toMatch(/MUST test for the value `1`/);
+      expect(commentBlock).toMatch(/must never test for key presence/);
+    });
+
+    it('carries the value-probe rule in the bulk-resolve-libraries endpoint description too', () => {
+      const opBlock = specText.slice(
+        specText.indexOf('/api/v1/identity/bulk-resolve-libraries:'),
+        specText.indexOf('/api/v1/artists/search-aliases/bulk:'),
+      );
+      expect(opBlock).toMatch(/MUST test for the value `1`/);
+      expect(opBlock).toMatch(/must never test for key presence/);
+    });
+
+    it('carries the partial-rollout producer rule (LML#1138 alongside LML#1021) in the four-state block comment', () => {
+      const commentBlock = specText.slice(
+        specText.indexOf('# Four states, read off the PAIR'),
+        specText.indexOf('BulkResolveLibrariesRequest:'),
+      );
+      expect(commentBlock).toMatch(/LML#1138/);
+      expect(commentBlock).toMatch(/LML#1021/);
+    });
+
+    it('carries the partial-rollout producer rule (LML#1138 alongside LML#1021) in the bulk-resolve-libraries endpoint description', () => {
+      const opBlock = specText.slice(
+        specText.indexOf('/api/v1/identity/bulk-resolve-libraries:'),
+        specText.indexOf('/api/v1/artists/search-aliases/bulk:'),
+      );
+      expect(opBlock).toMatch(/LML#1138/);
+      expect(opBlock).toMatch(/LML#1021/);
     });
 
     // --- BulkResolveTrackIdentity repair (BS#1991 / LML#1021) ---

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -163,11 +163,20 @@ describe("generated request types stay constructible (#297)", () => {
 // `default` (mirroring `LookupResponse.api_version`'s precedent) — this pins
 // the artifact consumers actually import, because the spec-level assertion
 // in api-spec.test.ts cannot see what the generator did with it.
-describe("generated tracks_contract_version marker stays optional (#303)", () => {
+//
+// #310 added `nullable: true` on top of that (LML ships
+// `"tracks_contract_version": null` on every response, and `null` is not a
+// valid instance of `enum: [1]` without it) — openapi-typescript renders
+// that as a `| null` union member alongside the optional marker, so the
+// full emitted type is `tracks_contract_version?: 1 | null;`, not just
+// `tracks_contract_version?: 1;`. Pinning the wider pattern would pass
+// whether or not the `| null` half is actually there, silently losing the
+// #310 regression guard.
+describe("generated tracks_contract_version marker stays optional and nullable (#303, #310)", () => {
   const responseBlock = () => schemaBlock("BulkResolveLibrariesResponse");
 
-  it("emits tracks_contract_version as optional", () => {
-    expect(responseBlock()).toMatch(/\btracks_contract_version\?:/);
+  it("emits tracks_contract_version as optional and nullable", () => {
+    expect(responseBlock()).toMatch(/\btracks_contract_version\?: 1 \| null;/);
   });
 
   it("keeps results required", () => {


### PR DESCRIPTION
Closes #310

Two defects on `BulkResolveLibrariesResponse.tracks_contract_version`, both shipped in api.yaml 1.31.0 one day before this fix (#307/BS#1965 producer-field pass).

## Defect 1: the field violates its own schema on every response

LML serves `bulk-resolve-libraries` through FastAPI's `response_model` with no `response_model_exclude_none` set, and `identity/router.py` never assigns `tracks_contract_version`. So the wire carries `"tracks_contract_version": null` on 100% of responses today, including from a producer that does not implement `include_tracks` at all. `null` is not a valid instance of `enum: [1]`, so every response currently violates the schema.

**Fix:** `nullable: true`, matching the treatment already given to the sibling fields `tracks` and `tracks_attempted` for the identical reason.

## Defect 2 (more serious): the probe the description invited is inverted

The original description read "Present and equal to 1 only when… Absent otherwise" — a presence-shaped rule. Because the field is always `null` in practice rather than truly absent, a consumer testing "is the key present" (or `body.tracks_contract_version !== undefined` against the generated TypeScript) reads TRUE against exactly the producer that predates the flag. That is the inverse of what the marker exists to signal, and precisely the rollout-window ambiguity #303 added this field to remove.

**Fix:** the description now mandates a value-equality check and forbids a presence check, at all three altitudes (the four-state block comment, the `bulk-resolve-libraries` endpoint description, and the property description — per #307's review establishing that omitting this from any altitude teaches the wrong implementation). Absent, `null`, and a pre-#310 producer must all read "not supported"; only the literal value `1` reads "supported", which keeps the check immune to whether any given producer omits or nulls its unset optionals.

## Also added: the partial-rollout producer rule

A producer sets the marker to `1` only once it emits `tracks_attempted` for **both** `kind: single_artist` and `kind: compilation` results, and omits or nulls the field until then. The two producer arms — WXYC/library-metadata-lookup#1021 (compilation) and WXYC/library-metadata-lookup#1138 (single_artist) — ship independently, so a producer that sets the marker with one arm unimplemented would be telling consumers to trust `tracks_attempted` on rows where it is still meaningless.

## Breaking-change gate

`npm run check:breaking` flags exactly one finding, as expected for a `nullable: true` addition:

```
error	[response-property-became-nullable] at api.yaml
	in API POST /api/v1/identity/bulk-resolve-libraries
		the response property `tracks_contract_version` became nullable for the status `200`
```

Whitelisted in `oasdiff-err-ignore.txt`, scoped to this one field, with the exact oasdiff message reproduced verbatim:

```
post /api/v1/identity/bulk-resolve-libraries the response property `tracks_contract_version` became nullable for the status `200`
```

Justification recorded in the file: the field was added in api.yaml 1.31.0 one day before this entry, no producer has ever set it, LML emits it as `null` on every response today, and no consumer reads it yet (WXYC/Backend-Service#1991 has not started) — so declaring the nullability cannot break a decoder that survives today's traffic. Same reasoning already recorded there for the `tracks`/`track_position` entries pruned after #297/#300 landed.

With the whitelist entry in place, `npm run check:breaking` reports "No breaking changes detected."

## Version

`info.version` bumped 1.31.0 → 1.32.0.

## Out of scope

`LookupResponse.api_version` has the identical always-null defect but is a different endpoint with its own consumers, tracked separately in #309. Not touched here.

## Testing

TDD throughout: `tests/api-spec.test.ts` extended first with assertions that failed against the pre-fix text (nullable declaration, value-probe rule at all three altitudes, partial-rollout producer rule), then api.yaml was edited until green. `tests/codegen-output-paths.test.ts`'s guard on the generated TypeScript is updated to pin the actual post-fix shape, `tracks_contract_version?: 1 | null;`, rather than the looser optional-only pattern it pinned before.

All local verification green: `generate:typescript`, `build`, `lint`, `lint:e2e`, `test` (652 passed), `check:breaking`, `test:breaking-guard`, `test:setup-script`, `test:drift-guard`, `test:python-codegen`.