### PR TITLE
feat(api): contract the three local-first base fields on AlbumMetadataResponse (#318)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -3146,6 +3146,12 @@ components:
         states. iOS branches on this to decide whether to render inline metadata or fall back
         to the proxy-fetch path (WXYC/wxyc-ios-64#270). Only emitted on track entries.
 
+        Two surfaces reference this schema and must move together: the V2 flowsheet track
+        entry's `metadata_status`, and `AlbumMetadataResponse.metadataStatus` — the latter a
+        local-first echo of the same column off the linked flowsheet row (wxyc-shared#318,
+        WXYC/Backend-Service#1827), so a client can reconcile a proxy response against the
+        feed row it came from. Add a value here, not in a copy of the list.
+
     AlbumMetadata:
       type: object
       required:
@@ -6438,7 +6444,57 @@ components:
 
     AlbumMetadataResponse:
       type: object
+      description: >-
+        Response body for `GET /proxy/metadata/album`. Two tiers of field share
+        one flat wire shape, with no `base`/`enriched` wrapper to tell them
+        apart. **Base** fields (`recordLabel`, `labelId`, `metadataStatus`) are
+        durable Backend-Service state read off the linked flowsheet row before
+        any upstream lookup is attempted (WXYC/Backend-Service#1827). **Enriched**
+        fields (`artworkUrl`, `discogsUrl`, `genres`, `label`, the streaming
+        URLs, ...) come from Discogs via library-metadata-lookup. The split is
+        the point: an LML timeout can blank every enriched field but can never
+        blank the base ones.
       properties:
+        # ── Base fields (WXYC/Backend-Service#1827) ────────────────────────
+        # Local-first: sourced from the linked flowsheet row via
+        # selectLinkedFlowsheetRow, never from Discogs/LML. All three are
+        # conditionally assigned in the handler, so all three are optional.
+        recordLabel:
+          type: string
+          description: >-
+            Local-first base field. The catalog record label Backend-Service
+            wrote onto the flowsheet row at play time (`flowsheet.record_label`),
+            read back off the linked flowsheet row — durable BS state, never a
+            Discogs/LML read. Distinct from `label`, which is the Discogs
+            *release* label; the two carry genuinely different values with
+            different provenance and must not be merged, because collapsing
+            them would make the catalog label blankable by an upstream timeout.
+            Omitted when the request resolves to no linked flowsheet row, or
+            when that row's `record_label` is null/empty — a free-text entry
+            that never linked to an `album_id` has no local source for it.
+        labelId:
+          type: integer
+          description: >-
+            Local-first base field. Backend-Service's `label` table id for
+            `recordLabel`, read off the same linked flowsheet row
+            (`flowsheet.label_id`). Lets a client join to the catalog label
+            record instead of string-matching the name. Omitted when the
+            request resolves to no linked flowsheet row, or when that row's
+            `label_id` is null.
+        metadataStatus:
+          allOf:
+            - $ref: '#/components/schemas/MetadataStatus'
+          description: >-
+            Local-first base field. A faithful echo of the linked flowsheet
+            row's `metadata_status` column — the same enrichment-lifecycle
+            value the V2 flowsheet feed reports for that row, which is why it
+            shares the `MetadataStatus` schema rather than restating the
+            literals (the two must move together). It reports the row's stored
+            state, including any replay staleness; the terminal-vs-non-terminal
+            interpretation belongs to the client (WXYC/wxyc-ios-64#685).
+            Omitted when the request resolves to no linked flowsheet row, or
+            when that row's `metadata_status` is null.
+        # ── Enriched fields (Discogs via library-metadata-lookup) ──────────
         discogsReleaseId:
           type: integer
           description: Discogs release ID
@@ -6463,7 +6519,14 @@ components:
           description: Discogs style classifications (more specific than genres)
         label:
           type: string
-          description: Primary record label name
+          description: >-
+            Primary label on the Discogs *release*, from the cached
+            `album_metadata` row or an LML fallthrough. Enriched, not base:
+            absent when the upstream lookup fails, and still null on
+            `album_metadata` rows enriched before WXYC/Backend-Service#1336
+            (see WXYC/Backend-Service#1442). Not the same field as
+            `recordLabel`, which is the catalog label from the linked
+            flowsheet row and survives an upstream failure.
         discogsArtistId:
           type: integer
           description: Discogs artist ID, for linking to artist metadata

--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.34.0
+  version: 1.35.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -6447,13 +6447,49 @@ components:
       description: >-
         Response body for `GET /proxy/metadata/album`. Two tiers of field share
         one flat wire shape, with no `base`/`enriched` wrapper to tell them
-        apart. **Base** fields (`recordLabel`, `labelId`, `metadataStatus`) are
-        durable Backend-Service state read off the linked flowsheet row before
-        any upstream lookup is attempted (WXYC/Backend-Service#1827). **Enriched**
-        fields (`artworkUrl`, `discogsUrl`, `genres`, `label`, the streaming
-        URLs, ...) come from Discogs via library-metadata-lookup. The split is
-        the point: an LML timeout can blank every enriched field but can never
-        blank the base ones.
+        apart.
+
+
+        **Base** — durable Backend-Service state, never an upstream read
+        (WXYC/Backend-Service#1827). Six fields in the handler. Three are
+        declared here — `recordLabel`, `labelId`, `metadataStatus`, resolved
+        from the linked flowsheet row. The other three are emitted but not yet
+        declared: `artistName`, `releaseTitle` and `trackTitle`, echoed
+        straight back from the request and therefore present on every
+        response, including one where every upstream call failed
+        (`artistName` unconditionally, the other two whenever the caller
+        supplied them). Contracting those three is follow-up work on
+        wxyc-shared#318 — read their absence from this schema as undeclared,
+        not as unemitted.
+
+
+        **Enriched** — `artworkUrl`, `discogsUrl`, `genres`, `label`, the
+        streaming URLs and the rest, resolved from Discogs via
+        library-metadata-lookup.
+
+
+        The split is the guarantee: a library-metadata-lookup timeout can blank
+        every enriched field but can never blank a base one.
+
+
+        **Freshness caveat — the base fields are memoized, so they are not
+        re-read per request.** The handler memoizes the assembled response for
+        1h (WXYC/Backend-Service#988), keyed on the normalized
+        `(artistName, releaseTitle, trackTitle)` plus the critic-reviews flag
+        bit. Only the three request-echoed fields are excluded from the cached
+        value; `recordLabel`, `labelId` and `metadataStatus` are part of it. A
+        cache hit short-circuits the flowsheet read entirely, so these three
+        describe the linked row as it was when the entry was written rather
+        than as it is now. Two consequences worth designing around: for up to
+        an hour after a DJ links a previously free-text play, the response can
+        still omit all three even though a linked row now exists; and a
+        librarian's label correction can be shadowed by the old `recordLabel`
+        for the same window. `metadataStatus` is bounded more tightly than its
+        two siblings — a `pending` or `enriching` snapshot is never memoized
+        (WXYC/Backend-Service#1893), so a cached value is always one of the
+        three terminal states. None of this weakens the tier guarantee above:
+        an upstream failure still cannot blank a base field. It bounds a
+        different property — recency, not presence-on-failure.
       properties:
         # ── Base fields (WXYC/Backend-Service#1827) ────────────────────────
         # Local-first: sourced from the linked flowsheet row via
@@ -6469,18 +6505,25 @@ components:
             *release* label; the two carry genuinely different values with
             different provenance and must not be merged, because collapsing
             them would make the catalog label blankable by an upstream timeout.
-            Omitted when the request resolves to no linked flowsheet row, or
-            when that row's `record_label` is null/empty — a free-text entry
-            that never linked to an `album_id` has no local source for it.
+            Omitted in three cases: the key resolved to no linked flowsheet row
+            (a free-text entry that never linked to an `album_id` has no local
+            source for it); the resolved row's `record_label` was null or
+            empty; or the response was served from the 1h memo and the entry
+            was written under either of those conditions — see this schema's
+            freshness caveat, which also covers the stale-value case where a
+            memoized `recordLabel` outlives a librarian's correction.
         labelId:
           type: integer
           description: >-
             Local-first base field. Backend-Service's `label` table id for
             `recordLabel`, read off the same linked flowsheet row
             (`flowsheet.label_id`). Lets a client join to the catalog label
-            record instead of string-matching the name. Omitted when the
-            request resolves to no linked flowsheet row, or when that row's
-            `label_id` is null.
+            record instead of string-matching the name. Omitted in the same
+            three cases as `recordLabel`: no linked flowsheet row resolved, the
+            resolved row's `label_id` was null, or the response came from the
+            1h memo of a request where one of those held. Presence is
+            independent of `recordLabel`'s — the handler tests the two columns
+            separately, so a row can supply one without the other.
         metadataStatus:
           allOf:
             - $ref: '#/components/schemas/MetadataStatus'
@@ -6490,10 +6533,16 @@ components:
             value the V2 flowsheet feed reports for that row, which is why it
             shares the `MetadataStatus` schema rather than restating the
             literals (the two must move together). It reports the row's stored
-            state, including any replay staleness; the terminal-vs-non-terminal
-            interpretation belongs to the client (WXYC/wxyc-ios-64#685).
-            Omitted when the request resolves to no linked flowsheet row, or
-            when that row's `metadata_status` is null.
+            state; the terminal-vs-non-terminal interpretation belongs to the
+            client (WXYC/wxyc-ios-64#685). Omitted only when the key resolved
+            to no linked flowsheet row, or when the response came from the 1h
+            memo of such a request. Unlike `recordLabel` and `labelId`, it is
+            never omitted for an empty column: `flowsheet.metadata_status` is
+            `NOT NULL DEFAULT 'pending'` in Backend-Service, so a linked row
+            always carries a value. A memoized value is additionally always
+            terminal — non-terminal snapshots are excluded from the memo
+            (WXYC/Backend-Service#1893) — so a `pending` or `enriching` reading
+            here is always freshly read, never a stale echo.
         # ── Enriched fields (Discogs via library-metadata-lookup) ──────────
         discogsReleaseId:
           type: integer

--- a/e2e/proxy.test.ts
+++ b/e2e/proxy.test.ts
@@ -137,69 +137,110 @@ describe('Proxy E2E', () => {
         metadata_status?: string | null;
       };
 
-      async function findLinkedRow(): Promise<LinkedRow | undefined> {
+      const TERMINAL_STATUSES = ['enriched_match', 'enriched_no_match', 'failed_no_retry'];
+
+      let linkedRow: LinkedRow | undefined;
+      let served: AlbumMetadataResponse | undefined;
+
+      // One fetch for the whole block. Two reasons beyond economy: a second
+      // proxy call would hit the memo the first one populated (so it would not
+      // be an independent observation anyway), and re-deriving the row per test
+      // would let the two cases disagree about which row they are asserting on.
+      beforeAll(async () => {
         const feed = await client.get<LinkedRow[]>('/flowsheet?limit=100');
-        if (!feed.ok || !Array.isArray(feed.body)) return undefined;
+        if (!feed.ok || !Array.isArray(feed.body)) return;
         // `album_id` is the discriminator BS itself keys the local read off
         // (selectLinkedFlowsheetRow); `record_label` narrows to rows that
         // actually have the base field to echo, since BS assigns it only when
         // the linked row's column is non-empty.
-        return feed.body.find(
+        linkedRow = feed.body.find(
           (row) => row.album_id != null && !!row.artist_name && !!row.album_title && !!row.record_label
         );
-      }
-
-      it('echoes recordLabel / labelId / metadataStatus from the linked row', async () => {
-        const row = await findLinkedRow();
-        if (!row) {
-          // A stack seeded with only free-text entries has nothing to assert
-          // against — the fields are correctly absent there.
-          console.log('Skipping: no linked flowsheet row with a record_label in the recent feed');
-          return;
-        }
+        if (!linkedRow) return;
 
         const query = new URLSearchParams({
-          artistName: row.artist_name!,
-          releaseTitle: row.album_title!,
+          artistName: linkedRow.artist_name!,
+          releaseTitle: linkedRow.album_title!,
         });
         const response = await client.get<AlbumMetadataResponse>(
           `/proxy/metadata/album?${query.toString()}`
         );
+        if (response.ok) served = response.body;
+      });
 
-        expect(response.ok).toBe(true);
+      /**
+       * Skip — visibly, as a `↓` in the reporter — when the stack has no linked
+       * row to assert against. `ctx.skip()` is deliberate: the surrounding
+       * `console.log(...) + return` idiom used elsewhere in `e2e/` records the
+       * case as PASSING, and this block is issue #318's acceptance criterion.
+       * A green that certifies nothing was checked is worse than no test. The
+       * other uses of that idiom skip on "backend not available", where the
+       * whole suite is failing loudly anyway; this one skips on a *data*
+       * condition against a healthy stack, which is exactly when a false green
+       * goes unnoticed.
+       */
+      function requireServedLinkedRow(ctx: { skip: () => void }): void {
+        if (!linkedRow || !served) ctx.skip();
+      }
 
-        // Present, and equal to the flowsheet row they were read from.
-        expect(response.body.recordLabel).toBe(row.record_label);
-        if (row.label_id != null) {
-          expect(response.body.labelId).toBe(row.label_id);
-        }
-        if (row.metadata_status) {
-          expect(response.body.metadataStatus).toBe(row.metadata_status);
+      it('serves the three base fields for a row the feed says is linked', (ctx) => {
+        requireServedLinkedRow(ctx);
+
+        // The acceptance criterion: present, not merely well-typed. If this
+        // ever goes red on a stack that is otherwise healthy, the first
+        // hypothesis is the 1h memo documented on the AlbumMetadataResponse
+        // schema — a cache entry written while this key had no linked row will
+        // keep omitting all three until it expires.
+        expect(
+          served!.recordLabel,
+          'recordLabel absent for a linked row; if the stack is healthy, suspect a pre-link entry still inside the 1h memo window'
+        ).toBeTruthy();
+        expect(typeof served!.recordLabel).toBe('string');
+        expect(served!.metadataStatus, 'metadataStatus absent for a linked row').toBeTruthy();
+        // NOT NULL DEFAULT 'pending' on the column, so a linked row always has one.
+        expect([
+          'pending',
+          'enriching',
+          ...TERMINAL_STATUSES,
+        ]).toContain(served!.metadataStatus);
+        if (served!.labelId !== undefined) {
+          expect(Number.isInteger(served!.labelId)).toBe(true);
         }
       });
 
-      it('keeps recordLabel distinct from the Discogs release label', async () => {
-        const row = await findLinkedRow();
-        if (!row) {
-          console.log('Skipping: no linked flowsheet row with a record_label in the recent feed');
+      it('echoes the same row the feed reports, when the response is not a stale memo', (ctx) => {
+        requireServedLinkedRow(ctx);
+
+        // Equality against a live feed read is only owed when the response was
+        // assembled from the row's CURRENT state. `metadataStatus` is the
+        // freshness witness: BS#1827 reads all three base fields from a single
+        // `selectLinkedFlowsheetRow` call, so a response whose status matches
+        // the feed row's was read from that same state and must agree on the
+        // rest. A response served from an older memo can legitimately disagree
+        // — asserting equality unconditionally would be a scheduled flake
+        // against a correctly-behaving server.
+        if (served!.metadataStatus !== linkedRow!.metadata_status) {
+          expect(TERMINAL_STATUSES, 'a memoized status is always terminal (BS#1893)').toContain(
+            served!.metadataStatus
+          );
           return;
         }
 
-        const query = new URLSearchParams({
-          artistName: row.artist_name!,
-          releaseTitle: row.album_title!,
-        });
-        const response = await client.get<AlbumMetadataResponse>(
-          `/proxy/metadata/album?${query.toString()}`
-        );
+        expect(served!.recordLabel).toBe(linkedRow!.record_label);
+        if (linkedRow!.label_id != null) {
+          expect(served!.labelId).toBe(linkedRow!.label_id);
+        }
+      });
 
-        expect(response.ok).toBe(true);
+      it('keeps recordLabel distinct from the Discogs release label', (ctx) => {
+        requireServedLinkedRow(ctx);
+
         // `label` may be absent entirely — pre-BS#1336 album_metadata rows
         // still carry a NULL label (BS#1442). That is exactly why the two are
         // separate keys: `recordLabel` survives regardless.
-        expect(response.body.recordLabel).toBeTruthy();
-        if (response.body.label !== undefined) {
-          expect(typeof response.body.label).toBe('string');
+        expect(served!.recordLabel).toBeTruthy();
+        if (served!.label !== undefined) {
+          expect(typeof served!.label).toBe('string');
         }
       });
     });

--- a/e2e/proxy.test.ts
+++ b/e2e/proxy.test.ts
@@ -117,6 +117,92 @@ describe('Proxy E2E', () => {
       const cacheControl = response.headers.get('cache-control');
       expect(cacheControl).toBeTruthy();
     });
+
+    // wxyc-shared#318 / WXYC/Backend-Service#1827. The "local-first base
+    // fields" are durable BS state read off the linked flowsheet row, so an
+    // LML timeout can blank `artworkUrl` but can never blank the catalog
+    // label or the enrichment status. They were emitted for months without
+    // being in api.yaml, which meant no generated client decoded them and the
+    // guarantee was consumed nowhere. This is the parity guard: drive the
+    // request off a row the flowsheet says IS linked, then assert the served
+    // response carries the three fields, decoded through the generated type.
+    describe('local-first base fields for a linked flowsheet row (#318 / BS#1827)', () => {
+      /** A recent flowsheet track row that resolved to a catalog album. */
+      type LinkedRow = {
+        album_id?: number | null;
+        artist_name?: string | null;
+        album_title?: string | null;
+        record_label?: string | null;
+        label_id?: number | null;
+        metadata_status?: string | null;
+      };
+
+      async function findLinkedRow(): Promise<LinkedRow | undefined> {
+        const feed = await client.get<LinkedRow[]>('/flowsheet?limit=100');
+        if (!feed.ok || !Array.isArray(feed.body)) return undefined;
+        // `album_id` is the discriminator BS itself keys the local read off
+        // (selectLinkedFlowsheetRow); `record_label` narrows to rows that
+        // actually have the base field to echo, since BS assigns it only when
+        // the linked row's column is non-empty.
+        return feed.body.find(
+          (row) => row.album_id != null && !!row.artist_name && !!row.album_title && !!row.record_label
+        );
+      }
+
+      it('echoes recordLabel / labelId / metadataStatus from the linked row', async () => {
+        const row = await findLinkedRow();
+        if (!row) {
+          // A stack seeded with only free-text entries has nothing to assert
+          // against — the fields are correctly absent there.
+          console.log('Skipping: no linked flowsheet row with a record_label in the recent feed');
+          return;
+        }
+
+        const query = new URLSearchParams({
+          artistName: row.artist_name!,
+          releaseTitle: row.album_title!,
+        });
+        const response = await client.get<AlbumMetadataResponse>(
+          `/proxy/metadata/album?${query.toString()}`
+        );
+
+        expect(response.ok).toBe(true);
+
+        // Present, and equal to the flowsheet row they were read from.
+        expect(response.body.recordLabel).toBe(row.record_label);
+        if (row.label_id != null) {
+          expect(response.body.labelId).toBe(row.label_id);
+        }
+        if (row.metadata_status) {
+          expect(response.body.metadataStatus).toBe(row.metadata_status);
+        }
+      });
+
+      it('keeps recordLabel distinct from the Discogs release label', async () => {
+        const row = await findLinkedRow();
+        if (!row) {
+          console.log('Skipping: no linked flowsheet row with a record_label in the recent feed');
+          return;
+        }
+
+        const query = new URLSearchParams({
+          artistName: row.artist_name!,
+          releaseTitle: row.album_title!,
+        });
+        const response = await client.get<AlbumMetadataResponse>(
+          `/proxy/metadata/album?${query.toString()}`
+        );
+
+        expect(response.ok).toBe(true);
+        // `label` may be absent entirely — pre-BS#1336 album_metadata rows
+        // still carry a NULL label (BS#1442). That is exactly why the two are
+        // separate keys: `recordLabel` survives regardless.
+        expect(response.body.recordLabel).toBeTruthy();
+        if (response.body.label !== undefined) {
+          expect(typeof response.body.label).toBe('string');
+        }
+      });
+    });
   });
 
   // -- GET /proxy/metadata/artist -------------------------------------------

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -32,29 +32,3 @@
 # test can catch that — the checks in
 # scripts/__tests__/check-breaking-changes.test.sh skip comment lines by
 # construction. Read the entries.
-
-# --- wxyc-shared#316 (api.yaml 1.34.0) ---
-# `LookupResponse.api_version` and `LookupResponse.identity` both gain
-# `nullable: true` (identity's lives on the referenced `LookupIdentityBlock`
-# schema rather than on the property itself — see that schema's description
-# for why: an `allOf`-wrapped nullable ref was tried first and produced a
-# spurious third finding, `response-required-property-removed` on
-# `identity/resolved`, which is not recorded here because it never
-# reproduced against the shape actually shipped in this entry). This is the
-# identical defect wxyc-shared#310 fixed on the sibling marker
-# `tracks_contract_version`, on the endpoint that supplied #310's precedent
-# in the first place: no `LookupResponse(...)` construction site in
-# library-metadata-lookup (`lookup/orchestrator.py` L1343/L1368/L1653,
-# `lookup/router.py` L690/L812) has ever set either field, not even when the
-# request sets `include_identity: true`, because neither side of the
-# cross-cache-identity feature is implemented in the producer yet. LML
-# serves `/lookup` through FastAPI's `response_model` with no
-# `response_model_exclude_none`, so both fields sit at their `None` default
-# and serialize as explicit `null` on every response — never an omitted key
-# — regardless of what the request set `include_identity` to. Declaring the
-# nullability corrects the schema toward a wire that already ships; it does
-# not change what any producer emits or what a decoder that survives
-# today's traffic has to handle.
-post /lookup the response property `api_version` became nullable for the status `200`
-post /lookup the response property `identity` became nullable for the status `200`
-

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -646,6 +646,116 @@ describe('OpenAPI Specification', () => {
     });
   });
 
+  // wxyc-shared#318. WXYC/Backend-Service#1827 (merged as #1838) added three
+  // "local-first base fields" to GET /proxy/metadata/album — durable BS state
+  // read off the linked flowsheet row, so an LML timeout can blank
+  // `artworkUrl` but can never blank artist/track/album/label — and never
+  // contracted them here. Undeclared field names are absent from every
+  // generated client, so the non-blankable guarantee was invisible to every
+  // consumer. All three are conditionally assigned in BS
+  // (`if (linkedRow?.record_label)`, `if (linkedRow?.label_id != null)`,
+  // `if (linkedRow?.metadata_status)`), so all three are optional: a free-text
+  // row that never linked to an `album_id` has no local source and the
+  // response omits them.
+  describe('local-first base fields on AlbumMetadataResponse (#318 / BS#1827)', () => {
+    type SchemaProp = {
+      type?: string;
+      nullable?: boolean;
+      description?: string;
+      $ref?: string;
+      allOf?: Array<{ $ref?: string }>;
+      enum?: string[];
+    };
+    type Schema = {
+      properties?: Record<string, SchemaProp>;
+      required?: string[];
+    };
+
+    function albumMetadataResponse(): Schema {
+      return spec.components.schemas.AlbumMetadataResponse as Schema;
+    }
+
+    it('declares recordLabel as an optional string', () => {
+      const schema = albumMetadataResponse();
+      const prop = schema.properties?.recordLabel;
+      expect(prop).toBeDefined();
+      expect(prop?.type).toBe('string');
+      expect(schema.required ?? []).not.toContain('recordLabel');
+    });
+
+    it('declares labelId as an optional integer', () => {
+      const schema = albumMetadataResponse();
+      const prop = schema.properties?.labelId;
+      expect(prop).toBeDefined();
+      expect(prop?.type).toBe('integer');
+      expect(schema.required ?? []).not.toContain('labelId');
+    });
+
+    it('declares metadataStatus as optional and $refs the shared MetadataStatus enum rather than inlining the literals', () => {
+      const schema = albumMetadataResponse();
+      const prop = schema.properties?.metadataStatus;
+      expect(prop).toBeDefined();
+      expect(schema.required ?? []).not.toContain('metadataStatus');
+      // An `allOf` wrapper around the single $ref is how this spec attaches a
+      // description to a referenced schema under OpenAPI 3.0, where sibling
+      // keys next to `$ref` are ignored (see FlowsheetV2TrackEntry's
+      // `upcoming_show`). The point is that the literals live in exactly one
+      // place, so this property and the flowsheet V2 entry cannot drift.
+      const refs = [prop?.$ref, ...(prop?.allOf ?? []).map((branch) => branch.$ref)];
+      expect(refs).toContain('#/components/schemas/MetadataStatus');
+      expect(prop?.enum).toBeUndefined();
+    });
+
+    it('reaches the same enum the V2 flowsheet track entry uses', () => {
+      const metadataStatus = spec.components.schemas.MetadataStatus as SchemaProp;
+      expect(metadataStatus.enum).toEqual([
+        'pending',
+        'enriching',
+        'enriched_match',
+        'enriched_no_match',
+        'failed_no_retry',
+      ]);
+      // The V2 track entry reaches the same schema; both consumers of the enum
+      // move together because neither owns a copy of the literals.
+      const v2Track = spec.components.schemas.FlowsheetV2TrackEntry as {
+        allOf?: Array<{ properties?: Record<string, SchemaProp> }>;
+      };
+      const v2Prop = (v2Track.allOf ?? [])
+        .map((branch) => branch.properties?.metadata_status)
+        .find((candidate) => candidate !== undefined);
+      expect(v2Prop?.$ref).toBe('#/components/schemas/MetadataStatus');
+    });
+
+    it('documents each base field with its provenance and the condition under which BS omits it', () => {
+      const schema = albumMetadataResponse();
+      for (const name of ['recordLabel', 'labelId', 'metadataStatus'] as const) {
+        const description = schema.properties?.[name]?.description ?? '';
+        expect(description, `${name} needs a description`).not.toBe('');
+        // Provenance: the linked flowsheet row, not Discogs/LML.
+        expect(description, `${name} must cite the linked flowsheet row`).toMatch(/flowsheet row/i);
+        // Omission condition: BS only assigns when a linked row supplies it.
+        expect(description, `${name} must state when BS omits it`).toMatch(/omitted/i);
+      }
+    });
+
+    it('keeps recordLabel distinct from label, naming the other in both descriptions', () => {
+      const schema = albumMetadataResponse();
+      const recordLabel = schema.properties?.recordLabel?.description ?? '';
+      const label = schema.properties?.label?.description ?? '';
+      // Merging the two would destroy the local-first guarantee: `label` is the
+      // Discogs *release* label (album_metadata or an LML fallthrough) and is
+      // still NULL on pre-BS#1336 rows (BS#1442), while `recordLabel` is the
+      // catalog label BS wrote at play time.
+      expect(recordLabel).toMatch(/`label`/);
+      expect(label).toMatch(/`recordLabel`/);
+    });
+
+    it('notes on MetadataStatus that AlbumMetadataResponse shares it', () => {
+      const metadataStatus = spec.components.schemas.MetadataStatus as SchemaProp;
+      expect(metadataStatus.description ?? '').toMatch(/AlbumMetadataResponse/);
+    });
+  });
+
   // GET /library/catalog (the gzipped-NDJSON bulk export) and its row shape
   // shipped in Backend-Service#1468 (Epic F, parent #1466) but were never
   // propagated to this cross-repo SSOT — only to BS's local Swagger-only

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -50,7 +50,7 @@ describe('OpenAPI Specification', () => {
     // move filed the assertion under a ticket that didn't bump anything. It
     // lives here permanently now; update the literal, leave the location.
     it('pins info.version to the released contract version', () => {
-      expect(spec.info.version).toBe('1.34.0');
+      expect(spec.info.version).toBe('1.35.0');
     });
 
     it('should have components section', () => {
@@ -753,6 +753,52 @@ describe('OpenAPI Specification', () => {
     it('notes on MetadataStatus that AlbumMetadataResponse shares it', () => {
       const metadataStatus = spec.components.schemas.MetadataStatus as SchemaProp;
       expect(metadataStatus.description ?? '').toMatch(/AlbumMetadataResponse/);
+    });
+
+    // The base-field read lives in the cache-MISS arm of the handler
+    // (proxy.controller.ts L660-668). On a hit the handler does
+    // `Object.assign(metadata, cachedEnrichment)` and never calls
+    // `selectLinkedFlowsheetRow` — and these three ARE memoized, because
+    // ALBUM_METADATA_BASE_FIELDS (L526) excludes only the request-echoed
+    // artistName/releaseTitle/trackTitle. So "read off the linked row on every
+    // request" is false, and a contract that implies it would declare a real
+    // production state impossible: for up to the 1h TTL after a DJ links a
+    // previously free-text play, the response can still omit all three.
+    it('documents the 1h memo, so the contract does not imply a fresh row read on every request', () => {
+      const description = (albumMetadataResponse() as { description?: string }).description ?? '';
+      expect(description).toMatch(/1h|one hour|TTL/i);
+      expect(description).toMatch(/cach|memo/i);
+      // The claim that must NOT survive: an unqualified "before any upstream
+      // lookup" reads as "on every request", which the cache-hit arm falsifies.
+      expect(description).not.toMatch(/before any upstream lookup is attempted/i);
+    });
+
+    it('scopes the base tier to all six fields BS treats as base, not just the three declared here', () => {
+      const description = (albumMetadataResponse() as { description?: string }).description ?? '';
+      // proxy.controller.ts L577-595 and L604-612 put artistName/releaseTitle/
+      // trackTitle in the same tier — artistName unconditionally. Declaring
+      // them is follow-up work, but this prose is the first place the contract
+      // *defines* the tier, so it must not define it by omission.
+      for (const name of ['artistName', 'releaseTitle', 'trackTitle']) {
+        expect(description, `base tier must name ${name}`).toMatch(new RegExp(`\`${name}\``));
+      }
+    });
+
+    it('does not claim metadataStatus is omitted for a null column, which the NOT NULL default makes unreachable', () => {
+      const description = albumMetadataResponse().properties?.metadataStatus?.description ?? '';
+      // Backend-Service/shared/database/src/schema.ts:1046 declares
+      // `metadata_status` .notNull().default('pending'), so a linked row always
+      // has a value. The recordLabel/labelId equivalents ARE reachable.
+      expect(description).toMatch(/NOT NULL/i);
+      expect(description).not.toMatch(/`metadata_status` is null/i);
+    });
+
+    it('states the memo as an omission path on each of the three fields', () => {
+      const schema = albumMetadataResponse();
+      for (const name of ['recordLabel', 'labelId', 'metadataStatus'] as const) {
+        const description = schema.properties?.[name]?.description ?? '';
+        expect(description, `${name} must name the memo as an omission path`).toMatch(/memo|cach/i);
+      }
     });
   });
 

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -39,6 +39,7 @@ import {
   Format,
   RequestStatus,
   MetadataSource,
+  MetadataStatus,
   TrackMatchSource,
 } from '../src/generated/models/index.js';
 
@@ -1082,6 +1083,71 @@ describe('Generated TypeScript Types', () => {
 
       expect(entry.discogsUnavailable).toBeUndefined();
       expect(entry.discogsUnavailableNote).toBeNull();
+    });
+  });
+
+  describe('local-first base fields on AlbumMetadataResponse (#318 / BS#1827)', () => {
+    it('accepts recordLabel, labelId and metadataStatus alongside the enriched fields', () => {
+      const response: AlbumMetadataResponse = {
+        recordLabel: 'Houndstooth',
+        labelId: 4271,
+        metadataStatus: MetadataStatus.enriched_match,
+        // Enriched, upstream-dependent siblings. `label` is the Discogs
+        // *release* label and is a different value from `recordLabel`; both
+        // ride the same response.
+        label: 'Houndstooth Recordings',
+        discogsReleaseId: 32346192,
+        artworkUrl: 'https://example.com/art.jpg',
+      };
+
+      expect(response.recordLabel).toBe('Houndstooth');
+      expect(response.labelId).toBe(4271);
+      expect(response.metadataStatus).toBe('enriched_match');
+      expect(response.label).toBe('Houndstooth Recordings');
+    });
+
+    it('allows omitting all three (the free-text row that never linked to an album_id)', () => {
+      const response: AlbumMetadataResponse = {
+        discogsReleaseId: 32346192,
+        artworkUrl: 'https://example.com/art.jpg',
+      };
+
+      expect(response.recordLabel).toBeUndefined();
+      expect(response.labelId).toBeUndefined();
+      expect(response.metadataStatus).toBeUndefined();
+    });
+
+    it('types metadataStatus as the shared MetadataStatus enum, not a bare string', () => {
+      // Assignability in both directions pins the alias to the enum union: a
+      // bare `string` here would let an arbitrary literal through.
+      const status: MetadataStatus = 'enriching';
+      const response: AlbumMetadataResponse = { metadataStatus: status };
+      const roundTrip: MetadataStatus | undefined = response.metadataStatus;
+
+      expect(roundTrip).toBe(MetadataStatus.enriching);
+      expect(Object.values(MetadataStatus)).toEqual([
+        'pending',
+        'enriching',
+        'enriched_match',
+        'enriched_no_match',
+        'failed_no_retry',
+      ]);
+    });
+
+    it('shares one enum alias with the V2 flowsheet track entry', () => {
+      // Same type on both surfaces, so a client can reconcile the proxy
+      // response against the feed row it came from.
+      const track: FlowsheetV2TrackEntry = {
+        id: 1,
+        show_id: 1,
+        play_order: 1,
+        entry_type: 'track',
+        request_flag: false,
+        metadata_status: MetadataStatus.enriched_no_match,
+      };
+      const response: AlbumMetadataResponse = { metadataStatus: track.metadata_status };
+
+      expect(response.metadataStatus).toBe(track.metadata_status);
     });
   });
 });


### PR DESCRIPTION
Closes #318.

## What

`GET /proxy/metadata/album` has emitted three fields that `api.yaml` never declared. Since the names weren't in the spec they weren't in any generated client, so every consumer silently dropped them. This adds them.

| Field | Type | Source |
|---|---|---|
| `recordLabel` | `string`, optional | `flowsheet.record_label` on the linked row |
| `labelId` | `integer`, optional | `flowsheet.label_id` on the same row |
| `metadataStatus` | `MetadataStatus`, optional | `flowsheet.metadata_status` on the same row |

Verified against production 2026-08-07: `?artistName=Djrum&releaseTitle=Meaning's%20Edge&trackTitle=Crawl` returns `recordLabel: "Houndstooth"` and `metadataStatus: "enriched_match"` alongside the spec'd fields.

## Why it matters

These are **local-first base fields** ([WXYC/Backend-Service#1827](https://github.com/WXYC/Backend-Service/issues/1827), merged as [#1838](https://github.com/WXYC/Backend-Service/pull/1838)) — durable Backend-Service state read off the linked flowsheet row via `selectLinkedFlowsheetRow`, *before* any upstream lookup runs. An LML timeout can blank `artworkUrl`, `discogsUrl`, `genres`, `label`, and the streaming URLs, but it can never blank the catalog label or the enrichment status.

That is a real guarantee the handler goes out of its way to provide, and until this PR it was expressible only in a doc comment. No client could consume it, because no client could see the fields.

## Design decisions

**Additive and optional only.** All three are conditionally assigned in BS (`if (linkedRow?.record_label)`, `if (linkedRow?.label_id != null)`, `if (linkedRow?.metadata_status)`). A free-text row that never linked to an `album_id` has no local source and the response omits all three. `oasdiff` confirms no breaking changes.

**`recordLabel` is not merged with `label`.** They are different values with different provenance — the catalog label BS wrote at play time versus the Discogs *release* label from `album_metadata` or an LML fallthrough. Collapsing them would destroy the local-first guarantee by making the catalog label blankable by an upstream failure. The distinction is load-bearing in production right now: `album_metadata` rows enriched before [WXYC/Backend-Service#1336](https://github.com/WXYC/Backend-Service/pull/1336) still carry a NULL `label` ([WXYC/Backend-Service#1442](https://github.com/WXYC/Backend-Service/issues/1442)). Both descriptions now name the other field, and a test asserts that cross-reference holds, so a future reader can't mistake them for duplicates.

**`metadataStatus` shares the enum by `$ref`, not by copy.** It points at the existing `MetadataStatus` schema — the same one the V2 flowsheet track entry's `metadata_status` uses — through a single-branch `allOf`:

```yaml
metadataStatus:
  allOf:
    - $ref: '#/components/schemas/MetadataStatus'
  description: >-
    Local-first base field. A faithful echo of the linked flowsheet row's ...
```

The `allOf` wrapper is the OpenAPI 3.0 idiom for attaching a description to a reference (sibling keys next to `$ref` are ignored); the spec already uses it for `FlowsheetV2TrackEntry.upcoming_show`. The five literals therefore live in exactly one place and the two surfaces cannot drift. `MetadataStatus`'s own description now records that `AlbumMetadataResponse` is its second consumer, with the instruction to add values there rather than in a copy. A test pins both halves — the `$ref` is present *and* no inline `enum` was added.

**Provenance and omission documented per field.** Each of the three descriptions names its source column, says it comes from the linked flowsheet row rather than Discogs/LML, and states the condition under which BS omits it. A test asserts all three descriptions carry both.

## Tests (written first)

- **`tests/api-spec.test.ts`** — spec-level: the three shapes, optionality, the `$ref`-not-inline-enum assertion, the enum reached from both surfaces, the provenance/omission content of each description, and the mutual `label` ↔ `recordLabel` cross-reference.
- **`tests/generated-types.test.ts`** — decodes the fields through the generated TypeScript; pins `metadataStatus` to the enum union rather than a bare string by asserting assignability in *both* directions (a `string`-typed field would pass one direction and fail the other); asserts the alias is shared with `FlowsheetV2TrackEntry.metadata_status`.
- **`e2e/proxy.test.ts`** — the served-response parity guard the ticket asks for, in the spirit of iOS's `FlowsheetContractParityTests`: find a flowsheet row the feed says is linked (`album_id != null` with a `record_label`), then assert the served response carries the three base fields. A single `beforeAll` fetch feeds all three cases — a second proxy call would only hit the memo the first one populated, so it would not be an independent observation.

  Two properties, both from review:

  - **The skip is a real skip.** When no linked row exists, the cases call `ctx.skip()`, which vitest renders as `↓ skipped`. An earlier revision used the `console.log(...) + return` idiom, which vitest records as **passing** — a vacuous green certifying this issue's own acceptance criterion. (Correcting my earlier claim that this "matched existing `e2e/` conventions": the idiom does appear ~19 times under `e2e/`, so it was not novel, but every one of those skips on *"backend not available"* — a condition under which the suite is failing loudly anyway. This one skips on a **data** condition against a healthy stack, which is exactly when a false green goes unnoticed. Prevalence was not the right test; I should have asked what the skip was conditioned on.)
  - **The equality assertion is memo-robust.** Presence is asserted unconditionally, since that is the acceptance criterion, with a failure message naming the 1h memo as the first hypothesis. Equality against the live feed row is gated on `metadataStatus` matching: BS#1827 reads all three base fields from a single `selectLinkedFlowsheetRow` call, so a status agreeing with the feed proves the rest came from that same row state. A response served from an older memo may legitimately disagree, and asserting equality unconditionally would have been a scheduled flake against a correctly-behaving server.

  Typechecked by PR CI (`lint:e2e`); runs from `bs-lml-gate`.

## Codegen verification

All four generators produce the fields cleanly:

- **TypeScript** — `metadataStatus?: components["schemas"]["MetadataStatus"]` (the `allOf` collapses to the referenced alias)
- **Python** — `metadataStatus: MetadataStatus | None = Field(None, description=...)`
- **Swift** — `public var metadataStatus: MetadataStatus?`; `grep -rl ": Identifiable" generated/swift | wc -l` still `0`
- **Kotlin** — generated without error

Contract version `1.34.0` → `1.35.0` (additive, minor). `origin/main` took 1.34.0 in `ac71499` while this branch was open. Worth noting for future api.yaml PRs: that collision does **not** surface as a merge conflict — both sides make the identical one-line edit, so the rebase is clean, the merged tree ships two materially different specs under one version, and the pinned-version test reads green on the colliding number.

## Local checks

`npm run generate:typescript` · `generate:python` · `generate:swift` · `npm run build` · `npm run lint` · `npm run lint:e2e` · `npm test` (684 passing) · `npm run check:breaking` (no breaking changes) · the four bats guards (`test:breaking-guard`, `test:setup-script`, `test:drift-guard`, `test:python-codegen`) — all green before pushing.

## Follow-up work this PR deliberately does not do

Three of the ticket's acceptance criteria reach outside this repo. Recording them here so they aren't lost:

1. **Downstream Python regen.** [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) and [request-o-matic](https://github.com/WXYC/request-o-matic) each commit their own `generated/api_models.py` and need a regen after this merges (pinned generators: request-o-matic `0.57.0`, LML `0.56.1`). Note each has an in-flight regen ticket already — LML [#1153](https://github.com/WXYC/library-metadata-lookup/issues/1153), ROM [#218](https://github.com/WXYC/request-o-matic/issues/218) — for the `--strict-nullable` change (wxyc-shared#302); this contract bump can ride along with those or follow separately.
2. **Swift consumer.** `Shared/WXYCAPIModels/Sources/WXYCAPIModels/Models/AlbumMetadataResponse.swift` is hand-authored in [wxyc-ios-64](https://github.com/WXYC/wxyc-ios-64) and needs the three fields added there before iOS can read them. This repo's `generated/swift` tree is a gitignored reference tree that nobody vendors yet (see CLAUDE.md's codegen table).
3. **Backend-Service doc comment.** `apps/backend/controllers/proxy.controller.ts` L577-595 still says these fields "aren't yet in `wxyc-shared/api.yaml`". That caveat becomes false when this merges and should be dropped — cross-repo, so not in this PR.

## Related

- [WXYC/Backend-Service#1827](https://github.com/WXYC/Backend-Service/issues/1827) / [#1838](https://github.com/WXYC/Backend-Service/pull/1838) — added the fields without contracting them
- [WXYC/wxyc-ios-64#685](https://github.com/WXYC/wxyc-ios-64/issues/685) — the original tracking pointer, closed without covering this
- [WXYC/Backend-Service#1336](https://github.com/WXYC/Backend-Service/pull/1336) / [#1442](https://github.com/WXYC/Backend-Service/issues/1442) — why `label` vs `recordLabel` is load-bearing today

