### PR TITLE
feat(api): add BulkResolveInput.legacy_release_id — id-space bridge for per-track reads (1.33.0)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -4310,25 +4310,33 @@ components:
           nullable: true
           description: >
             The row's legacy MySQL `LIBRARY_RELEASE_ID` — Backend's
-            `library.legacy_release_id` column. This is the id space
-            library.db (and therefore LML's per-track store,
+            `library.legacy_release_id` column, total and NOT NULL since
+            the WXYC/Backend-Service#1963 mint + NULL-legacy backfill
+            (migration 0137). This is the id space library.db (and
+            therefore LML's per-track store,
             `lml_cache.compilation_track_identity`) is keyed by;
             `library_id` above is Backend's own serial and is NOT in this
             space, so without this field LML cannot join a row to its
             per-track data at all (WXYC/library-metadata-lookup#1021,
-            WXYC/Backend-Service#1991). Optional and nullable — absent or
-            NULL means "no bridge available for this row": an un-upgraded
-            caller, or Backend's small residual of rows whose
-            `legacy_release_id` is NULL (ETL link-pass orphans). LML
-            answers such rows' `include_tracks: true` requests with the
-            not-yet-visited state (`tracks_attempted: false`, empty
-            `tracks`), so the consumer keeps re-asking rather than
-            mis-reading anything as resolved. Meaningful only alongside
-            `include_tracks: true`; harmless otherwise. Backend-authored
-            catalog adds mint `legacy_release_id` from a sequence floored
-            at 1,000,000 (WXYC/Backend-Service#1963), which flows into
-            library.db as its `id`, so the spaces stay joinable for
-            post-tubafrenzy rows too.
+            WXYC/Backend-Service#1991). Optional and nullable for wire
+            compatibility only: absent or NULL means the caller predates
+            this field. Because Backend's column is total, an upgraded
+            emitter always has a value to send — a NULL from an upgraded
+            emitter is a projection defect worth surfacing, not routine
+            data. LML answers bridge-less `include_tracks: true` rows of
+            the resolved kinds with the not-yet-visited state
+            (`tracks_attempted: false`, empty `tracks`) so consumers keep
+            re-asking rather than mis-reading anything as resolved
+            (`kind: unresolved` carries neither field, as ever).
+            Meaningful only alongside `include_tracks: true`; harmless
+            otherwise. Backend-authored catalog adds mint
+            `legacy_release_id` from a sequence floored at 1,000,000
+            (WXYC/Backend-Service#1963), which the Backend-sourced
+            library.db producer (discogs-etl#351) will emit AS
+            library.db's `id` — joining the spaces for post-tubafrenzy
+            rows once that source cutover (discogs-etl#346) lands; until
+            then a Backend-minted id matches no library.db row and simply
+            reads as not-yet-visited.
         artist_name:
           type: string
           description: Hint — Backend's denormalized artist name for the row.

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.32.0
+  version: 1.33.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -4305,6 +4305,30 @@ components:
         library_id:
           type: integer
           description: Backend `wxyc_schema.library.id` (FK target).
+        legacy_release_id:
+          type: integer
+          nullable: true
+          description: >
+            The row's legacy MySQL `LIBRARY_RELEASE_ID` — Backend's
+            `library.legacy_release_id` column. This is the id space
+            library.db (and therefore LML's per-track store,
+            `lml_cache.compilation_track_identity`) is keyed by;
+            `library_id` above is Backend's own serial and is NOT in this
+            space, so without this field LML cannot join a row to its
+            per-track data at all (WXYC/library-metadata-lookup#1021,
+            WXYC/Backend-Service#1991). Optional and nullable — absent or
+            NULL means "no bridge available for this row": an un-upgraded
+            caller, or Backend's small residual of rows whose
+            `legacy_release_id` is NULL (ETL link-pass orphans). LML
+            answers such rows' `include_tracks: true` requests with the
+            not-yet-visited state (`tracks_attempted: false`, empty
+            `tracks`), so the consumer keeps re-asking rather than
+            mis-reading anything as resolved. Meaningful only alongside
+            `include_tracks: true`; harmless otherwise. Backend-authored
+            catalog adds mint `legacy_release_id` from a sequence floored
+            at 1,000,000 (WXYC/Backend-Service#1963), which flows into
+            library.db as its `id`, so the spaces stay joinable for
+            post-tubafrenzy rows too.
         artist_name:
           type: string
           description: Hint — Backend's denormalized artist name for the row.

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -33,17 +33,3 @@
 # scripts/__tests__/check-breaking-changes.test.sh skip comment lines by
 # construction. Read the entries.
 
-# --- wxyc-shared#310 (api.yaml 1.32.0) ---
-# `BulkResolveLibrariesResponse.tracks_contract_version` gains `nullable: true`.
-# This one corrects the schema toward the wire rather than changing the wire:
-# the field was added in api.yaml 1.31.0 one day before this entry, no producer
-# has ever set it, and LML serves this endpoint through FastAPI's
-# `response_model` with no `response_model_exclude_none` and never assigns the
-# field, so `"tracks_contract_version": null` is what every bulk-resolve
-# response has carried since the field shipped. No consumer reads it yet
-# (WXYC/Backend-Service#1991 has not started), so there is no decoder in
-# production for this to break. Declaring the nullability cannot break a
-# decoder that survives today's traffic — the undeclared null is the status
-# quo, same reasoning as the `tracks`/`track_position` entries this file
-# already pruned.
-post /api/v1/identity/bulk-resolve-libraries the response property `tracks_contract_version` became nullable for the status `200`

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -2148,6 +2148,14 @@ describe('OpenAPI Specification', () => {
       expect(schema.required ?? []).not.toContain('legacy_release_id');
     });
 
+    // Same openapi-typescript `defaultNonNullable` trap as include_tracks: a
+    // schema-level default would emit the TS property non-optional despite
+    // its absence from `required`, forcing every caller to pass it.
+    it('does not give legacy_release_id a schema-level default', () => {
+      const schema = spec.components.schemas.BulkResolveInput as Schema;
+      expect(schema.properties?.legacy_release_id).not.toHaveProperty('default');
+    });
+
     it('documents legacy_release_id as the legacy LIBRARY_RELEASE_ID space, distinct from the serial library_id', () => {
       const schema = spec.components.schemas.BulkResolveInput as Schema;
       const description = (schema.properties?.legacy_release_id?.description as string) ?? '';

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -50,7 +50,7 @@ describe('OpenAPI Specification', () => {
     // move filed the assertion under a ticket that didn't bump anything. It
     // lives here permanently now; update the literal, leave the location.
     it('pins info.version to the released contract version', () => {
-      expect(spec.info.version).toBe('1.32.0');
+      expect(spec.info.version).toBe('1.33.0');
     });
 
     it('should have components section', () => {
@@ -2130,6 +2130,37 @@ describe('OpenAPI Specification', () => {
       const description = (schema.properties?.include_tracks?.description as string) ?? '';
       expect(description).toMatch(/single_artist/);
       expect(description).toMatch(/compilation/);
+    });
+
+    // --- The id-space bridge (LML#1021 F2): BulkResolveInput.legacy_release_id ---
+    // Backend's serial `library.id` and library.db's legacy MySQL
+    // LIBRARY_RELEASE_ID are unrelated id spaces; LML's per-track store is
+    // keyed by the latter, so without this field a per-track read cannot
+    // join at all. Decision trail: WXYC/library-metadata-lookup#1021 and
+    // WXYC/Backend-Service#1991.
+
+    it('adds legacy_release_id to BulkResolveInput as an optional nullable integer', () => {
+      const schema = spec.components.schemas.BulkResolveInput as Schema;
+      const field = schema.properties?.legacy_release_id;
+      expect(field).toBeDefined();
+      expect(field!.type).toBe('integer');
+      expect(field!.nullable).toBe(true);
+      expect(schema.required ?? []).not.toContain('legacy_release_id');
+    });
+
+    it('documents legacy_release_id as the legacy LIBRARY_RELEASE_ID space, distinct from the serial library_id', () => {
+      const schema = spec.components.schemas.BulkResolveInput as Schema;
+      const description = (schema.properties?.legacy_release_id?.description as string) ?? '';
+      expect(description).toMatch(/LIBRARY_RELEASE_ID/);
+      expect(description).toMatch(/library\.db/);
+      expect(description).toMatch(/serial/);
+    });
+
+    it('documents the bridge-absent degradation: not-yet-visited, keep re-asking', () => {
+      const schema = spec.components.schemas.BulkResolveInput as Schema;
+      const description = (schema.properties?.legacy_release_id?.description as string) ?? '';
+      expect(description).toMatch(/tracks_attempted/);
+      expect(description).toMatch(/absent or NULL/i);
     });
 
     it('replaces the two-state tracks wording with the four states, on both kinds', () => {


### PR DESCRIPTION
## Summary

Adds `BulkResolveInput.legacy_release_id` (optional, nullable integer) — the id-space bridge without which LML's per-track reads cannot exist. api.yaml 1.32.0 → **1.33.0**.

## Why

`BulkResolveInput.library_id` is Backend's serial `wxyc_schema.library.id`. LML's per-track store (`lml_cache.compilation_track_identity`, populated by WXYC/library-metadata-lookup#1020's matcher from library.db) is keyed by the legacy MySQL `LIBRARY_RELEASE_ID` space. These are unrelated: Backend's own ETL builds an explicit `legacy_release_id → library.id` map to translate, and the bridge the #1020 plan cited (`CatalogCompilationTrackRow.legacy_release_id`) exists only on the catalog-export shape, never on this wire path. A naive join returns zero rows for every compilation, silently. Full evidence and the decision record: [WXYC/library-metadata-lookup#1021 (comment)](https://github.com/WXYC/library-metadata-lookup/issues/1021#issuecomment-5221050121).

## Semantics

- Optional + nullable; **absent or NULL = "no bridge for this row"** — an un-upgraded caller, or Backend's small NULL-`legacy_release_id` residual (ETL link-pass orphans). LML answers such rows' `include_tracks: true` requests with the not-yet-visited `(tracks_attempted: false, tracks: [])` state — consumers keep re-asking; nothing is mis-read as resolved. No lockstep deploy needed in either direction.
- Meaningful only alongside `include_tracks: true`; harmless otherwise.
- Post-tubafrenzy rows stay joinable: Backend-authored adds mint `legacy_release_id` from the WXYC/Backend-Service#1963 sequence (floored at 1,000,000), which flows into library.db as its `id`.
- No schema-level default (nothing to default — absence is the meaning).

## Consumers

- **LML**: WXYC/library-metadata-lookup#1021 (V/A) keys its store read on this field; WXYC/library-metadata-lookup#1138 (non-V/A) consumes the same bridge for its release-identity join.
- **Backend-Service**: the identity consumer projects and sends it — recorded as an AC on [WXYC/Backend-Service#1991](https://github.com/WXYC/Backend-Service/issues/1991#issuecomment-5221052135).

## Checks

Contract tests added test-first (optional-nullable-integer shape, the id-space prose, the bridge-absent degradation). `npm test` 655/655, `npm run lint` clean, `npm run check:breaking` clean (additive optional request property).
