### PR TITLE
fix(api): make LookupResponse.api_version and .identity nullable to match the wire

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -6,7 +6,7 @@ info:
 
     This is the single source of truth for all WXYC API types. Code is generated from this spec
     for TypeScript, Swift, and Kotlin consumers.
-  version: 1.33.0
+  version: 1.34.0
   contact:
     name: WXYC
     url: https://wxyc.org
@@ -3480,14 +3480,35 @@ components:
           type: boolean
           default: false
           description: >
-            Per cross-cache-identity plan §3.2.2 (E2-LML write contract). When
-            true, the response carries an additional `identity` block (the
-            §3.2.5 cascade's per-source resolution detail), and `api_version`
-            is set to 2. When false (the default), the response is
-            byte-identical to v0.5.0 — `identity` is absent and `api_version`
-            is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets
-            this to true on every call; other consumers (catalog search,
-            dj-site proxy, iOS apps) leave it false.
+            Per cross-cache-identity plan §3.2.2 (E2-LML write contract).
+            When true, the response is meant to carry an additional
+            `identity` block (the §3.2.5 cascade's per-source resolution
+            detail) with `api_version` set to 2 — see
+            `LookupResponse.api_version` and `LookupResponse.identity`.
+            Neither side of that is implemented yet: no
+            `LookupResponse(...)` construction site in the producer ever
+            sets `api_version` or `identity`, not even when this flag is
+            true, so both fields ship `null` — never an omitted key — on
+            every `/lookup` response in production today, regardless of
+            what this flag is set to (WXYC/wxyc-shared#316). A consumer
+            MUST test `api_version === 2` to detect support, never
+            presence of either key: absent, `null`, and a producer that
+            hasn't implemented this at all must all read "not supported".
+
+
+            No current caller sets this to true. A source read of
+            Backend-Service (re-verified for this fix at `67d6d7b`, the
+            same SHA the original WXYC/wxyc-shared#309 read used —
+            Backend-Service has not moved since) finds no
+            `library-identity-writer.ts` file and no `include_identity`
+            reference anywhere in its TypeScript; the only occurrence in
+            that repo is prose in
+            `plans/library-hook-canonicalization/architecture-pivot-2026-05-09.md`
+            describing the planned E2-BS writer, which has not been
+            built. request-o-matic constructs `LookupRequest` without
+            setting this field, which serializes as the `false` default;
+            dj-site and tubafrenzy do not call `/lookup` with this field
+            at all.
         extended:
           type: boolean
           description: >
@@ -3862,20 +3883,46 @@ components:
       type: object
       description: >
         Response from the lookup service containing library search results
-        and metadata. When the request set `include_identity: true`, the
-        response additionally carries `api_version: 2` and the `identity`
-        block (per cross-cache-identity plan §3.2.2). When false or absent,
-        the response is byte-identical to v0.5.0 — both `api_version` and
-        `identity` are omitted.
+        and metadata. When the request sets `include_identity: true` and
+        the producer understands the flag, the response is meant to
+        additionally carry `api_version: 2` and the `identity` block (per
+        cross-cache-identity plan §3.2.2). Neither side is implemented in
+        the producer yet, so in production today both fields ship `null`
+        — never an omitted key — on every response, regardless of what
+        the request set `include_identity` to (WXYC/wxyc-shared#316). A
+        consumer MUST test `api_version === 2`, never key presence:
+        absent, `null`, and a producer that hasn't implemented this at
+        all must all read "not supported", and only the literal value `2`
+        reads "supported". See `api_version` below for the full rule, and
+        `LookupIdentityBlock` for `identity`'s.
       properties:
         api_version:
           type: integer
           enum:
             - 2
+          nullable: true
           description: >
             Present and equal to 2 only when the request set
-            `include_identity: true`. Absent for the v1-compatible shape so
-            existing consumers see byte-identical responses.
+            `include_identity: true` and the producer understands the
+            flag. No `LookupResponse(...)` construction site in the
+            producer sets this field anywhere yet — not even when the
+            request sets `include_identity: true` — and the endpoint is
+            served through FastAPI's `response_model` without
+            `response_model_exclude_none`, so it ships `null` — never an
+            omitted key — on every `/lookup` response in production today
+            (WXYC/wxyc-shared#316); `nullable: true` documents that wire
+            instead of describing one nobody emits.
+
+
+            Because of that, a consumer MUST test for the value `2` and
+            must never test for key presence — `!== undefined` against
+            the generated TypeScript reads TRUE for a producer that
+            implements none of this, the inverse of what the marker
+            exists to signal. Absent, `null`, and a producer that hasn't
+            implemented `include_identity` at all must all read "not
+            supported", and only the literal value `2` reads "supported"
+            — which keeps the check immune to whether any given producer
+            omits or nulls its unset optionals.
         results:
           type: array
           items:
@@ -3976,10 +4023,17 @@ components:
     # Identity Block (§3.2.2 / §3.2.5 cascade)
     # ====================================
     #
-    # Returned only when LookupRequest.include_identity is true. Carries the
-    # per-source resolution detail from the §3.2.5 cascade so Backend's
-    # `library-identity-writer.ts` (E2-BS) can populate
-    # `library_identity_source` per-row without a second round-trip.
+    # Meant to be returned only when LookupRequest.include_identity is true
+    # and the producer understands the flag, carrying the per-source
+    # resolution detail from the §3.2.5 cascade so a future Backend writer
+    # can populate `library_identity_source` per-row without a second
+    # round-trip. No such writer exists yet: a source read of
+    # Backend-Service at `67d6d7b` finds no `library-identity-writer.ts`
+    # file and no `include_identity` reference anywhere in its TypeScript —
+    # the planned E2-BS writer described in
+    # plans/library-hook-canonicalization/architecture-pivot-2026-05-09.md
+    # has not been built (WXYC/wxyc-shared#316, WXYC/wxyc-shared#309). See
+    # `LookupIdentityBlock` below for what actually ships today.
 
     IdentitySource:
       type: string
@@ -4089,13 +4143,46 @@ components:
 
     LookupIdentityBlock:
       type: object
+      nullable: true
       description: >
         Per-source identity resolution detail for a single library row.
-        Returned on `LookupResponse.identity` when the request set
-        `include_identity: true`. Per §3.2.2, the `resolved` array is
-        complete (one entry per source LML knows about, including the
-        sources whose legs didn't run with `attempted: false`) — consumers
-        get a deterministic shape regardless of which legs were available.
+        Meant to be returned on `LookupResponse.identity` when the request
+        set `include_identity: true` and the producer understands the
+        flag. Per §3.2.2, the `resolved` array is complete (one entry per
+        source LML knows about, including the sources whose legs didn't
+        run with `attempted: false`) — consumers get a deterministic
+        shape regardless of which legs were available, whenever this
+        block is actually populated.
+
+
+        No `LookupResponse(...)` construction site in the producer sets
+        `LookupResponse.identity` anywhere yet — not even when the
+        request sets `include_identity: true` — and the endpoint is
+        served through FastAPI's `response_model` without
+        `response_model_exclude_none`, so `identity` ships `null` — never
+        an omitted key — on every `/lookup` response in production today
+        (WXYC/wxyc-shared#316). `nullable: true` documents that wire
+        instead of describing a shape nobody emits. A consumer
+        distinguishes "identity resolution ran and found nothing" from
+        "the producer hasn't implemented `include_identity`" the same way
+        as `LookupResponse.api_version` — by reading `api_version`, not
+        by probing `identity` for presence or nullness. `identity` alone
+        cannot make that distinction: it is `null` in both cases.
+
+
+        `nullable: true` lives here, on the schema, rather than as an
+        `allOf`-wrapped sibling on `LookupResponse.identity` — the two
+        are equivalent where oasdiff can see through the composition, but
+        an `allOf`-wrapped nullable ref to an object schema with its own
+        `required` list cascaded into a spurious
+        `response-required-property-removed` finding that the direct
+        schema-level `nullable: true` does not, and marking a bare `$ref`
+        nullable by writing the keyword next to it does nothing at all
+        (OpenAPI 3.0 ignores sibling keys next to a `$ref`). This is safe
+        only because `LookupIdentityBlock` is referenced exactly once in
+        this spec, from `LookupResponse.identity` — a second reference
+        would inherit this nullability unconditionally, so re-examine
+        whether `null` is correct there too before adding one.
       required:
         - resolved
       properties:

--- a/oasdiff-err-ignore.txt
+++ b/oasdiff-err-ignore.txt
@@ -33,3 +33,28 @@
 # scripts/__tests__/check-breaking-changes.test.sh skip comment lines by
 # construction. Read the entries.
 
+# --- wxyc-shared#316 (api.yaml 1.34.0) ---
+# `LookupResponse.api_version` and `LookupResponse.identity` both gain
+# `nullable: true` (identity's lives on the referenced `LookupIdentityBlock`
+# schema rather than on the property itself — see that schema's description
+# for why: an `allOf`-wrapped nullable ref was tried first and produced a
+# spurious third finding, `response-required-property-removed` on
+# `identity/resolved`, which is not recorded here because it never
+# reproduced against the shape actually shipped in this entry). This is the
+# identical defect wxyc-shared#310 fixed on the sibling marker
+# `tracks_contract_version`, on the endpoint that supplied #310's precedent
+# in the first place: no `LookupResponse(...)` construction site in
+# library-metadata-lookup (`lookup/orchestrator.py` L1343/L1368/L1653,
+# `lookup/router.py` L690/L812) has ever set either field, not even when the
+# request sets `include_identity: true`, because neither side of the
+# cross-cache-identity feature is implemented in the producer yet. LML
+# serves `/lookup` through FastAPI's `response_model` with no
+# `response_model_exclude_none`, so both fields sit at their `None` default
+# and serialize as explicit `null` on every response — never an omitted key
+# — regardless of what the request set `include_identity` to. Declaring the
+# nullability corrects the schema toward a wire that already ships; it does
+# not change what any producer emits or what a decoder that survives
+# today's traffic has to handle.
+post /lookup the response property `api_version` became nullable for the status `200`
+post /lookup the response property `identity` became nullable for the status `200`
+

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -50,7 +50,7 @@ describe('OpenAPI Specification', () => {
     // move filed the assertion under a ticket that didn't bump anything. It
     // lives here permanently now; update the literal, leave the location.
     it('pins info.version to the released contract version', () => {
-      expect(spec.info.version).toBe('1.33.0');
+      expect(spec.info.version).toBe('1.34.0');
     });
 
     it('should have components section', () => {
@@ -1216,16 +1216,116 @@ describe('OpenAPI Specification', () => {
       expect(schema.required ?? []).not.toContain('api_version');
     });
 
-    it('should attach optional identity block to LookupResponse', () => {
+    it('should attach optional identity block to LookupResponse as a bare $ref', () => {
+      // #316 tried wrapping this in `allOf` + `nullable: true` first (the
+      // standard workaround for "sibling keys next to a bare $ref are
+      // ignored"), but that made oasdiff report a spurious
+      // response-required-property-removed on `identity/resolved` on top
+      // of the expected became-nullable finding — LookupIdentityBlock.required
+      // never changed, so the finding doesn't correspond to a real change
+      // on the wire, but adding it to the whitelist would have gone beyond
+      // what the ticket pre-authorized. Nullability lives on the
+      // LookupIdentityBlock schema itself instead (see the dedicated test
+      // below), so `identity` stays exactly the bare $ref it was on main.
       const schema = spec.components.schemas.LookupResponse as {
-        properties: Record<string, { $ref?: string }>;
+        properties: Record<string, { $ref?: string; nullable?: boolean }>;
         required?: string[];
       };
-      expect(schema.properties.identity).toBeDefined();
-      expect(schema.properties.identity.$ref).toBe(
-        '#/components/schemas/LookupIdentityBlock',
-      );
+      const identity = schema.properties.identity;
+      expect(identity).toBeDefined();
+      expect(identity.$ref).toBe('#/components/schemas/LookupIdentityBlock');
+      expect(identity.nullable).toBeUndefined();
       expect(schema.required ?? []).not.toContain('identity');
+    });
+
+    it('declares LookupIdentityBlock itself nullable, because LML ships `"identity": null` on every response today', () => {
+      const schema = spec.components.schemas.LookupIdentityBlock as { nullable?: boolean };
+      expect(schema.nullable).toBe(true);
+    });
+
+    it('documents on LookupIdentityBlock why nullable lives on the schema rather than as an allOf sibling on the property', () => {
+      const schema = spec.components.schemas.LookupIdentityBlock as { description?: string };
+      const description = schema.description ?? '';
+      expect(description).toMatch(/referenced exactly once/);
+      expect(description).toMatch(/response-required-property-removed/);
+    });
+
+    it('documents on LookupIdentityBlock that identity ships null on every response and how a consumer should read it', () => {
+      const schema = spec.components.schemas.LookupIdentityBlock as { description?: string };
+      const description = schema.description ?? '';
+      expect(description).toMatch(/`null`/);
+      expect(description).toMatch(/api_version/);
+      expect(description).not.toMatch(/byte-identical to v0\.5\.0/);
+    });
+
+    // --- #316: LookupResponse.api_version / identity ship `null` on every
+    // `/lookup` response today, and the "byte-identical to v0.5.0 — both
+    // omitted" claim never held ---
+    //
+    // LML serves this endpoint through FastAPI's `response_model` without
+    // `response_model_exclude_none`, and no `LookupResponse(...)`
+    // construction site (lookup/orchestrator.py L1343/L1368/L1653,
+    // lookup/router.py L690/L812) ever sets either field — not even when
+    // the request sets `include_identity: true`, because neither side of
+    // the feature is implemented yet. So both fields sit at their `None`
+    // default and FastAPI serializes `null`, which is not a valid instance
+    // of `api_version`'s `enum: [2]`. This is the identical defect
+    // WXYC/wxyc-shared#310 fixed on the sibling marker
+    // `tracks_contract_version`.
+
+    it('declares api_version nullable, because LML ships `"api_version": null` on every response today', () => {
+      const schema = spec.components.schemas.LookupResponse as {
+        properties: Record<string, { nullable?: boolean }>;
+      };
+      expect(schema.properties.api_version.nullable).toBe(true);
+    });
+
+    it('mandates a value-equality check on api_version and forbids a presence check', () => {
+      const schema = spec.components.schemas.LookupResponse as {
+        properties: Record<string, { description?: string }>;
+      };
+      const description = schema.properties.api_version.description ?? '';
+      expect(description).toMatch(/MUST test for the value `2`/);
+      expect(description).toMatch(/must never test for key presence/);
+    });
+
+    it('explains why the value probe is required: absent, null, and an unimplemented producer must all read "not supported"', () => {
+      const schema = spec.components.schemas.LookupResponse as {
+        properties: Record<string, { description?: string }>;
+      };
+      const description = schema.properties.api_version.description ?? '';
+      expect(description).toMatch(/not supported/);
+      expect(description).toMatch(/only the literal value `2` reads "supported"/);
+    });
+
+    it('corrects the LookupResponse schema-level description away from the false "byte-identical to v0.5.0 — both omitted" claim', () => {
+      const schema = spec.components.schemas.LookupResponse as { description?: string };
+      const description = schema.description ?? '';
+      expect(description).not.toMatch(/byte-identical to v0\.5\.0/);
+      expect(description).toMatch(/`null`/);
+      expect(description).toMatch(/MUST test/);
+    });
+
+    it('corrects the include_identity request-field description away from the same false "byte-identical / omitted" claim', () => {
+      const schema = spec.components.schemas.LookupRequest as {
+        properties: Record<string, { description?: string }>;
+      };
+      const description = schema.properties.include_identity.description ?? '';
+      expect(description).not.toMatch(/byte-identical to v0\.5\.0/);
+      expect(description).toMatch(/`null`/);
+    });
+
+    it('re-verifies the stale library-identity-writer.ts caller claim and drops the unverified assertion', () => {
+      // A source read of Backend-Service (re-verified for this fix, same
+      // SHA the original claim was read at: Backend-Service has not moved)
+      // finds no `library-identity-writer.ts` file and no `include_identity`
+      // reference anywhere in its TypeScript. The description must stop
+      // asserting Backend as a live caller that sets this field.
+      const schema = spec.components.schemas.LookupRequest as {
+        properties: Record<string, { description?: string }>;
+      };
+      const description = schema.properties.include_identity.description ?? '';
+      expect(description).not.toMatch(/sets this to true on every call/);
     });
 
     it('should define IdentitySource enum with the six §3.2.0 sources', () => {

--- a/tests/codegen-output-paths.test.ts
+++ b/tests/codegen-output-paths.test.ts
@@ -185,3 +185,62 @@ describe("generated tracks_contract_version marker stays optional and nullable (
     expect(responseBlock()).toMatch(/\n\s+results: /);
   });
 });
+
+// #316: the identical defect on LookupResponse.api_version / .identity — LML
+// never sets either field (not even when `include_identity: true`), and
+// serves `/lookup` without `response_model_exclude_none`, so both ship
+// `null` on every response today.
+//
+// `api_version` is a scalar enum, so `nullable: true` on the property is
+// enough — openapi-typescript renders it right there as `2 | null`.
+//
+// `identity` took a different shape. It stayed a bare `$ref` (OpenAPI 3.0
+// ignores sibling keys — including `nullable: true` — written next to a
+// bare `$ref`, so that alone would have done nothing); nullability instead
+// lives on the *referenced* `LookupIdentityBlock` schema itself. An
+// `allOf`-wrapped nullable ref was tried first and rejected: it made oasdiff
+// report a spurious `response-required-property-removed` on
+// `identity/resolved` (`LookupIdentityBlock.required` is untouched — the
+// finding doesn't correspond to any real change on the wire), on top of the
+// `identity`-became-nullable finding the ticket already expected. Marking
+// the schema nullable instead makes `null` reachable through the *type
+// alias* rather than at the property: `identity?:
+// components["schemas"]["LookupIdentityBlock"];` (no `| null` on this
+// line), with the `| null` living on `LookupIdentityBlock` itself. Both
+// shapes are equivalent for a TypeScript consumer — `null` is reachable
+// either way — but only one of the two produces exactly the two expected
+// oasdiff findings, so this pins the actual emitted shape rather than the
+// originally-planned one.
+describe("generated LookupResponse markers stay optional and nullable (#316)", () => {
+  const responseBlock = () => schemaBlock("LookupResponse");
+
+  it("emits api_version as optional and nullable, nullable right on the property", () => {
+    expect(responseBlock()).toMatch(/\bapi_version\?: 2 \| null;/);
+  });
+
+  it("emits identity as optional, referencing the LookupIdentityBlock type alias (no `| null` at the property)", () => {
+    expect(responseBlock()).toMatch(
+      /\bidentity\?: components\["schemas"\]\["LookupIdentityBlock"\];/,
+    );
+  });
+
+  it("keeps results required", () => {
+    // Guards the assertions above against passing for the wrong reason —
+    // e.g. a regex that matches because the whole block vanished.
+    expect(responseBlock()).toMatch(/\n\s+results: /);
+  });
+
+  it("makes null reachable through the LookupIdentityBlock type alias itself", () => {
+    const start = dts.indexOf("LookupIdentityBlock: {");
+    expect(start, "LookupIdentityBlock missing from generated types").toBeGreaterThan(-1);
+    const closeIdx = dts.indexOf("} | null;", start);
+    expect(
+      closeIdx,
+      "LookupIdentityBlock's closing brace is not followed by `| null;` — nullability was lost",
+    ).toBeGreaterThan(-1);
+    const block = dts.slice(start, closeIdx + "} | null;".length);
+    // Guards against the slice picking up some other `} | null;` far away in
+    // the file — the resolved property must still be inside it.
+    expect(block).toMatch(/\bresolved: components\["schemas"\]\["IdentityResolution"\]\[\];/);
+  });
+});


### PR DESCRIPTION
Closes #316

## Problem

`LookupResponse.api_version` and `.identity` were documented as absent-when-unset, but library-metadata-lookup serves `POST /lookup` through FastAPI's `response_model` without `response_model_exclude_none`, and no `LookupResponse(...)` construction site (`lookup/orchestrator.py` L1343/L1368/L1653, `lookup/router.py` L690/L812) ever sets either field — not even when the request sets `include_identity: true`, because neither side of the cross-cache-identity feature is implemented in the producer yet. So both fields sit at their `None` default and ship as explicit `null` on 100% of `/lookup` responses, which `api_version`'s `enum: [2]` doesn't accept, and which the schema's "byte-identical to v0.5.0 — both omitted" claim never actually described. This is the identical defect #310 fixed on the sibling marker `BulkResolveLibrariesResponse.tracks_contract_version`, on the endpoint that supplied #310's precedent in the first place.

## Fix

- `api_version` gets `nullable: true` directly on the property, same shape as #310.
- `identity` needed a different shape than the ticket originally specified. The bare-`$ref`-plus-`allOf`-wrapper workaround (needed because OpenAPI 3.0 ignores sibling keys, including `nullable: true`, written next to a bare `$ref`) produced a spurious third oasdiff finding — `response-required-property-removed` on `identity/resolved` — even though `LookupIdentityBlock.required` never changed and nothing about that requirement is actually different on the wire. Rather than whitelist a finding beyond what was scoped, `identity` stays exactly the bare `$ref` it is on `main`, and `nullable: true` moved onto the `LookupIdentityBlock` schema definition itself instead — safe because that schema is referenced exactly once in the whole spec, from `LookupResponse.identity`. The schema's description now says so explicitly, including the instruction that a second reference must re-examine whether nullability is still correct there. Emitted TypeScript is functionally equivalent either way; `null` just becomes reachable through the type alias (`LookupIdentityBlock: {...} | null`) rather than at the property (`identity?: ... | null`).
- Every description that claimed either field is absent/omitted now says what actually ships, and mandates `api_version === 2` as the value-equality probe — never a presence check, since absent, `null`, and an unimplemented producer must all read "not supported."

## Verified emitted TypeScript

```ts
api_version?: 2 | null;
identity?: components["schemas"]["LookupIdentityBlock"];
// ...
LookupIdentityBlock: {
    resolved: components["schemas"]["IdentityResolution"][];
} | null;
```

`null` is reachable in both cases — directly on `api_version`, and through the `LookupIdentityBlock` type alias for `identity`.

## Breaking-change gate

`npm run check:breaking` reports exactly the two expected findings, verbatim:

```
the response property `api_version` became nullable for the status `200`
the response property `identity` became nullable for the status `200`
```

Both whitelisted in `oasdiff-err-ignore.txt` with the standard justification: no producer has ever set either field, so declaring the nullability corrects the schema toward a wire that already ships rather than changing wire behavior for any decoder.

## The stale `library-identity-writer.ts` claim

Re-verified rather than assumed. Backend-Service's `main` is at the same SHA (`67d6d7b`) the original #309 read used — it has not moved — and a full-tree `git grep` finds no file named `library-identity-writer.ts` and zero `include_identity` references anywhere in its TypeScript; the only occurrence in the entire repo is prose in `plans/library-hook-canonicalization/architecture-pivot-2026-05-09.md` describing a writer that has not been built. So the claim wasn't merely stale — the file it names doesn't exist. request-o-matic's production `LookupRequest(...)` call site (`routers/request.py:454`) never sets `include_identity`, so it ships as the `false` default, consistent with the original claim; dj-site and tubafrenzy have zero `include_identity` references at all. The `include_identity` description, the `LookupResponse`/`LookupIdentityBlock` schema descriptions, and the Identity Block section comment are all corrected accordingly.

## Testing

TDD throughout: 9 new/rewritten tests written and run red against the unmodified spec first, then green after the `api.yaml` changes. `npm test` (669/669), `npm run lint`, `npm run check:breaking`, and the `test:breaking-guard` bats suite (`scripts/__tests__/check-breaking-changes.test.sh`, 14/14) all pass locally.

## Related

- #310 — the identical defect on the sibling marker, whose PR (#314) this one mirrors where the shapes matched
- #309 — the presence-vs-value-probe pattern and the `include_identity` caller claim this PR re-verifies
- #303 — introduced `tracks_contract_version` citing `api_version` as precedent
- WXYC/library-metadata-lookup#1158 — LML's half; its acceptance criteria specify the `response_model_exclude_none` approach this PR (like #310) rejects, and should be updated to point at this fix
