### PR TITLE
spec(api.yaml): document GET /flowsheet/range (start/end epoch ms -> {shows, entries})

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -205,120 +205,243 @@ components:
         show_id:
           type: integer
 
+    FlowsheetEntryFields:
+      description: >-
+        Every non-identity field of a v1 flowsheet row. Factored out of
+        `FlowsheetEntryResponse` so `FlowsheetRangeEntry` can carry the identical
+        field set while relaxing `show_id` to nullable — the two response shapes
+        must not drift, because iOS V2 decodes both with one decoder
+        (tubafrenzy-decommissioning plan §2.5, consumer #3). Not referenced
+        directly by any path; compose it with an identity block instead.
+      type: object
+      required:
+        - request_flag
+      properties:
+        # Song entry fields
+        album_id:
+          type: integer
+        track_title:
+          type: string
+        album_title:
+          type: string
+        artist_name:
+          type: string
+        record_label:
+          type: string
+        label_id:
+          type: integer
+        rotation_id:
+          type: integer
+        rotation_bin:
+          $ref: '#/components/schemas/RotationBin'
+        request_flag:
+          type: boolean
+        segue:
+          type: boolean
+        # Message/breakpoint fields
+        message:
+          type: string
+        # Metadata fields (from cache)
+        artwork_url:
+          type: string
+          nullable: true
+        discogs_url:
+          type: string
+          nullable: true
+        release_year:
+          type: integer
+          nullable: true
+        discogsUnavailable:
+          type: boolean
+          description: >-
+            Rides the same MD-set "not on Discogs" flag as the Album
+            surfaces (see `Album.discogsUnavailable`), non-nullable to
+            match them. Deliberately camelCase — unlike its snake_case
+            siblings in this block — to match Backend's
+            `withDiscogsUnavailableCamelCase` serializer. Contract-first:
+            the V2 flowsheet album embed will carry this field once the
+            BS-emit piece (WXYC/Backend-Service#1908) lands; it is not
+            emitted there yet.
+        discogsUnavailableNote:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: Optional free-text reason for `discogsUnavailable`.
+        spotify_url:
+          type: string
+          nullable: true
+        apple_music_url:
+          type: string
+          nullable: true
+        youtube_music_url:
+          type: string
+          nullable: true
+        bandcamp_url:
+          type: string
+          nullable: true
+        soundcloud_url:
+          type: string
+          nullable: true
+        artist_bio:
+          type: string
+          nullable: true
+        artist_wikipedia_url:
+          type: string
+          nullable: true
+        track_position:
+          type: string
+          nullable: true
+          description: >
+            Track position on the release (e.g., "A1", "B2", "5"). Populated when the
+            flowsheet entry was created via the dj-site picker after release selection
+            (catalog-track-search plan §5.3 / Track 3). String-typed to match Discogs's
+            `release_track.position`. Null for free-text entries and legacy rows.
+        metadata_status:
+          $ref: '#/components/schemas/MetadataStatus'
+        # Projection-parity fields (BS#1513 / BS#1534). These ride the
+        # flowsheet mutation echoes and the liveFs:update SSE payload via
+        # Backend's CLIENT_FACING_FLOWSHEET_COLUMNS allow-list, but were
+        # previously undeclared here. Optional: absent/nullable on some rows.
+        entry_type:
+          $ref: '#/components/schemas/FlowsheetEntryType'
+        add_time:
+          type: string
+          format: date-time
+          description: The instant this row was logged (ISO 8601).
+        radio_hour:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Top-of-hour a breakpoint row marks (ISO 8601), sourced from
+            tubafrenzy's RADIO_HOUR. Null on non-breakpoint rows and rows
+            predating the producer rollout. Mirrors the V2 breakpoint entry.
+        dj_name:
+          type: string
+          nullable: true
+          description: >-
+            Resolved public display name of the DJ on the row's show. Nullable
+            per the PII-safe resolution chain (BS#1371): user.djName ->
+            shows.legacy_dj_name -> null; never the real-name PII column.
+
     FlowsheetEntryResponse:
       description: Flowsheet entry as returned by the API with all possible fields
       allOf:
         - $ref: '#/components/schemas/FlowsheetEntryBase'
-        - type: object
-          required:
-            - request_flag
-          properties:
-            # Song entry fields
-            album_id:
-              type: integer
-            track_title:
-              type: string
-            album_title:
-              type: string
-            artist_name:
-              type: string
-            record_label:
-              type: string
-            label_id:
-              type: integer
-            rotation_id:
-              type: integer
-            rotation_bin:
-              $ref: '#/components/schemas/RotationBin'
-            request_flag:
-              type: boolean
-            segue:
-              type: boolean
-            # Message/breakpoint fields
-            message:
-              type: string
-            # Metadata fields (from cache)
-            artwork_url:
-              type: string
-              nullable: true
-            discogs_url:
-              type: string
-              nullable: true
-            release_year:
-              type: integer
-              nullable: true
-            discogsUnavailable:
-              type: boolean
-              description: >-
-                Rides the same MD-set "not on Discogs" flag as the Album
-                surfaces (see `Album.discogsUnavailable`), non-nullable to
-                match them. Deliberately camelCase — unlike its snake_case
-                siblings in this block — to match Backend's
-                `withDiscogsUnavailableCamelCase` serializer. Contract-first:
-                the V2 flowsheet album embed will carry this field once the
-                BS-emit piece (WXYC/Backend-Service#1908) lands; it is not
-                emitted there yet.
-            discogsUnavailableNote:
-              type: string
-              nullable: true
-              maxLength: 500
-              description: Optional free-text reason for `discogsUnavailable`.
-            spotify_url:
-              type: string
-              nullable: true
-            apple_music_url:
-              type: string
-              nullable: true
-            youtube_music_url:
-              type: string
-              nullable: true
-            bandcamp_url:
-              type: string
-              nullable: true
-            soundcloud_url:
-              type: string
-              nullable: true
-            artist_bio:
-              type: string
-              nullable: true
-            artist_wikipedia_url:
-              type: string
-              nullable: true
-            track_position:
-              type: string
-              nullable: true
-              description: >
-                Track position on the release (e.g., "A1", "B2", "5"). Populated when the
-                flowsheet entry was created via the dj-site picker after release selection
-                (catalog-track-search plan §5.3 / Track 3). String-typed to match Discogs's
-                `release_track.position`. Null for free-text entries and legacy rows.
-            metadata_status:
-              $ref: '#/components/schemas/MetadataStatus'
-            # Projection-parity fields (BS#1513 / BS#1534). These ride the
-            # flowsheet mutation echoes and the liveFs:update SSE payload via
-            # Backend's CLIENT_FACING_FLOWSHEET_COLUMNS allow-list, but were
-            # previously undeclared here. Optional: absent/nullable on some rows.
-            entry_type:
-              $ref: '#/components/schemas/FlowsheetEntryType'
-            add_time:
-              type: string
-              format: date-time
-              description: The instant this row was logged (ISO 8601).
-            radio_hour:
-              type: string
-              format: date-time
-              nullable: true
-              description: >-
-                Top-of-hour a breakpoint row marks (ISO 8601), sourced from
-                tubafrenzy's RADIO_HOUR. Null on non-breakpoint rows and rows
-                predating the producer rollout. Mirrors the V2 breakpoint entry.
-            dj_name:
-              type: string
-              nullable: true
-              description: >-
-                Resolved public display name of the DJ on the row's show. Nullable
-                per the PII-safe resolution chain (BS#1371): user.djName ->
-                shows.legacy_dj_name -> null; never the real-name PII column.
+        - $ref: '#/components/schemas/FlowsheetEntryFields'
+
+    FlowsheetRangeEntryBase:
+      description: >-
+        Identity block for `GET /flowsheet/range`. Identical to
+        `FlowsheetEntryBase` except that `show_id` is nullable — see that
+        property's description. Kept separate rather than relaxing
+        `FlowsheetEntryBase` in place so the other flowsheet paths' documented
+        shapes are untouched by this endpoint.
+      type: object
+      required:
+        - id
+        - play_order
+        - show_id
+      properties:
+        id:
+          type: integer
+        play_order:
+          type: integer
+        show_id:
+          type: integer
+          nullable: true
+          description: >-
+            The show this entry belongs to, or `null` for an **unattributed**
+            entry — a row that exists with no linked show. 20 of 2,619,011 rows
+            are in that state (2005-02-06 → 2026-04-21), and the Phase 0 audit
+            for the tubafrenzy decommissioning decided against backfilling them,
+            so this endpoint returns them rather than dropping them. Consumers
+            that group entries by show must render an unattributed bucket; they
+            must not assume every entry joins to a member of `shows`, and must
+            not crash on the null. The key is always present.
+
+    FlowsheetRangeEntry:
+      description: >-
+        A flowsheet row as returned by `GET /flowsheet/range`. Carries the exact
+        field set of `FlowsheetEntryResponse` (both compose
+        `FlowsheetEntryFields`) and differs from it in one respect: `show_id` is
+        nullable. Field parity is a contract requirement, not a coincidence —
+        iOS V2 decodes this endpoint and `GET /flowsheet` with a single decoder
+        (tubafrenzy-decommissioning plan §2.5, consumer #3).
+      allOf:
+        - $ref: '#/components/schemas/FlowsheetRangeEntryBase'
+        - $ref: '#/components/schemas/FlowsheetEntryFields'
+
+    FlowsheetRangeShow:
+      description: >-
+        Show metadata for one show overlapping a `GET /flowsheet/range` window.
+        A deliberately public-safe projection of the `shows` row: it carries the
+        DJ's public handle but no user id and no real-name column. Distinct from
+        `Show`, which exposes `primary_dj_id` and is used on authenticated
+        surfaces.
+      type: object
+      required:
+        - id
+        - start_time
+      properties:
+        id:
+          type: integer
+          description: >-
+            Matches `FlowsheetRangeEntry.show_id` for every entry belonging to
+            this show.
+        show_name:
+          type: string
+          nullable: true
+          description: Specialty-show name, or `null` for a regular show.
+        dj_name:
+          type: string
+          nullable: true
+          description: >-
+            Resolved public display name of the show's DJ. Same PII-safe
+            resolution chain as `FlowsheetEntryFields.dj_name` (BS#1371):
+            per-show override -> `user.djName` -> `shows.legacy_dj_name`
+            (tubafrenzy's `DJ_HANDLE`) -> null. Never the real-name column.
+        specialty_id:
+          type: integer
+          nullable: true
+        start_time:
+          type: string
+          format: date-time
+          description: When the DJ signed on (ISO 8601).
+        end_time:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            When the DJ signed off (ISO 8601), or `null` for a show still on
+            air — which is the normal case for a window ending at "now", and
+            also occurs on historical rows whose sign-off was never recorded.
+
+    FlowsheetRangeResponse:
+      description: >-
+        Response body of `GET /flowsheet/range`. `shows` is a deliberate
+        superset: consumers that only need the entry stream (which carries
+        inline `show_start` / `show_end` markers in `entry_type`) can ignore it.
+      type: object
+      required:
+        - shows
+        - entries
+      properties:
+        shows:
+          type: array
+          description: >-
+            Every show overlapping the window, ordered by `start_time` ascending.
+            Empty when the window contains no shows.
+          items:
+            $ref: '#/components/schemas/FlowsheetRangeShow'
+        entries:
+          type: array
+          description: >-
+            Every flowsheet row in the window, ordered by `play_order` ascending
+            (chronological). Includes the `show_start` / `show_end` marker rows,
+            so a consumer can segment the stream without joining `shows`.
+          items:
+            $ref: '#/components/schemas/FlowsheetRangeEntry'
 
     FlowsheetSongEntry:
       description: Song entry in the flowsheet
@@ -7406,6 +7529,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ShowPlaylist'
+
+  /flowsheet/range:
+    get:
+      summary: Get flowsheet entries and show metadata for a time window
+      description: |
+        Public, unauthenticated, date-windowed read of the flowsheet. Successor
+        to tubafrenzy's `GET /playlists/dailyEntries?dayStart=<epoch>`, which
+        dies at the tubafrenzy cutover; specified in
+        [`plans/tubafrenzy-decommissioning.md` §2.5](https://github.com/WXYC/wiki/blob/main/plans/tubafrenzy-decommissioning.md).
+
+        **Window semantics.** `start` and `end` are epoch **milliseconds**, not
+        ISO strings — they match the `dayStart` convention the `archive` app
+        already computes. The window is half-open, `[start, end)`, evaluated
+        against each entry's `add_time`. `entries` therefore never
+        double-counts a row across two adjacent windows. `shows` uses *overlap*
+        rather than containment: a show is returned when
+        `[start_time, end_time)` intersects the window, so a show spanning
+        midnight appears in both days' responses. A show still on air
+        (`end_time: null`) is treated as extending to the present.
+
+        **Bounded on purpose.** This is an unauthenticated route over a 2.6M-row
+        table, so an unbounded window is a trivially available denial of
+        service. Windows longer than **31 days** are rejected with `400`. That
+        ceiling clears both real consumers with room to spare — 24h for the
+        `archive` daily playlist and 7d for the `wxyc.org` historical-archive
+        page — and is deliberately not exactly 7d, because a week spanning the
+        autumn DST transition is 7d + 1h and would otherwise fail.
+
+        An empty window is a normal result: `200` with
+        `{"shows": [], "entries": []}`, never `404`.
+      security: []
+      parameters:
+        - name: start
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: Inclusive start of the window, epoch milliseconds (UTC).
+        - name: end
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: >-
+            Exclusive end of the window, epoch milliseconds (UTC). Must be
+            strictly greater than `start`.
+      responses:
+        '200':
+          description: Shows and entries for the window.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowsheetRangeResponse'
+        '400':
+          description: >-
+            `start` or `end` missing or not an integer, `end` not strictly
+            greater than `start`, or the window longer than 31 days.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
 
   /flowsheet/search:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -413,9 +413,13 @@ components:
           format: date-time
           nullable: true
           description: >-
-            When the DJ signed off (ISO 8601), or `null` for a show still on
-            air — which is the normal case for a window ending at "now", and
-            also occurs on historical rows whose sign-off was never recorded.
+            When the DJ signed off (ISO 8601), or `null`. Null has **two**
+            causes and they are not distinguishable from this field alone: the
+            show is genuinely on the air, or its `show_end` delivery was
+            dropped and the column stayed null permanently (nothing re-closes
+            it on a schedule). Do not render a null `end_time` as "on air now";
+            compare `start_time` against the present, or read the `show_end`
+            marker row in `entries`, which is the second independent signal.
 
     FlowsheetRangeResponse:
       description: >-
@@ -437,9 +441,15 @@ components:
         entries:
           type: array
           description: >-
-            Every flowsheet row in the window, ordered by `play_order` ascending
-            (chronological). Includes the `show_start` / `show_end` marker rows,
-            so a consumer can segment the stream without joining `shows`.
+            Every flowsheet row in the window, ordered by `add_time` ascending
+            and tie-broken on `id` — NOT by `play_order`, which is per-show and
+            interleaves a multi-show window (see the endpoint description).
+            Includes the `show_start` / `show_end` marker rows. Those markers
+            are a convenience, not a guarantee: a show whose `show_end`
+            delivery was dropped has no closing marker (the same failure that
+            leaves `FlowsheetRangeShow.end_time` null), so a consumer that
+            segments purely on markers will run one show's entries into the
+            next. Segment on `show_id` and treat the markers as labels.
           items:
             $ref: '#/components/schemas/FlowsheetRangeEntry'
 
@@ -7542,20 +7552,49 @@ paths:
         **Window semantics.** `start` and `end` are epoch **milliseconds**, not
         ISO strings — they match the `dayStart` convention the `archive` app
         already computes. The window is half-open, `[start, end)`, evaluated
-        against each entry's `add_time`. `entries` therefore never
-        double-counts a row across two adjacent windows. `shows` uses *overlap*
-        rather than containment: a show is returned when
+        against each entry's `add_time`, so `entries` never double-counts a row
+        across two adjacent windows.
+
+        One consequence to design around rather than discover: `add_time` is the
+        instant a row was *logged*, and a breakpoint row is logged roughly a
+        minute **before** the hour it marks (its true hour lives in
+        `radio_hour`). An hour-aligned window therefore reports each hour's
+        breakpoint in the *previous* window — for a midnight-aligned day, the
+        00:00 marker arrives with the day before. This is the off-by-one-hour
+        class BS#1448 / BS#1449 fixed at the rendering layer; consumers that
+        draw hour markers should key on `radio_hour`, not on which window the
+        row arrived in.
+
+        `shows` uses *overlap* rather than containment: a show is returned when
         `[start_time, end_time)` intersects the window, so a show spanning
-        midnight appears in both days' responses. A show still on air
-        (`end_time: null`) is treated as extending to the present.
+        midnight appears in both days' responses. **A `null` `end_time` does not
+        mean "on the air"** and must not be treated as extending to now — a
+        show whose `show_end` delivery was dropped keeps `end_time` NULL
+        permanently, and reading NULL as open-ended would make every one of
+        those orphaned historical shows intersect every window forever. An
+        open-ended show is included only when its `start_time` falls inside the
+        window; a genuinely live show satisfies that on the windows a listener
+        actually asks for.
+
+        **Ordering.** `entries` is ordered by `add_time` ascending, tie-broken
+        on `id` ascending. **Not by `play_order`** — that column is assigned
+        independently per show by the tubafrenzy webhook path and the dj-site
+        insert path, so it is only meaningful within one show and repeats
+        across the many shows a window spans. Ordering a multi-show window by
+        it interleaves the shows. `id` is globally monotonic, which is why it
+        is the tie-break (same reason `getEntriesByShow` needs one — see the
+        2026-05-01 reordering incident).
 
         **Bounded on purpose.** This is an unauthenticated route over a 2.6M-row
         table, so an unbounded window is a trivially available denial of
-        service. Windows longer than **31 days** are rejected with `400`. That
-        ceiling clears both real consumers with room to spare — 24h for the
-        `archive` daily playlist and 7d for the `wxyc.org` historical-archive
-        page — and is deliberately not exactly 7d, because a week spanning the
-        autumn DST transition is 7d + 1h and would otherwise fail.
+        service. Windows longer than **8 days** are rejected with `400`. That
+        covers both real consumers — 24h for the `archive` daily playlist and
+        7d for the `wxyc.org` historical-archive page — with a day of slack,
+        deliberately not exactly 7d because a week spanning the autumn DST
+        transition is 7d + 1h and would otherwise fail. The ceiling is this
+        tight because the response is unpaginated: it bounds the row count, and
+        therefore the response size, not just the time span. Month- and
+        year-scale analytical reads are explicitly **not** this endpoint's job.
 
         An empty window is a normal result: `200` with
         `{"shows": [], "entries": []}`, never `404`.
@@ -7587,7 +7626,7 @@ paths:
         '400':
           description: >-
             `start` or `end` missing or not an integer, `end` not strictly
-            greater than `start`, or the window longer than 31 days.
+            greater than `start`, or the window longer than 8 days.
           content:
             application/json:
               schema:

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -33,6 +33,50 @@ describe('OpenAPI Specification', () => {
     spec = parse(content) as OpenAPISpec;
   });
 
+  // Composed schemas in this spec are `allOf: [<identity block>, <field block>]`
+  // and either branch may be a `$ref` rather than an inline object —
+  // `FlowsheetEntryResponse` and `FlowsheetRangeEntry` both share their field
+  // block that way, so that the two can never drift apart. A walk that only
+  // reads inline `properties`/`required` off the immediate branches silently
+  // finds nothing on those, which reads as "the field isn't declared" rather
+  // than "the helper can't see it". These two follow `$ref` instead.
+  function deref(node: unknown, seen = new Set<string>()): Record<string, unknown> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const schema = node as Record<string, unknown>;
+    const ref = schema.$ref;
+    if (typeof ref !== 'string') return schema;
+    if (seen.has(ref)) return undefined;
+    seen.add(ref);
+    return deref(spec.components.schemas[ref.split('/').pop() as string], seen);
+  }
+
+  function propertyOf(schemaName: string, prop: string): Record<string, unknown> | undefined {
+    function walk(node: unknown): Record<string, unknown> | undefined {
+      const schema = deref(node);
+      if (!schema) return undefined;
+      const properties = schema.properties as Record<string, Record<string, unknown>> | undefined;
+      if (properties?.[prop]) return properties[prop];
+      for (const branch of (schema.allOf as unknown[] | undefined) ?? []) {
+        const found = walk(branch);
+        if (found) return found;
+      }
+      return undefined;
+    }
+    return walk(spec.components.schemas[schemaName]);
+  }
+
+  function requiredKeysOf(schemaName: string): string[] {
+    function walk(node: unknown): string[] {
+      const schema = deref(node);
+      if (!schema) return [];
+      return [
+        ...((schema.required as string[] | undefined) ?? []),
+        ...((schema.allOf as unknown[] | undefined) ?? []).flatMap(walk),
+      ];
+    }
+    return walk(spec.components.schemas[schemaName]);
+  }
+
   describe('Structure', () => {
     it('should be valid OpenAPI 3.0', () => {
       expect(spec.openapi).toMatch(/^3\.0/);
@@ -144,17 +188,7 @@ describe('OpenAPI Specification', () => {
     });
 
     describe('track_position field (catalog-track-search Track 3 / E6)', () => {
-      function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
-        const schema = spec.components.schemas[schemaName] as
-          | { properties?: Record<string, Record<string, unknown>>; allOf?: Array<{ properties?: Record<string, Record<string, unknown>> }> }
-          | undefined;
-        if (!schema) return undefined;
-        if (schema.properties?.[prop]) return schema.properties[prop];
-        for (const branch of schema.allOf ?? []) {
-          if (branch.properties?.[prop]) return branch.properties[prop];
-        }
-        return undefined;
-      }
+      const getProperty = propertyOf;
 
       // String-typed to match Discogs's `release_track.position` (vinyl "A1",
       // CD "5", multi-disc "1-12"). FlowsheetEntryBase + FlowsheetSongEntry
@@ -248,17 +282,7 @@ describe('OpenAPI Specification', () => {
     });
 
     describe('metadata_status field (BS#891 / Epic C)', () => {
-      function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
-        const schema = spec.components.schemas[schemaName] as
-          | { properties?: Record<string, Record<string, unknown>>; allOf?: Array<{ properties?: Record<string, Record<string, unknown>> }> }
-          | undefined;
-        if (!schema) return undefined;
-        if (schema.properties?.[prop]) return schema.properties[prop];
-        for (const branch of schema.allOf ?? []) {
-          if (branch.properties?.[prop]) return branch.properties[prop];
-        }
-        return undefined;
-      }
+      const getProperty = propertyOf;
 
       it('should define MetadataStatus enum with all 5 BS-side values', () => {
         const metadataStatus = spec.components.schemas.MetadataStatus as { type?: string; enum?: string[] };
@@ -280,11 +304,7 @@ describe('OpenAPI Specification', () => {
       });
 
       it('FlowsheetEntryResponse should not require metadata_status (absent on non-track / pre-Epic-C rows)', () => {
-        const schema = spec.components.schemas.FlowsheetEntryResponse as {
-          allOf?: Array<{ required?: string[] }>;
-          required?: string[];
-        };
-        const required = [...(schema.required ?? []), ...(schema.allOf ?? []).flatMap((b) => b.required ?? [])];
+        const required = requiredKeysOf('FlowsheetEntryResponse');
         expect(required).not.toContain('metadata_status');
       });
 
@@ -295,11 +315,7 @@ describe('OpenAPI Specification', () => {
       });
 
       it('FlowsheetV2TrackEntry should not require metadata_status', () => {
-        const schema = spec.components.schemas.FlowsheetV2TrackEntry as {
-          allOf?: Array<{ required?: string[] }>;
-          required?: string[];
-        };
-        const required = [...(schema.required ?? []), ...(schema.allOf ?? []).flatMap((b) => b.required ?? [])];
+        const required = requiredKeysOf('FlowsheetV2TrackEntry');
         expect(required).not.toContain('metadata_status');
       });
     });
@@ -312,25 +328,9 @@ describe('OpenAPI Specification', () => {
       // add_time, radio_hour, and dj_name — fields that rode the wire but were
       // undeclared here, so the SSOT under-described its own payload. They are
       // optional (absent/nullable on some rows), so none is added to `required`.
-      function getProperty(schemaName: string, prop: string): Record<string, unknown> | undefined {
-        const schema = spec.components.schemas[schemaName] as
-          | { properties?: Record<string, Record<string, unknown>>; allOf?: Array<{ properties?: Record<string, Record<string, unknown>> }> }
-          | undefined;
-        if (!schema) return undefined;
-        if (schema.properties?.[prop]) return schema.properties[prop];
-        for (const branch of schema.allOf ?? []) {
-          if (branch.properties?.[prop]) return branch.properties[prop];
-        }
-        return undefined;
-      }
+      const getProperty = propertyOf;
 
-      function requiredKeys(schemaName: string): string[] {
-        const schema = spec.components.schemas[schemaName] as {
-          allOf?: Array<{ required?: string[] }>;
-          required?: string[];
-        };
-        return [...(schema.required ?? []), ...(schema.allOf ?? []).flatMap((b) => b.required ?? [])];
-      }
+      const requiredKeys = requiredKeysOf;
 
       it('declares entry_type via the FlowsheetEntryType enum', () => {
         const entryType = getProperty('FlowsheetEntryResponse', 'entry_type');
@@ -365,6 +365,109 @@ describe('OpenAPI Specification', () => {
         for (const field of ['entry_type', 'add_time', 'radio_hour', 'dj_name']) {
           expect(required).not.toContain(field);
         }
+      });
+    });
+
+    // Successor to tubafrenzy's `/playlists/dailyEntries`, which dies at the
+    // 2026-08-31 cutover (WXYC/wiki#91 Phase 4, WXYC/wxyc-shared#329). Three
+    // consumers get built against this shape at roughly the same time — the
+    // `archive` daily playlist, the wxyc.org historical-archive page, and iOS
+    // V2 — so it is pinned here rather than reverse-engineered from whichever
+    // ships first.
+    describe('GET /flowsheet/range (Phase 4 — wiki#91 / #329)', () => {
+      function rangeGet(): {
+        security?: unknown[];
+        parameters?: Array<{ name: string; in: string; required?: boolean; schema?: { type?: string } }>;
+        responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }>;
+      } {
+        const path = spec.paths['/flowsheet/range'] as { get?: ReturnType<typeof rangeGet> };
+        expect(path?.get).toBeDefined();
+        return path.get as ReturnType<typeof rangeGet>;
+      }
+
+      it('is public — no auth, matching its sibling /flowsheet/search', () => {
+        expect(rangeGet().security).toEqual([]);
+      });
+
+      it('requires start and end as epoch-millisecond integers', () => {
+        const params = rangeGet().parameters ?? [];
+        for (const name of ['start', 'end']) {
+          const param = params.find((p) => p.name === name);
+          expect(param, `missing query param ${name}`).toBeDefined();
+          expect(param?.in).toBe('query');
+          expect(param?.required).toBe(true);
+          expect(param?.schema?.type).toBe('integer');
+          // Epoch ms overflows int32 (has since 1970 + 24.8 days).
+          expect(param?.schema).toMatchObject({ format: 'int64' });
+        }
+      });
+
+      it('returns FlowsheetRangeResponse on 200 and ApiErrorResponse on 400', () => {
+        const responses = rangeGet().responses ?? {};
+        expect(responses['200']?.content?.['application/json']?.schema?.$ref).toBe(
+          '#/components/schemas/FlowsheetRangeResponse'
+        );
+        expect(responses['400']?.content?.['application/json']?.schema?.$ref).toBe(
+          '#/components/schemas/ApiErrorResponse'
+        );
+      });
+
+      it('documents the 31-day window ceiling that bounds this unauthenticated route', () => {
+        const description = (spec.paths['/flowsheet/range'] as { get: { description?: string } }).get.description ?? '';
+        expect(description).toMatch(/31 days/);
+      });
+
+      it('envelopes shows and entries, both required', () => {
+        expect(requiredKeysOf('FlowsheetRangeResponse').sort()).toEqual(['entries', 'shows']);
+        expect(propertyOf('FlowsheetRangeResponse', 'entries')).toMatchObject({
+          items: { $ref: '#/components/schemas/FlowsheetRangeEntry' },
+        });
+        expect(propertyOf('FlowsheetRangeResponse', 'shows')).toMatchObject({
+          items: { $ref: '#/components/schemas/FlowsheetRangeShow' },
+        });
+      });
+
+      // 20 of 2,619,011 rows have no linked show and Phase 0 decided against a
+      // backfill, so the null reaches the wire. Both consumers that group by
+      // show are the likely defect site.
+      it('declares entries[].show_id nullable, present, and names the unattributed case', () => {
+        const showId = propertyOf('FlowsheetRangeEntry', 'show_id');
+        expect(showId?.type).toBe('integer');
+        expect(showId?.nullable).toBe(true);
+        expect(String(showId?.description)).toMatch(/unattributed/i);
+        // Nullable value, still-present key — the `--strict-nullable` idiom.
+        expect(requiredKeysOf('FlowsheetRangeEntry')).toContain('show_id');
+      });
+
+      // iOS V2 decodes this endpoint and GET /flowsheet with one decoder
+      // (tubafrenzy-decommissioning plan §2.5, consumer #3), so the two entry
+      // shapes may differ in show_id's nullability and in nothing else. Both
+      // compose FlowsheetEntryFields to make that structural; this pins it.
+      it('carries the exact field set of FlowsheetEntryResponse', () => {
+        function fieldNames(schemaName: string): string[] {
+          function walk(node: unknown): string[] {
+            const schema = deref(node);
+            if (!schema) return [];
+            return [
+              ...Object.keys((schema.properties as Record<string, unknown> | undefined) ?? {}),
+              ...((schema.allOf as unknown[] | undefined) ?? []).flatMap(walk),
+            ];
+          }
+          return [...new Set(walk(spec.components.schemas[schemaName]))].sort();
+        }
+        expect(fieldNames('FlowsheetRangeEntry')).toEqual(fieldNames('FlowsheetEntryResponse'));
+        expect(requiredKeysOf('FlowsheetRangeEntry').sort()).toEqual(
+          requiredKeysOf('FlowsheetEntryResponse').sort()
+        );
+      });
+
+      // Public, unauthenticated surface: the show projection carries the DJ's
+      // handle, never a user id or the real-name column (BS#1371).
+      it('projects shows without primary_dj_id, with a nullable resolved dj_name', () => {
+        expect(propertyOf('FlowsheetRangeShow', 'primary_dj_id')).toBeUndefined();
+        expect(propertyOf('FlowsheetRangeShow', 'dj_name')).toMatchObject({ type: 'string', nullable: true });
+        expect(propertyOf('FlowsheetRangeShow', 'end_time')).toMatchObject({ nullable: true });
+        expect(requiredKeysOf('FlowsheetRangeShow').sort()).toEqual(['id', 'start_time']);
       });
     });
   });
@@ -607,17 +710,8 @@ describe('OpenAPI Specification', () => {
     });
 
     describe('FlowsheetEntryResponse (api.yaml piece of Backend-Service#1908)', () => {
-      function getProperty(prop: string): SchemaProp | undefined {
-        const schema = spec.components.schemas.FlowsheetEntryResponse as {
-          properties?: Record<string, SchemaProp>;
-          allOf?: Array<{ properties?: Record<string, SchemaProp> }>;
-        };
-        if (schema.properties?.[prop]) return schema.properties[prop];
-        for (const branch of schema.allOf ?? []) {
-          if (branch.properties?.[prop]) return branch.properties[prop];
-        }
-        return undefined;
-      }
+      const getProperty = (prop: string): SchemaProp | undefined =>
+        propertyOf('FlowsheetEntryResponse', prop) as SchemaProp | undefined;
 
       it('gains discogsUnavailable as a non-nullable boolean matching the other Album surfaces, camelCase deliberately unlike its snake_case siblings', () => {
         const prop = getProperty('discogsUnavailable');

--- a/tests/api-spec.test.ts
+++ b/tests/api-spec.test.ts
@@ -74,7 +74,12 @@ describe('OpenAPI Specification', () => {
         ...((schema.allOf as unknown[] | undefined) ?? []).flatMap(walk),
       ];
     }
-    return walk(spec.components.schemas[schemaName]);
+    // De-duplicated: composition here is a lattice, not a tree — two allOf
+    // branches can reach the same field block (that is the whole point of
+    // `FlowsheetEntryFields`), and a raw concat would then report a key twice
+    // and fail an equality assertion for a reason that has nothing to do with
+    // the contract.
+    return [...new Set(walk(spec.components.schemas[schemaName]))];
   }
 
   describe('Structure', () => {
@@ -377,12 +382,16 @@ describe('OpenAPI Specification', () => {
     describe('GET /flowsheet/range (Phase 4 — wiki#91 / #329)', () => {
       function rangeGet(): {
         security?: unknown[];
+        description?: string;
         parameters?: Array<{ name: string; in: string; required?: boolean; schema?: { type?: string } }>;
         responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }>;
       } {
-        const path = spec.paths['/flowsheet/range'] as { get?: ReturnType<typeof rangeGet> };
-        expect(path?.get).toBeDefined();
-        return path.get as ReturnType<typeof rangeGet>;
+        const path = spec.paths['/flowsheet/range'] as { get?: ReturnType<typeof rangeGet> } | undefined;
+        // Throw rather than expect-then-dereference: an absent path would make
+        // every test in this block report a TypeError instead of the missing
+        // endpoint.
+        if (!path?.get) throw new Error('/flowsheet/range is missing from api.yaml');
+        return path.get;
       }
 
       it('is public — no auth, matching its sibling /flowsheet/search', () => {
@@ -412,9 +421,41 @@ describe('OpenAPI Specification', () => {
         );
       });
 
-      it('documents the 31-day window ceiling that bounds this unauthenticated route', () => {
-        const description = (spec.paths['/flowsheet/range'] as { get: { description?: string } }).get.description ?? '';
-        expect(description).toMatch(/31 days/);
+      it('documents the 8-day window ceiling that bounds this unpaginated unauthenticated route', () => {
+        const description = rangeGet().description ?? '';
+        expect(description).toMatch(/8 days/);
+        const badRequest = rangeGet().responses?.['400'] as { description?: string } | undefined;
+        expect(badRequest?.description).toMatch(/8 days/);
+      });
+
+      // Each of these three is a documented invariant of the underlying tables
+      // that a reader of the plan alone would get wrong, and that all three
+      // consumers would then get wrong identically.
+      it('orders entries by add_time, and says why not play_order', () => {
+        const description = rangeGet().description ?? '';
+        // play_order is assigned per-show by two independent writers, so it
+        // interleaves the many shows a window spans (2026-05-01 incident).
+        expect(description).toMatch(/`add_time` ascending/);
+        expect(description).toMatch(/[Nn]ot by `play_order`/);
+        expect(String(propertyOf('FlowsheetRangeResponse', 'entries')?.description)).toMatch(/NOT by `play_order`/);
+      });
+
+      it('forbids reading a null end_time as "on the air"', () => {
+        // A dropped show_end delivery leaves end_time NULL permanently, so
+        // treating NULL as open-ended makes every orphaned historical show
+        // intersect every window forever.
+        expect(rangeGet().description ?? '').toMatch(/does not\s+mean "on the air"/);
+        expect(String(propertyOf('FlowsheetRangeShow', 'end_time')?.description)).toMatch(/two.*causes/s);
+      });
+
+      it('warns that show_end markers can be absent, so grouping keys on show_id', () => {
+        expect(String(propertyOf('FlowsheetRangeResponse', 'entries')?.description)).toMatch(/Segment on `show_id`/);
+      });
+
+      it('warns that breakpoint rows land in the window before the hour they mark', () => {
+        // add_time is the logging instant, ~1 min before the hour in
+        // radio_hour — the BS#1448 / BS#1449 off-by-one-hour class.
+        expect(rangeGet().description ?? '').toMatch(/radio_hour/);
       });
 
       it('envelopes shows and entries, both required', () => {


### PR DESCRIPTION
Closes #329.

Adds the `api.yaml` contract for `GET /flowsheet/range?start=<epoch ms>&end=<epoch ms>` → `200 {shows, entries}` — the successor to tubafrenzy's `GET /playlists/dailyEntries?dayStart=<epoch>`, which dies at the 2026-08-31 cutover. Spec only; no implementation, no version bump.

This is Wave 1 of the [Phase 4 DAG](https://github.com/WXYC/wiki/issues/91#issuecomment-5228914352) and unblocks [WXYC/Backend-Service#2062](https://github.com/WXYC/Backend-Service/issues/2062), which in turn gates [WXYC/archive#105](https://github.com/WXYC/archive/issues/105) and [WXYC/website#213](https://github.com/WXYC/website/issues/213).

## The three contract points consumers get wrong

Written down explicitly, because three consumers get built against this shape at roughly the same time — the `archive` daily playlist, the `wxyc.org` historical-archive page, and iOS V2.

1. **`entries[].show_id` is nullable.** 20 unlinked rows of 2,619,011 (2005-02-06 → 2026-04-21); Phase 0 decided no backfill, so the null reaches the wire. The property description names the *unattributed-entry* case and says the key is always present. Consumers that group by show must render an unattributed bucket rather than dropping or crashing.
2. **`start`/`end` are epoch milliseconds, not ISO strings** — matching the `dayStart` convention `archive`'s `computeRadioHourEpoch` already produces. Typed `format: int64`, since epoch ms has overflowed int32 since 1970 + 24.8 days.
3. **The window is bounded at 8 days**, `400` above it. An unbounded range over a 2.6M-row table on an unauthenticated route is a trivially available denial of service. Not exactly 7d, because a week spanning the autumn DST transition is 7d + 1h and would otherwise fail — one day of slack over the longest real consumer. (An earlier revision said 31 days; see the review response below for why that was wrong.)

Window semantics are stated too, since §2.5 left them open: half-open `[start, end)` evaluated on `add_time` for entries, so adjacent windows never double-count a row; `shows` uses **overlap** rather than containment, so a show spanning midnight appears in both days' responses. `entries` is ordered by `add_time` then `id`. Empty window is `200 {"shows": [], "entries": []}`, never `404`.

Three table invariants are written into the description because a reader of the plan alone gets each one wrong, and all three consumers would then get it wrong identically: `play_order` is per-show and must not order a multi-show window; a null `end_time` does **not** mean "on the air"; and a `show_end` marker can be absent, so grouping keys on `show_id`. Details in the review response below.

## Why `FlowsheetEntryFields` was extracted

`FlowsheetEntryBase.show_id` is declared `type: integer`, non-nullable and required. Relaxing it in place would change the documented shape of every other flowsheet path, so the range entry needs its own identity block — and OpenAPI 3.0 `allOf` intersects rather than overrides, so it cannot inherit `FlowsheetEntryResponse` and relax one field.

The alternative was duplicating ~30 property declarations, which is actively dangerous here: **iOS V2 decodes this endpoint and `GET /flowsheet` with a single decoder** (plan §2.5, consumer #3), so field parity between `FlowsheetRangeEntry` and `FlowsheetEntryResponse` is a contract requirement, not a coincidence. Instead the shared field block is extracted as `FlowsheetEntryFields` and both compose it:

```
FlowsheetEntryResponse = FlowsheetEntryBase      + FlowsheetEntryFields
FlowsheetRangeEntry    = FlowsheetRangeEntryBase + FlowsheetEntryFields   # show_id nullable
```

Every existing path's **resolved** schema is byte-identical after the extraction (verified by flattening both trees before and after; 32 properties, `required: [id, play_order, request_flag, show_id]` unchanged), and `oasdiff` reports no breaking changes. The generated TypeScript goes from `FlowsheetEntryBase & {…inline…}` to `FlowsheetEntryBase & FlowsheetEntryFields` — structurally identical for `@wxyc/shared/dtos` consumers.

A test pins the parity so the two can't drift apart later.

## `FlowsheetRangeShow` is deliberately not `Show`

`Show` exposes `primary_dj_id` (a user id) and carries no DJ name. This route is public and unauthenticated, so the projection carries the DJ's resolved **public handle** — same PII-safe chain as `FlowsheetEntryFields.dj_name` (per-show override → `user.djName` → `shows.legacy_dj_name`, tubafrenzy's `DJ_HANDLE`, never the real-name column, BS#1371) — and omits the user id. A test asserts `primary_dj_id` is absent.

## Spec-test helper fix (why `tests/api-spec.test.ts` has a real diff)

Five copies of the same `getProperty` helper walked `allOf` branches but did **not** follow `$ref`, so a composed schema whose branches are refs read as having *no properties at all*. That surfaced immediately: extracting `FlowsheetEntryFields` turned 7 existing green assertions red, not because the spec changed but because the helper couldn't see through the ref. They're replaced by one shared `$ref`-following `propertyOf` / `requiredKeysOf` pair. Two inline `required`-flatteners had the same blind spot and now use `requiredKeysOf` — those were passing *vacuously* (`expect(required).not.toContain(...)` against an empty array).

## Follow-up, not taken here

`FlowsheetEntryBase.show_id` is mis-specced for the existing paths as well — `GET /flowsheet` can already return `null` there today for those same 20 rows, and the spec says it can't. Correcting it is a change to shipped paths' documented shapes with downstream codegen ripple, so it wants its own ticket and its own conversation rather than riding a spec addition. Filed as [#332](https://github.com/WXYC/wxyc-shared/issues/332), which also enumerates the codegen ripple (TS `number | null` into BS + dj-site, `--strict-nullable` Python regen, hand-authored Swift/Kotlin, and the `oasdiff` verdict) that makes it more than a one-line edit.

## Verification

All run locally, mirroring `ci.yml`:

| Check | Result |
|---|---|
| `npm run generate:typescript` + `npm run build` | pass (new types emitted) |
| `npm run generate:python` | pass — `show_id: int \| None = Field(...)`, the `--strict-nullable` nullable-value/required-key idiom |
| `npm run lint` / `npm run lint:e2e` | pass |
| `npm test` | 692 passed (15 files); 8 new, verified red against `origin/main`'s `api.yaml` first |
| `npm run check:breaking` | **no breaking changes detected** |
| bats guards (breaking / setup / drift / python-codegen / spec-drift) | pass |

No version bump, per the ticket: `/flowsheet/range` is a v1 flowsheet route and v1 flowsheet routes do not consume `@wxyc/shared` DTOs, so Backend-Service#2062 depends on this being *merged*, not published.

